### PR TITLE
fix(ralph): don't fail on non-zero exit code if task completed

### DIFF
--- a/plugins/flow-next/skills/flow-next-ralph-init/templates/ralph.sh
+++ b/plugins/flow-next/skills/flow-next-ralph-init/templates/ralph.sh
@@ -732,7 +732,9 @@ Violations break automation and leave the user with incomplete work. Be precise,
     exit_code=2
   elif [[ "$force_retry" == "1" ]]; then
     exit_code=2
-  elif [[ "$claude_rc" -ne 0 ]]; then
+  elif [[ "$claude_rc" -ne 0 && "$task_status" != "done" ]]; then
+    # Only fail on non-zero exit code if task didn't complete successfully
+    # This prevents false failures from transient errors (telemetry, model fallback, etc.)
     exit_code=1
   fi
 


### PR DESCRIPTION
## Summary
Only treat non-zero Claude exit code as failure if task didn't complete successfully.

## Problem
Ralph fails even when task succeeds (status=done) if Claude CLI exits with non-zero code due to transient errors like:
- Telemetry export failures
- Model streaming fallbacks
- Other non-fatal CLI errors

## Solution
Add `&& "$task_status" != "done"` check before declaring failure based on exit code.

## Test plan
- [x] Verify logic: if task_status=done, don't fail on claude_rc!=0
- [ ] Run Ralph with task that has telemetry errors but succeeds

Fixes #11

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling for completed tasks. The system now distinguishes between genuine failures and exit codes for already-completed tasks, preventing incorrect failure flagging. Previously, any exit code triggered a failure; the updated logic now verifies task completion status before applying failure conditions, improving reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->