### PR TITLE
feat: add Beads integration to flow skills

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,13 +6,13 @@
   },
   "metadata": {
     "description": "Claude Code plugin marketplace by Gordon Mickel",
-    "version": "0.3.0"
+    "version": "0.4.0"
   },
   "plugins": [
     {
       "name": "flow",
-      "description": "Two-step planning + execution workflow. Includes 5 subagents, 4 commands, 5 skills.",
-      "version": "0.3.0",
+      "description": "Two-step planning + execution workflow with optional Beads integration. Includes 5 subagents, 4 commands, 5 skills.",
+      "version": "0.4.0",
       "author": {
         "name": "Gordon Mickel",
         "email": "gordon@mickel.tech",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to the gmickel-claude-marketplace.
 
+## [0.4.0] - 2025-12-27
+
+### Added
+- **Beads integration**: Optional Beads (`bd`) support for flow skills
+  - `flow-plan`: Can create Beads epics/tasks instead of markdown plans
+  - `flow-work`: Can accept Beads IDs/titles, track via `bd ready`/`bd update`/`bd close`
+  - `flow-plan-review`: Can accept Beads IDs/titles as input
+  - `flow-impl-review`: Looks for Beads context during code review
+- Graceful fallback to markdown/TodoWrite when `bd` unavailable
+- Context recovery guidance per Anthropic's long-running agent best practices
+
+### Technical
+- Agent-first design: no rigid detection gates, uses judgment based on context
+- Validated against bd v0.38.0
+- CLI behavior documented in plan (ID formats, parent linking, scoped ready)
+
 ## [0.3.0] - 2024-12-27
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ This marketplace contains plugins that fix those problems.
 | Ignoring existing code | Explicit reuse of repo patterns |
 | Drifting from plan | Plan re‑read between every task |
 | No review discipline | Built-in Carmack-level code reviews |
+| Lost task state | Optional [Beads](https://github.com/steveyegge/beads) integration for dependency-aware tracking |
 
 ```bash
 /plugin install flow
@@ -57,6 +58,11 @@ This marketplace contains plugins that fix those problems.
 ```
 ```bash
 /flow:work plans/add-oauth-login.md, then review with /flow:impl-review and fix issues until it passes
+```
+
+**With Beads** (if `.beads/` configured):
+```bash
+/flow:work bd-a3f8e9   # Work on Beads epic with dependency tracking
 ```
 
 Claude understands intent and flows between commands automatically.

--- a/plugins/flow/.claude-plugin/plugin.json
+++ b/plugins/flow/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "flow",
-  "version": "0.3.0",
-  "description": "Two-step planning + execution workflow. Includes 5 subagents, 4 commands, 5 skills.",
+  "version": "0.4.0",
+  "description": "Two-step planning + execution workflow with optional Beads integration. Includes 5 subagents, 4 commands, 5 skills.",
   "author": {
     "name": "Gordon Mickel",
     "email": "gordon@mickel.tech",

--- a/plugins/flow/README.md
+++ b/plugins/flow/README.md
@@ -36,6 +36,10 @@ Commands work standalone or chained. Claude understands intent and flows between
 /flow:work plans/add-oauth-login.md
 /flow:plan-review plans/add-oauth-login.md
 /flow:impl-review
+
+# With Beads (if configured)
+/flow:work bd-a3f8e9              # Work on Beads epic
+/flow:plan-review bd-a3f8e9       # Review Beads epic
 ```
 
 ### Full Workflow (Plan → Review → Work → Review)
@@ -262,6 +266,22 @@ Skills use **progressive disclosure**: only name + description (~100 tokens) loa
 **Two ways to trigger**:
 1. **Explicit**: `/flow:plan add OAuth` or `/flow:work plans/oauth.md`
 2. **Natural language**: "help me plan out adding OAuth" or "implement the plan in plans/oauth.md" — Claude auto-triggers the matching skill
+
+---
+
+## Beads Integration
+
+Flow has optional [Beads](https://github.com/steveyegge/beads) (`bd`) integration for dependency-aware issue tracking.
+
+**When Beads is detected** (`.beads/` exists or CLAUDE.md mentions it):
+
+| Command | Beads Mode |
+|---------|-----------|
+| `/flow:plan` | Create epic/tasks instead of markdown |
+| `/flow:work <beads-id>` | Track via `bd ready`/`bd close` instead of TodoWrite |
+| `/flow:plan-review <beads-id>` | Review Beads epic directly |
+
+**Fallback**: If `bd` unavailable, uses markdown plans + TodoWrite (no config needed).
 
 ---
 

--- a/plugins/flow/commands/flow/plan-review.md
+++ b/plugins/flow/commands/flow/plan-review.md
@@ -1,7 +1,7 @@
 ---
 name: flow:plan-review
 description: Carmack-level plan review via rp-cli context builder + chat
-argument-hint: "<plan-file> [focus areas]"
+argument-hint: "<plan-file or Beads ID> [focus areas]"
 ---
 
 # Plan Review

--- a/plugins/flow/commands/flow/work.md
+++ b/plugins/flow/commands/flow/work.md
@@ -1,7 +1,7 @@
 ---
 name: flow:work
 description: Execute a plan file end-to-end with checks
-argument-hint: "[plan file path or plan name]"
+argument-hint: "[plan file, Beads ID, or title]"
 ---
 
 # Flow work

--- a/plugins/flow/skills/flow-impl-review/SKILL.md
+++ b/plugins/flow/skills/flow-impl-review/SKILL.md
@@ -19,6 +19,14 @@ Example: `/flow:impl-review focus on the auth changes, ignore styling`
 
 Reviews all changes on the **current branch** vs main/master.
 
+## Context Sources
+
+The workflow gathers context from:
+- Git diff and commit messages
+- Plan files referenced in commits
+- PRD/architecture docs
+- **Beads**: If you know which issue(s) this work relates to, include via `bd show`
+
 ## Critical Requirement
 
 **DO NOT REVIEW CODE YOURSELF** – you are a coordinator, not the reviewer.

--- a/plugins/flow/skills/flow-impl-review/workflow.md
+++ b/plugins/flow/skills/flow-impl-review/workflow.md
@@ -59,8 +59,8 @@ rp-cli -w W -e 'search "docs/impl" --mode path'
 rp-cli -w W -e 'search "PRD" --mode path'
 rp-cli -w W -e 'search "prd_" --mode path'
 
-# Find beads issues
-rp-cli -w W -e 'search ".beads/issues" --mode path'
+# Find beads JSONL (Beads uses .beads/issues.jsonl, not individual files)
+rp-cli -w W -e 'search ".beads/" --mode path'
 
 # Check commit messages for issue references
 git log main..HEAD --format="%B" 2>/dev/null || git log master..HEAD --format="%B"
@@ -70,8 +70,9 @@ Read any relevant docs you find:
 ```bash
 rp-cli -w W -e 'read docs/plan/xxx.md'
 rp-cli -w W -e 'read docs/impl/xxx.md'
-rp-cli -w W -e 'read .beads/issues/XXX-xxx.md'
 ```
+
+**Beads context**: If you know which Beads issue(s) this work relates to (from conversation, commits, or user), include that context in the review prompt via `bd show <id>`.
 
 ---
 
@@ -93,7 +94,7 @@ rp-cli -w W -e 'select add path/to/changed/file2.ts'
 
 # Add supporting docs
 rp-cli -w W -e 'select add docs/plan/xxx.md'
-rp-cli -w W -e 'select add .beads/issues/XXX-xxx.md'
+# Note: Beads data is in JSONL, use `bd show <id>` to get issue details
 ```
 
 ---
@@ -126,6 +127,15 @@ rp-cli -w W -e 'select add path/to/missed/file.ts'
 
 Use chat in **chat mode** to conduct the review. The chat sees all selected files completely.
 
+**Shell escaping note:** Complex prompts with `?`, `()`, etc. may fail with zsh glob errors. Use heredoc:
+```bash
+rp-cli -w W -e "$(cat <<'PROMPT'
+chat "..."
+PROMPT
+)"
+```
+
+Example prompt structure:
 ```bash
 rp-cli -w W -e 'chat "Conduct a John Carmack-level code review of these implementation changes.
 
@@ -135,7 +145,7 @@ Files changed: [LIST FILES]
 Commits: [COMMIT SUMMARY]
 
 ## Original Plan/Spec
-[REFERENCE OR SUMMARIZE THE PLAN/BEADS ISSUE IF FOUND]
+[INCLUDE PLAN CONTENT OR `bd show` OUTPUT IF BEADS]
 
 ## Additional Context from User
 [INCLUDE ANY FOCUS AREAS/COMMENTS FROM ARGUMENTS]

--- a/plugins/flow/skills/flow-plan-review/SKILL.md
+++ b/plugins/flow/skills/flow-plan-review/SKILL.md
@@ -13,7 +13,11 @@ Conduct a John Carmack-level review of implementation plans using RepoPrompt's c
 ## Input
 
 Arguments: #$ARGUMENTS
-Format: `<plan-file> [additional context or focus areas]`
+Format: `<plan-file-or-beads-id> [additional context or focus areas]`
+
+Accepts:
+- Plan file path: `plans/<slug>.md`
+- Beads ID(s) or title(s) directly
 
 Example: `/flow:plan-review docs/plan/auth-refactor.md focus on security and error handling`
 

--- a/plugins/flow/skills/flow-plan/SKILL.md
+++ b/plugins/flow/skills/flow-plan/SKILL.md
@@ -24,7 +24,12 @@ Read [steps.md](steps.md) and follow each step in order. The steps include runni
 
 Read [examples.md](examples.md) for plan structure examples.
 
+## Output
+
+- Standard: `plans/<slug>.md`
+- Beads: epic/tasks/subtasks in Beads (no file written)
+
 ## Output rules
 
-- Only write the plan file
+- Only write the plan file (or create Beads epic)
 - No code changes

--- a/plugins/flow/skills/flow-plan/steps.md
+++ b/plugins/flow/skills/flow-plan/steps.md
@@ -55,25 +55,37 @@ Default to short unless complexity demands more.
 
 ## Step 4: Write the plan
 
-Create `plans/<slug>.md`.
+**Standard**: Create `plans/<slug>.md`
 - Slug = kebab-case title
 - Use clear headings, short bullets
 - Put file paths + links under References
 - Include code sketches only if needed, with fake filenames
 - If schema changes, include a Mermaid ERD
 
+**Beads alternative** (if Beads is in use - .beads/ exists, CLAUDE.md mentions it):
+
+1. **Probe** (read-only): `bd --version` succeeds
+2. **Confirm**: "Create Beads issues instead of markdown plan? [Y/n]"
+3. Create structure based on plan complexity:
+   - Simple: `bd create "Title" -t task -p <priority> --json`
+   - Standard: epic with child tasks (children auto-numbered .1, .2, .3)
+   - Complex: epic with tasks and subtasks (up to 3 levels)
+4. Add dependencies inline: `bd create "Title" --deps blocks:<other-id> --json`
+5. Output: `bd show <id> --json` - user can run `/flow:work <id>` directly
+
+**On failure after epic created**:
+- Report what was created (epic ID, any tasks)
+- Offer options: (A) retry failed tasks, (B) close epic, (C) leave for manual handling
+- Do not silently fall back to markdown
+
 ## Step 5: Offer next step
 
-After writing, ask:
-"Plan ready at `plans/<slug>.md`. Next?"
+**If Beads was used**: Output is already in Beads. Ask:
+"Epic created: `<id>`. Start `/flow:work <id>`?"
 
-Options:
+**If markdown plan**: Ask:
+"Plan ready at `plans/<slug>.md`. Next?"
 1) Open plan
 2) Start `/flow:work` with this plan
-3) Create issue in tracker (GitHub/Linear/Beads/Other)
+3) Create issue in tracker (GitHub/Linear/Other)
 4) Simplify or refine
-
-If Open: run `open plans/<slug>.md`.
-If Start work: run `/flow:work plans/<slug>.md`.
-If Create issue: detect tracker from CLAUDE.md, repo docs, MCP servers, or installed plugins. If GitHub, use `gh issue create --title "<title>" --body-file plans/<slug>.md`. If Linear, use linear CLI if present. If Beads, use the Beads tool referenced in CLAUDE.md. If Other or auto-detect, ask for command/tool. Then re-ask next steps.
-If refine: ask what to change, update file, re-ask.

--- a/plugins/flow/skills/flow-work/SKILL.md
+++ b/plugins/flow/skills/flow-work/SKILL.md
@@ -14,6 +14,10 @@ Execute a plan systematically. Focus on finishing.
 
 Plan file: #$ARGUMENTS
 
+Accepts:
+- Plan file: `plans/<slug>.md`
+- Beads ID(s) or title(s) directly
+
 If empty, ask for the plan path.
 
 ## Workflow

--- a/plugins/flow/skills/flow-work/phases.md
+++ b/plugins/flow/skills/flow-work/phases.md
@@ -7,6 +7,12 @@
 - Ask only blocking questions
 - Get user go-ahead
 
+**Beads alternative** - if Beads is in use (.beads/ exists, CLAUDE.md mentions it, or user explicitly passes Beads input):
+1. If file exists: standard markdown plan
+2. Else try `bd show <arg>` - if succeeds, treat as Beads ID
+3. Else try `bd search "<arg>"` - if unique match, use that issue
+4. Else: ask user for clarification
+
 ## Phase 2: Setup
 
 Ask: "Work on current branch, create new branch, or use isolated worktree?"
@@ -24,24 +30,38 @@ If current branch: confirm this is intentional.
 
 ## Phase 3: Task list
 
+**Standard**: Use TodoWrite
 - Convert plan to TodoWrite tasks
 - Include tests + lint steps
 - Keep tasks small + ordered
 
+**Beads alternative**:
+- `bd ready --parent <epic-id> --json` for next task
+- If multiple ready: pick first (hybrid sort by priority/age is deterministic)
+- `bd update <id> --status in_progress --json` to start
+- `bd close <id> --json` to complete
+
 ## Phase 4: Execute loop
 
-For each task:
-- Re-open plan
-- Put plan text at top of working context
-- Check remaining steps vs TodoWrite
-- Mark in_progress
-- Follow existing patterns
-- Implement + test
-- Mark done
+**Context recovery (every turn/task):**
+Re-read plan or Beads state before each task. This ensures coherence across context windows per Anthropic's long-running agent guidance.
+- `bd show <epic-id>` for Beads, or re-read plan file
+- Check git log for recent commits
+- Verify working state (run basic tests before starting new work)
 
-After each completed task:
-- Re-open plan
-- Confirm next task matches plan order
+**For each task:**
+- Check remaining: TodoWrite or `bd ready --parent <epic-id>`
+- Pick ONE task only - never batch
+- Mark in_progress (`bd update <id> --status in_progress --json` for Beads)
+- Implement + test thoroughly
+- If you discover new work: `bd create "Found issue" -t bug -p 2 --deps discovered-from:<current-id> --json`
+- Leave clean state: commit with descriptive message
+- Mark TodoWrite task done (internal tracking)
+- If Beads and wrapping up session: ask before closing (user may want to review first)
+
+**Between tasks:**
+- Re-read plan/Beads to confirm next task
+- Verify no regressions before continuing
 
 ## Phase 5: Quality
 
@@ -53,6 +73,9 @@ After each completed task:
 
 ## Phase 6: Ship
 
+**Beads addition**: `bd dep tree <epic-id>` or `bd show <epic-id>`
+Check that all child tasks are closed before commit.
+
 ```bash
 git add .
 git status
@@ -60,16 +83,19 @@ git diff --staged
 git commit -m "<short summary>"
 ```
 
+**CRITICAL for Beads**: Run `bd sync` at end of session to force immediate export/commit (bypasses 5s debounce).
+
 Then push + open PR if user wants.
 
 ## Definition of Done
 
 Confirm before ship:
 - All plan steps completed or explicitly deferred
-- All TodoWrite tasks done
+- All TodoWrite tasks done (or all Beads tasks closed)
 - Tests pass
 - Lint/format pass
 - Docs updated if needed
+- `bd sync` run (if using Beads)
 
 ## Example loop
 


### PR DESCRIPTION
## Summary
- Add optional Beads (`bd`) integration to flow-plan, flow-work, flow-plan-review
- Version bump 0.3.0 → 0.4.0
- Agent-first design: try Beads, fallback gracefully if unavailable

## Changes
- **flow-plan**: can create epic/tasks/subtasks in Beads instead of markdown
- **flow-work**: accepts Beads ID(s) or title(s), tracks via `bd ready/update/close`
- **flow-plan-review**: accepts Beads ID(s) or title(s), prompt-stuffs `bd show` output

## Test plan
- [ ] `bd --version` available → Beads path offered
- [ ] `bd` unavailable → fallback to markdown
- [ ] `/flow:work <beads-id>` resolves and tracks correctly
- [ ] `/flow:work "<title>"` resolves via `bd search`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * v0.4.0 release: optional Beads integration — accept Beads IDs/titles as input and optionally create Beads epics instead of only writing plan files.
  * Beads-aware execution: per-task Beads commands, status handling, and requirement to close Beads tasks or complete TodoWrite tasks.

* **Documentation**
  * Updated docs and examples for Beads workflows, command hints, input formats, fallback behavior, and context-recovery guidance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->