### PR TITLE
feat(ralph): --watch mode, review feedback, codex timeout

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -31,7 +31,7 @@
     {
       "name": "flow-next",
       "description": "Zero-dependency planning + execution with .flow/ task tracking and Ralph autonomous mode (multi-model review gates). Includes 6 subagents, 8 commands, 11 skills.",
-      "version": "0.5.8",
+      "version": "0.5.10",
       "author": {
         "name": "Gordon Mickel",
         "email": "gordon@mickel.tech",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,23 @@
 
 All notable changes to the gmickel-claude-marketplace.
 
-## [Unreleased]
+## [flow-next 0.5.10] - 2026-01-12
 
 ### Added
-- `--watch` flag for Ralph to stream tool calls in real-time with TUI styling
-- `--watch verbose` flag to stream full Claude output
-- `--help` flag with usage information
-- `watch-filter.py` to parse stream-json and display tool icons
+- **Watch mode**: `--watch` flag streams tool calls in real-time with TUI styling (icons, colors)
+- **Watch verbose**: `--watch verbose` also streams model text responses
+- `watch-filter.py` for stream-json parsing (fail-open pattern, drains stdin on error)
+- **Standalone Codex review**: `flowctl codex impl-review --base main` works without task context
+- `--focus` flag for Codex reviews: `--focus "error handling, security"`
+- **Review feedback in receipts**: Codex plan/impl review receipts now include `review` field with full feedback (enables fix loops)
+- `FLOW_RALPH_CLAUDE_PLUGIN_DIR` env var for testing with local dev plugin
+
+### Changed
+- TIMEOUT_CMD detection for macOS (timeout/gtimeout/none with warning)
+- Stream-json text extraction for reliable tag parsing in watch mode
+- Conditional signal trap (only in watch mode)
+- Python 3.9 compatibility (Optional[str] not str | None)
+- Codex exec timeout increased 300s → 600s (matches RP timeout)
 
 ## [flow-next 0.5.8] - 2026-01-11
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Claude Code](https://img.shields.io/badge/Claude_Code-Plugin_Marketplace-blueviolet)](https://claude.ai/code)
-[![Flow-next](https://img.shields.io/badge/Flow--next-v0.5.8-green)](plugins/flow-next/)
+[![Flow-next](https://img.shields.io/badge/Flow--next-v0.5.10-green)](plugins/flow-next/)
 [![Flow](https://img.shields.io/badge/Flow-v0.8.4-blue)](plugins/flow/)
 [![Author](https://img.shields.io/badge/Author-Gordon_Mickel-orange)](https://mickel.tech)
 [![Twitter](https://img.shields.io/badge/@gmickel-black?logo=x)](https://twitter.com/gmickel)

--- a/plugins/flow-next/.claude-plugin/plugin.json
+++ b/plugins/flow-next/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "flow-next",
-  "version": "0.5.8",
+  "version": "0.5.10",
   "description": "Zero-dependency planning + execution with .flow/ task tracking and Ralph autonomous mode (multi-model review gates). Includes 6 subagents, 8 commands, 11 skills.",
   "author": {
     "name": "Gordon Mickel",

--- a/plugins/flow-next/README.md
+++ b/plugins/flow-next/README.md
@@ -4,7 +4,7 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](../../LICENSE)
 [![Claude Code](https://img.shields.io/badge/Claude_Code-Plugin-blueviolet)](https://claude.ai/code)
-[![Version](https://img.shields.io/badge/Version-0.5.8-green)](../../CHANGELOG.md)
+[![Version](https://img.shields.io/badge/Version-0.5.10-green)](../../CHANGELOG.md)
 [![Status](https://img.shields.io/badge/Status-Active_Development-brightgreen)](../../CHANGELOG.md)
 
 **Plan first, work second. Zero external dependencies.**

--- a/plugins/flow-next/scripts/flowctl.py
+++ b/plugins/flow-next/scripts/flowctl.py
@@ -172,7 +172,9 @@ def run_rp_cli(args: list[str], timeout: int = 600) -> subprocess.CompletedProce
     rp = require_rp_cli()
     cmd = [rp] + args
     try:
-        return subprocess.run(cmd, capture_output=True, text=True, check=True, timeout=timeout)
+        return subprocess.run(
+            cmd, capture_output=True, text=True, check=True, timeout=timeout
+        )
     except subprocess.TimeoutExpired:
         error_exit(f"rp-cli timed out after {timeout}s", use_json=False, code=3)
     except subprocess.CalledProcessError as e:
@@ -420,9 +422,7 @@ def extract_symbols_from_file(file_path: Path) -> list[str]:
 
         # Python: def/class definitions
         if ext == ".py":
-            for match in re.finditer(
-                r"^(?:def|class)\s+(\w+)", content, re.MULTILINE
-            ):
+            for match in re.finditer(r"^(?:def|class)\s+(\w+)", content, re.MULTILINE):
                 symbols.append(match.group(1))
             # Also catch exported __all__
             all_match = re.search(r"__all__\s*=\s*\[([^\]]+)\]", content)
@@ -451,9 +451,7 @@ def extract_symbols_from_file(file_path: Path) -> list[str]:
 
         # Rust: pub fn/struct/enum/trait, also private fn for references
         elif ext == ".rs":
-            for match in re.finditer(
-                r"^(?:pub\s+)?fn\s+(\w+)", content, re.MULTILINE
-            ):
+            for match in re.finditer(r"^(?:pub\s+)?fn\s+(\w+)", content, re.MULTILINE):
                 symbols.append(match.group(1))
             for match in re.finditer(
                 r"^(?:pub\s+)?(?:struct|enum|trait|type)\s+(\w+)",
@@ -672,7 +670,7 @@ def run_codex_exec(
                 capture_output=True,
                 text=True,
                 check=True,
-                timeout=300,
+                timeout=600,
             )
             output = result.stdout
             # For resumed sessions, thread_id stays the same
@@ -700,13 +698,13 @@ def run_codex_exec(
             capture_output=True,
             text=True,
             check=True,
-            timeout=300,
+            timeout=600,
         )
         output = result.stdout
         thread_id = parse_codex_thread_id(output)
         return output, thread_id
     except subprocess.TimeoutExpired:
-        error_exit("codex exec timed out (300s)", use_json=False, code=2)
+        error_exit("codex exec timed out (600s)", use_json=False, code=2)
     except subprocess.CalledProcessError as e:
         msg = (e.stderr or e.stdout or str(e)).strip()
         error_exit(f"codex exec failed: {msg}", use_json=False, code=2)
@@ -773,7 +771,9 @@ a thorough review requires understanding the system, not just the diff.
 """
 
     if review_type == "impl":
-        instruction = context_preamble + """Conduct a John Carmack-level review of this implementation.
+        instruction = (
+            context_preamble
+            + """Conduct a John Carmack-level review of this implementation.
 
 ## Review Criteria
 
@@ -801,8 +801,11 @@ Be critical. Find real issues.
 <verdict>MAJOR_RETHINK</verdict> - Fundamental approach problems
 
 Do NOT skip this tag. The automation depends on it."""
+        )
     else:  # plan
-        instruction = context_preamble + """Conduct a John Carmack-level review of this plan.
+        instruction = (
+            context_preamble
+            + """Conduct a John Carmack-level review of this plan.
 
 ## Review Criteria
 
@@ -830,6 +833,7 @@ Be critical. Find real issues.
 <verdict>MAJOR_RETHINK</verdict> - Fundamental approach problems
 
 Do NOT skip this tag. The automation depends on it."""
+        )
 
     parts = []
 
@@ -3212,30 +3216,79 @@ def cmd_codex_check(args: argparse.Namespace) -> None:
             print("codex not available")
 
 
+def build_standalone_review_prompt(
+    base_branch: str, focus: Optional[str], diff_summary: str
+) -> str:
+    """Build review prompt for standalone branch review (no task context)."""
+    focus_section = ""
+    if focus:
+        focus_section = f"""
+## Focus Areas
+{focus}
+
+Pay special attention to these areas during review.
+"""
+
+    return f"""# Implementation Review: Branch Changes vs {base_branch}
+
+Review all changes on the current branch compared to {base_branch}.
+{focus_section}
+## Diff Summary
+```
+{diff_summary}
+```
+
+## Review Criteria (Carmack-level)
+
+1. **Correctness** - Does the code do what it claims?
+2. **Reliability** - Can this fail silently or cause flaky behavior?
+3. **Simplicity** - Is this the simplest solution?
+4. **Security** - Injection, auth gaps, resource exhaustion?
+5. **Edge Cases** - Failure modes, race conditions, malformed input?
+
+## Output Format
+
+For each issue found:
+- **Severity**: Critical / Major / Minor / Nitpick
+- **File:Line**: Exact location
+- **Problem**: What's wrong
+- **Suggestion**: How to fix
+
+Be critical. Find real issues.
+
+**REQUIRED**: End your response with exactly one verdict tag:
+- `<verdict>SHIP</verdict>` - Ready to merge
+- `<verdict>NEEDS_WORK</verdict>` - Issues must be fixed first
+- `<verdict>MAJOR_RETHINK</verdict>` - Fundamental problems, reconsider approach
+"""
+
+
 def cmd_codex_impl_review(args: argparse.Namespace) -> None:
     """Run implementation review via codex exec."""
-    if not ensure_flow_exists():
-        error_exit(".flow/ does not exist", use_json=args.json)
-
     task_id = args.task
     base_branch = args.base
+    focus = getattr(args, "focus", None)
 
-    # Validate task ID
-    if not is_task_id(task_id):
-        error_exit(f"Invalid task ID: {task_id}", use_json=args.json)
+    # Standalone mode (no task ID) - review branch without task context
+    standalone = task_id is None
 
-    # Load task spec
-    flow_dir = get_flow_dir()
-    epic_num, task_num = parse_id(task_id)
-    task_spec_path = flow_dir / TASKS_DIR / f"{task_id}.md"
+    if not standalone:
+        # Task-specific review requires .flow/
+        if not ensure_flow_exists():
+            error_exit(".flow/ does not exist", use_json=args.json)
 
-    if not task_spec_path.exists():
-        error_exit(f"Task spec not found: {task_spec_path}", use_json=args.json)
+        # Validate task ID
+        if not is_task_id(task_id):
+            error_exit(f"Invalid task ID: {task_id}", use_json=args.json)
 
-    task_spec = task_spec_path.read_text(encoding="utf-8")
+        # Load task spec
+        flow_dir = get_flow_dir()
+        task_spec_path = flow_dir / TASKS_DIR / f"{task_id}.md"
 
-    # Get context hints
-    context_hints = gather_context_hints(base_branch)
+        if not task_spec_path.exists():
+            error_exit(f"Task spec not found: {task_spec_path}", use_json=args.json)
+
+        task_spec = task_spec_path.read_text(encoding="utf-8")
 
     # Get diff summary
     try:
@@ -3250,7 +3303,12 @@ def cmd_codex_impl_review(args: argparse.Namespace) -> None:
         diff_summary = ""
 
     # Build prompt
-    prompt = build_review_prompt("impl", task_spec, context_hints, diff_summary)
+    if standalone:
+        prompt = build_standalone_review_prompt(base_branch, focus, diff_summary)
+    else:
+        # Get context hints for task-specific review
+        context_hints = gather_context_hints(base_branch)
+        prompt = build_review_prompt("impl", task_spec, context_hints, diff_summary)
 
     # Check for existing session in receipt
     receipt_path = args.receipt if hasattr(args, "receipt") and args.receipt else None
@@ -3270,17 +3328,23 @@ def cmd_codex_impl_review(args: argparse.Namespace) -> None:
     # Parse verdict
     verdict = parse_codex_verdict(output)
 
+    # Determine review id (task_id for task reviews, "branch" for standalone)
+    review_id = task_id if task_id else "branch"
+
     # Write receipt if path provided (Ralph-compatible schema)
     if receipt_path:
         receipt_data = {
             "type": "impl_review",  # Required by Ralph
-            "id": task_id,  # Required by Ralph
+            "id": review_id,  # Required by Ralph
             "mode": "codex",
             "base": base_branch,
             "verdict": verdict,
             "session_id": thread_id,
             "timestamp": now_iso(),
+            "review": output,  # Full review feedback for fix loop
         }
+        if focus:
+            receipt_data["focus"] = focus
         Path(receipt_path).write_text(
             json.dumps(receipt_data, indent=2) + "\n", encoding="utf-8"
         )
@@ -3290,10 +3354,12 @@ def cmd_codex_impl_review(args: argparse.Namespace) -> None:
         json_output(
             {
                 "type": "impl_review",
-                "id": task_id,
+                "id": review_id,
                 "verdict": verdict,
                 "session_id": thread_id,
                 "mode": "codex",
+                "standalone": standalone,
+                "review": output,  # Full review feedback for fix loop
             }
         )
     else:
@@ -3355,6 +3421,7 @@ def cmd_codex_plan_review(args: argparse.Namespace) -> None:
             "verdict": verdict,
             "session_id": thread_id,
             "timestamp": now_iso(),
+            "review": output,  # Full review feedback for fix loop
         }
         Path(receipt_path).write_text(
             json.dumps(receipt_data, indent=2) + "\n", encoding="utf-8"
@@ -3369,6 +3436,7 @@ def cmd_codex_plan_review(args: argparse.Namespace) -> None:
                 "verdict": verdict,
                 "session_id": thread_id,
                 "mode": "codex",
+                "review": output,  # Full review feedback for fix loop
             }
         )
     else:
@@ -3843,8 +3911,13 @@ def main() -> None:
     p_codex_check.set_defaults(func=cmd_codex_check)
 
     p_codex_impl = codex_sub.add_parser("impl-review", help="Implementation review")
-    p_codex_impl.add_argument("task", help="Task ID (fn-N.M)")
+    p_codex_impl.add_argument(
+        "task", nargs="?", default=None, help="Task ID (fn-N.M), optional for standalone"
+    )
     p_codex_impl.add_argument("--base", required=True, help="Base branch for diff")
+    p_codex_impl.add_argument(
+        "--focus", help="Focus areas for standalone review (comma-separated)"
+    )
     p_codex_impl.add_argument(
         "--receipt", help="Receipt file path for session continuity"
     )

--- a/plugins/flow-next/skills/flow-next-ralph-init/templates/config.env
+++ b/plugins/flow-next/skills/flow-next-ralph-init/templates/config.env
@@ -31,6 +31,7 @@ YOLO=1
 # FLOW_RALPH_CLAUDE_NO_SESSION_PERSISTENCE=0
 # FLOW_RALPH_CLAUDE_DEBUG=hooks
 # FLOW_RALPH_CLAUDE_VERBOSE=1
+# FLOW_RALPH_CLAUDE_PLUGIN_DIR=  # Use local dev plugin instead of cached (for testing)
 
 # Watch mode (command-line flags, not env vars):
 #   --watch          Show tool calls in real-time (logs still captured)

--- a/plugins/flow-next/skills/flow-next-ralph-init/templates/ralph.sh
+++ b/plugins/flow-next/skills/flow-next-ralph-init/templates/ralph.sh
@@ -1,9 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Ensure Ctrl+C kills entire process group (needed for pipe chains in watch mode)
-trap 'kill 0' SIGINT SIGTERM
-
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
 CONFIG="$SCRIPT_DIR/config.env"
@@ -320,7 +317,23 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+# Set up signal trap for watch mode (pipe chains need clean Ctrl+C handling)
+if [[ -n "$WATCH_MODE" ]]; then
+  cleanup() { kill -- -$$ 2>/dev/null; exit 130; }
+  trap cleanup SIGINT SIGTERM
+fi
+
 CLAUDE_BIN="${CLAUDE_BIN:-claude}"
+
+# Detect timeout command (GNU coreutils). On macOS: brew install coreutils
+if command -v timeout >/dev/null 2>&1; then
+  TIMEOUT_CMD="timeout"
+elif command -v gtimeout >/dev/null 2>&1; then
+  TIMEOUT_CMD="gtimeout"
+else
+  TIMEOUT_CMD=""
+  echo "ralph: warning: timeout command not found; worker timeout disabled (brew install coreutils)" >&2
+fi
 
 sanitize_id() {
   local v="$1"
@@ -431,6 +444,35 @@ tag = sys.argv[1]
 text = sys.stdin.read()
 matches = re.findall(rf"<{tag}>(.*?)</{tag}>", text, flags=re.S)
 print(matches[-1] if matches else "")
+PY
+}
+
+# Extract assistant text from stream-json log (for tag extraction in watch mode)
+extract_text_from_stream_json() {
+  local log_file="$1"
+  python3 - "$log_file" <<'PY'
+import json, sys
+path = sys.argv[1]
+out = []
+try:
+    with open(path, encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                ev = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if ev.get("type") != "assistant":
+                continue
+            msg = ev.get("message") or {}
+            for blk in (msg.get("content") or []):
+                if blk.get("type") == "text":
+                    out.append(blk.get("text", ""))
+except Exception:
+    pass
+print("\n".join(out))
 PY
 }
 
@@ -676,7 +718,13 @@ while (( iter <= MAX_ITERATIONS )); do
   fi
 
   export FLOW_RALPH="1"
-  claude_args=(-p --output-format text)
+  claude_args=(-p)
+  # Set output format based on watch mode (stream-json required for real-time output)
+  if [[ -n "$WATCH_MODE" ]]; then
+    claude_args+=(--output-format stream-json)
+  else
+    claude_args+=(--output-format text)
+  fi
 
   # Autonomous mode system prompt - critical for preventing drift
   claude_args+=(--append-system-prompt "AUTONOMOUS MODE ACTIVE (FLOW_RALPH=1). You are running unattended. CRITICAL RULES:
@@ -689,6 +737,7 @@ Violations break automation and leave the user with incomplete work. Be precise,
 
   [[ -n "${MAX_TURNS:-}" ]] && claude_args+=(--max-turns "$MAX_TURNS")
   [[ "$YOLO" == "1" ]] && claude_args+=(--dangerously-skip-permissions)
+  [[ -n "${FLOW_RALPH_CLAUDE_PLUGIN_DIR:-}" ]] && claude_args+=(--plugin-dir "$FLOW_RALPH_CLAUDE_PLUGIN_DIR")
   [[ -n "${FLOW_RALPH_CLAUDE_MODEL:-}" ]] && claude_args+=(--model "$FLOW_RALPH_CLAUDE_MODEL")
   [[ -n "${FLOW_RALPH_CLAUDE_SESSION_ID:-}" ]] && claude_args+=(--session-id "$FLOW_RALPH_CLAUDE_SESSION_ID")
   [[ -n "${FLOW_RALPH_CLAUDE_PERMISSION_MODE:-}" ]] && claude_args+=(--permission-mode "$FLOW_RALPH_CLAUDE_PERMISSION_MODE")
@@ -707,39 +756,50 @@ Violations break automation and leave the user with incomplete work. Be precise,
   set +e
   if [[ "$WATCH_MODE" == "verbose" ]]; then
     # Full output: stream through filter with --verbose to show text/thinking
-    # Must use stream-json for real-time output (text mode buffers until done)
-    claude_args+=(--output-format stream-json)
     [[ ! " ${claude_args[*]} " =~ " --verbose " ]] && claude_args+=(--verbose)
     echo ""
-    timeout "$WORKER_TIMEOUT" "$CLAUDE_BIN" "${claude_args[@]}" "$prompt" 2>&1 | tee "$iter_log" | "$SCRIPT_DIR/watch-filter.py" --verbose
+    if [[ -n "$TIMEOUT_CMD" ]]; then
+      "$TIMEOUT_CMD" "$WORKER_TIMEOUT" "$CLAUDE_BIN" "${claude_args[@]}" "$prompt" 2>&1 | tee "$iter_log" | "$SCRIPT_DIR/watch-filter.py" --verbose
+    else
+      "$CLAUDE_BIN" "${claude_args[@]}" "$prompt" 2>&1 | tee "$iter_log" | "$SCRIPT_DIR/watch-filter.py" --verbose
+    fi
     claude_rc=${PIPESTATUS[0]}
     claude_out="$(cat "$iter_log")"
   elif [[ "$WATCH_MODE" == "tools" ]]; then
     # Filtered output: stream-json through watch-filter.py
-    claude_args+=(--output-format stream-json)
-    # Add --verbose only if not already set
+    # Add --verbose only if not already set (needed for tool visibility)
     [[ ! " ${claude_args[*]} " =~ " --verbose " ]] && claude_args+=(--verbose)
-    timeout "$WORKER_TIMEOUT" "$CLAUDE_BIN" "${claude_args[@]}" "$prompt" 2>&1 | tee "$iter_log" | "$SCRIPT_DIR/watch-filter.py"
+    if [[ -n "$TIMEOUT_CMD" ]]; then
+      "$TIMEOUT_CMD" "$WORKER_TIMEOUT" "$CLAUDE_BIN" "${claude_args[@]}" "$prompt" 2>&1 | tee "$iter_log" | "$SCRIPT_DIR/watch-filter.py"
+    else
+      "$CLAUDE_BIN" "${claude_args[@]}" "$prompt" 2>&1 | tee "$iter_log" | "$SCRIPT_DIR/watch-filter.py"
+    fi
     claude_rc=${PIPESTATUS[0]}
     # Log contains stream-json; verdict/promise extraction handled by fallback logic
     claude_out="$(cat "$iter_log")"
   else
     # Default: quiet mode
-    claude_out="$(timeout "$WORKER_TIMEOUT" "$CLAUDE_BIN" "${claude_args[@]}" "$prompt" 2>&1)"
+    if [[ -n "$TIMEOUT_CMD" ]]; then
+      claude_out="$("$TIMEOUT_CMD" "$WORKER_TIMEOUT" "$CLAUDE_BIN" "${claude_args[@]}" "$prompt" 2>&1)"
+    else
+      claude_out="$("$CLAUDE_BIN" "${claude_args[@]}" "$prompt" 2>&1)"
+    fi
     claude_rc=$?
     printf '%s\n' "$claude_out" > "$iter_log"
   fi
   set -e
 
-  # Handle timeout (exit code 124)
-  if [[ "$claude_rc" -eq 124 ]]; then
+  # Handle timeout (exit code 124 from timeout command)
+  worker_timeout=0
+  if [[ -n "$TIMEOUT_CMD" && "$claude_rc" -eq 124 ]]; then
     echo "ralph: worker timed out after ${WORKER_TIMEOUT}s" >> "$iter_log"
     log "worker timeout after ${WORKER_TIMEOUT}s"
+    worker_timeout=1
   fi
 
   log "claude rc=$claude_rc log=$iter_log"
 
-  force_retry=0
+  force_retry=$worker_timeout
   plan_review_status=""
   task_status=""
   if [[ "$status" == "plan" && ( "$PLAN_REVIEW" == "rp" || "$PLAN_REVIEW" == "codex" ) ]]; then
@@ -761,8 +821,14 @@ Violations break automation and leave the user with incomplete work. Be precise,
   fi
 
   # Extract verdict/promise for progress log (not displayed in UI)
-  verdict="$(printf '%s' "$claude_out" | extract_tag verdict)"
-  promise="$(printf '%s' "$claude_out" | extract_tag promise)"
+  # In watch mode, parse stream-json to get assistant text; otherwise use raw output
+  if [[ -n "$WATCH_MODE" ]]; then
+    claude_text="$(extract_text_from_stream_json "$iter_log")"
+  else
+    claude_text="$claude_out"
+  fi
+  verdict="$(printf '%s' "$claude_text" | extract_tag verdict)"
+  promise="$(printf '%s' "$claude_text" | extract_tag promise)"
 
   # Fallback: derive verdict from flowctl status for logging
   if [[ -z "$verdict" && -n "$plan_review_status" ]]; then
@@ -787,16 +853,16 @@ Violations break automation and leave the user with incomplete work. Be precise,
   fi
   append_progress "$verdict" "$promise" "$plan_review_status" "$task_status"
 
-  if echo "$claude_out" | grep -q "<promise>COMPLETE</promise>"; then
+  if echo "$claude_text" | grep -q "<promise>COMPLETE</promise>"; then
     ui_complete
     echo "<promise>COMPLETE</promise>"
     exit 0
   fi
 
   exit_code=0
-  if echo "$claude_out" | grep -q "<promise>FAIL</promise>"; then
+  if echo "$claude_text" | grep -q "<promise>FAIL</promise>"; then
     exit_code=1
-  elif echo "$claude_out" | grep -q "<promise>RETRY</promise>"; then
+  elif echo "$claude_text" | grep -q "<promise>RETRY</promise>"; then
     exit_code=2
   elif [[ "$force_retry" == "1" ]]; then
     exit_code=2

--- a/plugins/flow-next/skills/flow-next-ralph-init/templates/watch-filter.py
+++ b/plugins/flow-next/skills/flow-next-ralph-init/templates/watch-filter.py
@@ -4,6 +4,9 @@ Watch filter for Ralph - parses Claude's stream-json output and shows key events
 
 Reads JSON lines from stdin, outputs formatted tool calls in TUI style.
 
+CRITICAL: This filter is "fail open" - if output breaks, it continues draining
+stdin to prevent SIGPIPE cascading to upstream processes (tee, claude).
+
 Usage:
     watch-filter.py           # Show tool calls only
     watch-filter.py --verbose # Show tool calls + thinking + text responses
@@ -13,14 +16,18 @@ import argparse
 import json
 import os
 import sys
+from typing import Optional
+
+# Global flag to disable output on pipe errors (fail open pattern)
+_output_disabled = False
 
 # ANSI color codes (match ralph.sh TUI)
 if sys.stdout.isatty() and not os.environ.get("NO_COLOR"):
-    C_RESET = '\033[0m'
-    C_DIM = '\033[2m'
-    C_CYAN = '\033[36m'
+    C_RESET = "\033[0m"
+    C_DIM = "\033[2m"
+    C_CYAN = "\033[36m"
 else:
-    C_RESET = C_DIM = C_CYAN = ''
+    C_RESET = C_DIM = C_CYAN = ""
 
 # TUI indentation (3 spaces to match ralph.sh)
 INDENT = "   "
@@ -41,13 +48,35 @@ ICONS = {
     "Skill": "⚡",
 }
 
-def truncate(s, max_len=60):
+
+def safe_print(msg: str) -> None:
+    """Print that fails open - disables output on BrokenPipe instead of crashing."""
+    global _output_disabled
+    if _output_disabled:
+        return
+    try:
+        print(msg, flush=True)
+    except BrokenPipeError:
+        _output_disabled = True
+
+
+def drain_stdin() -> None:
+    """Consume remaining stdin to prevent SIGPIPE to upstream processes."""
+    try:
+        for _ in sys.stdin:
+            pass
+    except Exception:
+        pass
+
+
+def truncate(s: str, max_len: int = 60) -> str:
     s = s.replace("\n", " ").strip()
     if len(s) > max_len:
-        return s[:max_len-3] + "..."
+        return s[: max_len - 3] + "..."
     return s
 
-def format_tool_use(tool_name, tool_input):
+
+def format_tool_use(tool_name: str, tool_input: dict) -> str:
     """Format a tool use event for TUI display."""
     icon = ICONS.get(tool_name, "🔹")
 
@@ -97,22 +126,76 @@ def format_tool_use(tool_name, tool_input):
     else:
         return f"{icon} {tool_name}"
 
-def format_tool_result(result):
-    """Format a tool result (errors only)."""
-    if isinstance(result, dict):
-        if result.get("is_error"):
-            error = result.get("error", result.get("content", ""))
-            return f"{INDENT}{C_DIM}❌ {truncate(str(error), 60)}{C_RESET}"
-    elif isinstance(result, str):
-        lower = result.lower()
+
+def format_tool_result(block: dict) -> Optional[str]:
+    """Format a tool_result block (errors only).
+
+    Args:
+        block: The full tool_result block (not just content)
+    """
+    # Check is_error on the block itself
+    if block.get("is_error"):
+        content = block.get("content", "")
+        error_text = str(content) if content else "unknown error"
+        return f"{INDENT}{C_DIM}❌ {truncate(error_text, 60)}{C_RESET}"
+
+    # Also check content for error strings (heuristic)
+    content = block.get("content", "")
+    if isinstance(content, str):
+        lower = content.lower()
         if "error" in lower or "failed" in lower:
-            return f"{INDENT}{C_DIM}⚠️  {truncate(result, 60)}{C_RESET}"
+            return f"{INDENT}{C_DIM}⚠️  {truncate(content, 60)}{C_RESET}"
+
     return None
 
-def main():
-    parser = argparse.ArgumentParser(description='Filter Claude stream-json output')
-    parser.add_argument('--verbose', action='store_true',
-                        help='Show text and thinking in addition to tool calls')
+
+def process_event(event: dict, verbose: bool) -> None:
+    """Process a single stream-json event."""
+    event_type = event.get("type", "")
+
+    # Tool use events (assistant messages)
+    if event_type == "assistant":
+        message = event.get("message", {})
+        content = message.get("content", [])
+
+        for block in content:
+            block_type = block.get("type", "")
+
+            if block_type == "tool_use":
+                tool_name = block.get("name", "")
+                tool_input = block.get("input", {})
+                formatted = format_tool_use(tool_name, tool_input)
+                safe_print(f"{INDENT}{C_DIM}{formatted}{C_RESET}")
+
+            elif verbose and block_type == "text":
+                text = block.get("text", "")
+                if text.strip():
+                    safe_print(f"{INDENT}{C_CYAN}💬 {text}{C_RESET}")
+
+            elif verbose and block_type == "thinking":
+                thinking = block.get("thinking", "")
+                if thinking.strip():
+                    safe_print(f"{INDENT}{C_DIM}🧠 {truncate(thinking, 100)}{C_RESET}")
+
+    # Tool results (user messages with tool_result blocks)
+    elif event_type == "user":
+        message = event.get("message", {})
+        content = message.get("content", [])
+
+        for block in content:
+            if block.get("type") == "tool_result":
+                formatted = format_tool_result(block)
+                if formatted:
+                    safe_print(formatted)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Filter Claude stream-json output")
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Show text and thinking in addition to tool calls",
+    )
     args = parser.parse_args()
 
     for line in sys.stdin:
@@ -125,48 +208,12 @@ def main():
         except json.JSONDecodeError:
             continue
 
-        event_type = event.get("type", "")
+        try:
+            process_event(event, args.verbose)
+        except Exception:
+            # Swallow processing errors - keep draining stdin
+            pass
 
-        # Tool use events
-        if event_type == "assistant":
-            message = event.get("message", {})
-            content = message.get("content", [])
-
-            for block in content:
-                block_type = block.get("type", "")
-
-                if block_type == "tool_use":
-                    tool_name = block.get("name", "")
-                    tool_input = block.get("input", {})
-                    formatted = format_tool_use(tool_name, tool_input)
-                    print(f"{INDENT}{C_DIM}{formatted}{C_RESET}", flush=True)
-
-                elif args.verbose and block_type == "text":
-                    text = block.get("text", "")
-                    if text.strip():
-                        # Show model response
-                        print(f"{INDENT}{C_CYAN}💬 {text}{C_RESET}", flush=True)
-
-                elif args.verbose and block_type == "thinking":
-                    thinking = block.get("thinking", "")
-                    if thinking.strip():
-                        # Show thinking (truncated)
-                        print(f"{INDENT}{C_DIM}🧠 {truncate(thinking, 100)}{C_RESET}", flush=True)
-
-        # Tool results (show errors only)
-        elif event_type == "user":
-            message = event.get("message", {})
-            content = message.get("content", [])
-
-            for block in content:
-                if block.get("type") == "tool_result":
-                    result = block.get("content", "")
-                    # Handle both string and object content types
-                    if not isinstance(result, (str, dict)):
-                        result = str(result)
-                    formatted = format_tool_result(result)
-                    if formatted:
-                        print(formatted, flush=True)
 
 if __name__ == "__main__":
     try:
@@ -174,4 +221,10 @@ if __name__ == "__main__":
     except KeyboardInterrupt:
         sys.exit(0)
     except BrokenPipeError:
+        # Output broken but keep draining to prevent upstream SIGPIPE
+        drain_stdin()
+        sys.exit(0)
+    except Exception as e:
+        print(f"watch-filter: {e}", file=sys.stderr)
+        drain_stdin()
         sys.exit(0)


### PR DESCRIPTION
## Summary
- **Watch mode**: `--watch` streams tool calls in real-time, `--watch verbose` includes model text
- **Review feedback in receipts**: Codex plan/impl review receipts now include `review` field with full feedback (enables fix loops)
- **Codex timeout**: Bumped 300s → 600s (matches RP)
- **Plugin-dir support**: `FLOW_RALPH_CLAUDE_PLUGIN_DIR` for dev testing with local plugin

## Test plan
- [x] Codex e2e: plan SHIP, impl NEEDS_WORK → fix → SHIP, review field present
- [x] RP e2e: tasks complete, no drift, correct workflow
- [x] Watch mode: tool calls visible, Ctrl+C works
- [x] Timeout self-corrects on retry

Closes #17