### PR TITLE
fix(flow-next): remove hardcoded opus model from review skills

### DIFF
--- a/plugins/flow-next/skills/flow-next-impl-review/SKILL.md
+++ b/plugins/flow-next/skills/flow-next-impl-review/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: flow-next-impl-review
 description: John Carmack-level implementation review via RepoPrompt or Codex. Use when reviewing code changes, PRs, or implementations. Triggers on /flow-next:impl-review.
-model: claude-opus-4-5-20251101
 ---
 
 # Implementation Review Mode

--- a/plugins/flow-next/skills/flow-next-plan-review/SKILL.md
+++ b/plugins/flow-next/skills/flow-next-plan-review/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: flow-next-plan-review
 description: Carmack-level plan review via RepoPrompt or Codex. Use when reviewing Flow epic specs or design docs. Triggers on /flow-next:plan-review.
-model: claude-opus-4-5-20251101
 ---
 
 # Plan Review Mode


### PR DESCRIPTION
## Summary
- Remove `model: claude-opus-4-5-20251101` from review skill frontmatter
- Skills now inherit session's default model

## Problem
Skills with hardcoded opus model fail with 404 on API endpoints that don't have opus available, causing streaming fallback errors in print mode.

## Test plan
- [x] Verify no `model:` lines in affected skills
- [ ] Test Ralph run with impl-review skill

Fixes #9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed model configuration fields from workflow skill definitions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->