### PR TITLE
feat(flow-next): add browser automation skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -30,8 +30,8 @@
     },
     {
       "name": "flow-next",
-      "description": "Zero-dependency planning + execution with .flow/ task tracking and Ralph autonomous mode (multi-model review gates). Includes 6 subagents, 8 commands, 11 skills.",
-      "version": "0.8.0",
+      "description": "Zero-dependency planning + execution with .flow/ task tracking and Ralph autonomous mode (multi-model review gates). Includes 6 subagents, 8 commands, 12 skills.",
+      "version": "0.9.0",
       "author": {
         "name": "Gordon Mickel",
         "email": "gordon@mickel.tech",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to the gmickel-claude-marketplace.
 
+## [flow-next 0.9.0] - 2026-01-15
+
+### Added
+- **Browser automation skill** - Web testing, form filling, screenshots, scraping via agent-browser CLI
+  - Core workflow: snapshot → ref-based interaction (@e1, @e2)
+  - Progressive disclosure: main skill + debugging/auth/advanced references
+  - Triggers on UI verification, doc lookup, baseline capture, e2e testing
+- **Bundled Skills** section in README documenting utility skills
+
+### Fixed
+- `install-codex.sh` now auto-discovers all skills (was hardcoded, missing 7 skills)
+
 ## [flow-next-tui 0.1.2] - 2026-01-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Claude Code](https://img.shields.io/badge/Claude_Code-Plugin_Marketplace-blueviolet)](https://claude.ai/code)
 
-[![Flow-next](https://img.shields.io/badge/Flow--next-v0.8.0-green)](plugins/flow-next/)
+[![Flow-next](https://img.shields.io/badge/Flow--next-v0.9.0-green)](plugins/flow-next/)
 
 [![Flow](https://img.shields.io/badge/Flow-v0.8.4-blue)](plugins/flow/)
 [![Author](https://img.shields.io/badge/Author-Gordon_Mickel-orange)](https://mickel.tech)
@@ -18,7 +18,7 @@
 
 > 🔄 **Update issues?** Run: `claude plugin update flow-next@gmickel-claude-marketplace`
 >
-> 🆕 **v0.8.0**: Async control for Ralph — `flowctl ralph pause/resume/stop`, `flowctl task reset --cascade`, external agent integration
+> 🆕 **v0.9.0**: Async control for Ralph — `flowctl ralph pause/resume/stop`, `flowctl task reset --cascade`, external agent integration
 >
 > 🤖 **[Ralph mode](plugins/flow-next/docs/ralph.md)**: Ship features while you sleep. Fresh context per iteration, multi-model review gates, auto-blocks stuck tasks.
 >

--- a/plugins/flow-next/.claude-plugin/plugin.json
+++ b/plugins/flow-next/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "flow-next",
-  "version": "0.8.0",
-  "description": "Zero-dependency planning + execution with .flow/ task tracking and Ralph autonomous mode (multi-model review gates). Includes 6 subagents, 8 commands, 11 skills.",
+  "version": "0.9.0",
+  "description": "Zero-dependency planning + execution with .flow/ task tracking and Ralph autonomous mode (multi-model review gates). Includes 6 subagents, 8 commands, 12 skills.",
   "author": {
     "name": "Gordon Mickel",
     "email": "gordon@mickel.tech",

--- a/plugins/flow-next/README.md
+++ b/plugins/flow-next/README.md
@@ -5,9 +5,9 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](../../LICENSE)
 [![Claude Code](https://img.shields.io/badge/Claude_Code-Plugin-blueviolet)](https://claude.ai/code)
 
-[![Version](https://img.shields.io/badge/Version-0.8.0-green)](../../CHANGELOG.md)
+[![Version](https://img.shields.io/badge/Version-0.9.0-green)](../../CHANGELOG.md)
 
-[![Version](https://img.shields.io/badge/Version-0.8.0-green)](../../CHANGELOG.md)
+[![Version](https://img.shields.io/badge/Version-0.9.0-green)](../../CHANGELOG.md)
 
 [![Status](https://img.shields.io/badge/Status-Active_Development-brightgreen)](../../CHANGELOG.md)
 
@@ -412,6 +412,17 @@ Everything is bundled:
 - No external tracker CLI to install
 - No external services
 - Just Python 3
+
+### Bundled Skills
+
+Utility skills available during planning and implementation:
+
+| Skill | Use Case |
+|-------|----------|
+| `browser` | Web automation via agent-browser CLI (verify UI, scrape docs, test flows) |
+| `flow-next-rp-explorer` | Token-efficient codebase exploration via RepoPrompt |
+| `flow-next-worktree-kit` | Git worktree management for parallel work |
+| `flow-next-export-context` | Export context for external LLM review |
 
 ### Non-invasive
 

--- a/plugins/flow-next/skills/browser/SKILL.md
+++ b/plugins/flow-next/skills/browser/SKILL.md
@@ -1,0 +1,212 @@
+---
+name: browser
+description: Browser automation via agent-browser CLI. Use when you need to navigate websites, verify deployed UI, test web apps, read online documentation, scrape data, fill forms, capture baseline screenshots before design work, or inspect current page state. Triggers on "check the page", "verify UI", "test the site", "read docs at", "look up API", "visit URL", "browse", "screenshot", "scrape", "e2e test", "login flow", "capture baseline", "see how it looks", "inspect current", "before redesign".
+---
+
+# Browser Automation
+
+Browser automation via Vercel's agent-browser CLI. Runs headless by default; use `--headed` for visible window. Uses ref-based selection (@e1, @e2) from accessibility snapshots.
+
+## Setup
+
+```bash
+command -v agent-browser >/dev/null 2>&1 && echo "OK" || echo "MISSING: npm i -g agent-browser && agent-browser install"
+```
+
+## Core Workflow
+
+1. **Open** URL
+2. **Snapshot** to get refs
+3. **Interact** via refs
+4. **Re-snapshot** after DOM changes
+
+```bash
+agent-browser open https://example.com
+agent-browser snapshot -i              # Interactive elements with refs
+agent-browser click @e1
+agent-browser wait --load networkidle  # Wait for SPA to settle
+agent-browser snapshot -i              # Re-snapshot after change
+```
+
+## Essential Commands
+
+### Navigation
+
+```bash
+agent-browser open <url>       # Navigate
+agent-browser back             # Go back
+agent-browser forward          # Go forward
+agent-browser reload           # Reload
+agent-browser close            # Close browser
+```
+
+### Snapshots
+
+```bash
+agent-browser snapshot           # Full accessibility tree
+agent-browser snapshot -i        # Interactive only (recommended)
+agent-browser snapshot -i --json # JSON for parsing
+agent-browser snapshot -c        # Compact (remove empty)
+agent-browser snapshot -d 3      # Limit depth
+agent-browser snapshot -s "#main" # Scope to selector
+```
+
+### Interactions
+
+```bash
+agent-browser click @e1              # Click
+agent-browser dblclick @e1           # Double-click
+agent-browser fill @e1 "text"        # Clear + fill input
+agent-browser type @e1 "text"        # Type without clearing
+agent-browser press Enter            # Key press
+agent-browser press Control+a        # Key combination
+agent-browser hover @e1              # Hover
+agent-browser check @e1              # Check checkbox
+agent-browser uncheck @e1            # Uncheck
+agent-browser select @e1 "option"    # Dropdown
+agent-browser scroll down 500        # Scroll direction + pixels
+agent-browser scrollintoview @e1     # Scroll element visible
+```
+
+### Get Info
+
+```bash
+agent-browser get text @e1       # Element text
+agent-browser get value @e1      # Input value
+agent-browser get html @e1       # Element HTML
+agent-browser get attr href @e1  # Attribute
+agent-browser get title          # Page title
+agent-browser get url            # Current URL
+agent-browser get count "button" # Count matches
+```
+
+### Check State
+
+```bash
+agent-browser is visible @e1    # Check visibility
+agent-browser is enabled @e1    # Check enabled
+agent-browser is checked @e1    # Check checkbox state
+```
+
+### Wait
+
+```bash
+agent-browser wait @e1                 # Wait for element visible
+agent-browser wait 2000                # Wait milliseconds
+agent-browser wait --text "Success"    # Wait for text
+agent-browser wait --url "**/dashboard" # Wait for URL pattern
+agent-browser wait --load networkidle  # Wait for network idle (SPAs)
+agent-browser wait --fn "window.ready" # Wait for JS condition
+```
+
+### Screenshots
+
+```bash
+agent-browser screenshot              # Viewport to stdout
+agent-browser screenshot out.png      # Save to file
+agent-browser screenshot --full       # Full page
+agent-browser pdf out.pdf             # Save as PDF
+```
+
+### Semantic Locators
+
+Alternative when you know the element (no snapshot needed, see [advanced.md](references/advanced.md) for tabs, frames, network mocking):
+
+```bash
+agent-browser find role button click --name "Submit"
+agent-browser find text "Sign In" click
+agent-browser find label "Email" fill "user@test.com"
+agent-browser find placeholder "Search" fill "query"
+agent-browser find first ".item" click
+agent-browser find nth 2 "a" text
+```
+
+## Sessions
+
+Parallel isolated browsers (see [auth.md](references/auth.md) for multi-user auth):
+
+```bash
+agent-browser --session test1 open site-a.com
+agent-browser --session test2 open site-b.com
+agent-browser session list
+```
+
+## JSON Output
+
+Add `--json` for machine-readable output:
+
+```bash
+agent-browser snapshot -i --json
+agent-browser get text @e1 --json
+agent-browser is visible @e1 --json
+```
+
+## Examples
+
+### Form Submission
+
+```bash
+agent-browser open https://example.com/form
+agent-browser snapshot -i
+# textbox "Email" [ref=e1], textbox "Password" [ref=e2], button "Submit" [ref=e3]
+agent-browser fill @e1 "user@example.com"
+agent-browser fill @e2 "password123"
+agent-browser click @e3
+agent-browser wait --load networkidle
+agent-browser snapshot -i  # Verify result
+```
+
+### Auth with Saved State
+
+```bash
+# Login once
+agent-browser open https://app.example.com/login
+agent-browser snapshot -i
+agent-browser fill @e1 "username"
+agent-browser fill @e2 "password"
+agent-browser click @e3
+agent-browser wait --url "**/dashboard"
+agent-browser state save auth.json
+
+# Later: reuse saved auth
+agent-browser state load auth.json
+agent-browser open https://app.example.com/dashboard
+```
+
+More auth patterns in [auth.md](references/auth.md).
+
+### Token Auth (Skip Login)
+
+```bash
+# Headers scoped to origin only
+agent-browser open api.example.com --headers '{"Authorization": "Bearer <token>"}'
+agent-browser snapshot -i --json
+```
+
+## Debugging
+
+```bash
+agent-browser --headed open example.com  # Show browser window
+agent-browser console                    # View console messages
+agent-browser errors                     # View page errors
+agent-browser highlight @e1              # Highlight element
+```
+
+See [debugging.md](references/debugging.md) for traces, common issues.
+
+## Troubleshooting
+
+**"Browser not launched" error**: Daemon stuck. Kill and retry:
+```bash
+pkill -f agent-browser && agent-browser open <url>
+```
+
+**Element not found**: Re-snapshot after page changes. DOM may have updated.
+
+## References
+
+| Topic | File |
+|-------|------|
+| Debugging, traces, common issues | [debugging.md](references/debugging.md) |
+| Auth, cookies, storage, state persistence | [auth.md](references/auth.md) |
+| Network mocking, tabs, frames, dialogs, settings | [advanced.md](references/advanced.md) |

--- a/plugins/flow-next/skills/browser/references/advanced.md
+++ b/plugins/flow-next/skills/browser/references/advanced.md
@@ -1,0 +1,169 @@
+# Advanced Features
+
+## Network Interception
+
+Mock or block network requests:
+
+```bash
+# Intercept and track requests
+agent-browser network route "**/api/*"
+
+# Block requests (ads, analytics)
+agent-browser network route "**/analytics/*" --abort
+
+# Mock response
+agent-browser network route "**/api/user" --body '{"name":"Test User"}'
+
+# Remove route
+agent-browser network unroute "**/api/*"
+
+# View tracked requests
+agent-browser network requests
+agent-browser network requests --filter api
+```
+
+## Tabs
+
+```bash
+agent-browser tab                # List tabs
+agent-browser tab new            # New blank tab
+agent-browser tab new url.com    # New tab with URL
+agent-browser tab 2              # Switch to tab 2
+agent-browser tab close          # Close current tab
+agent-browser tab close 2        # Close tab 2
+```
+
+## Windows
+
+```bash
+agent-browser window new         # New browser window
+```
+
+## Frames (iframes)
+
+```bash
+agent-browser frame "#iframe-selector"  # Switch to iframe
+agent-browser snapshot -i               # Snapshot within iframe
+agent-browser click @e1                 # Interact within iframe
+agent-browser frame main                # Back to main frame
+```
+
+## Dialogs
+
+Handle alert/confirm/prompt dialogs:
+
+```bash
+agent-browser dialog accept              # Accept dialog
+agent-browser dialog accept "input text" # Accept prompt with text
+agent-browser dialog dismiss             # Dismiss/cancel dialog
+```
+
+## Mouse Control
+
+Low-level mouse operations:
+
+```bash
+agent-browser mouse move 100 200       # Move to coordinates
+agent-browser mouse down               # Press left button
+agent-browser mouse down right         # Press right button
+agent-browser mouse up                 # Release button
+agent-browser mouse wheel -500         # Scroll wheel (negative = up)
+```
+
+## Drag and Drop
+
+```bash
+agent-browser drag @e1 @e2             # Drag e1 to e2
+agent-browser drag "#source" "#target"
+```
+
+## File Upload
+
+```bash
+agent-browser upload @e1 /path/to/file.pdf
+agent-browser upload @e1 file1.jpg file2.jpg  # Multiple files
+```
+
+## Browser Settings
+
+### Viewport
+
+```bash
+agent-browser set viewport 1920 1080
+```
+
+### Device Emulation
+
+```bash
+agent-browser set device "iPhone 14"
+agent-browser set device "Pixel 5"
+```
+
+### Geolocation
+
+```bash
+agent-browser set geo 37.7749 -122.4194  # San Francisco
+```
+
+### Offline Mode
+
+```bash
+agent-browser set offline on
+agent-browser set offline off
+```
+
+### Color Scheme
+
+```bash
+agent-browser set media dark
+agent-browser set media light
+```
+
+## CDP Mode
+
+Connect to existing browser via Chrome DevTools Protocol:
+
+```bash
+# Connect to Electron app or Chrome with remote debugging
+# Start Chrome: google-chrome --remote-debugging-port=9222
+agent-browser --cdp 9222 snapshot
+agent-browser --cdp 9222 click @e1
+```
+
+Use cases:
+- Control Electron apps
+- Connect to existing Chrome sessions
+- WebView2 applications
+
+## JavaScript Evaluation
+
+```bash
+agent-browser eval "document.title"
+agent-browser eval "window.scrollTo(0, 1000)"
+agent-browser eval "localStorage.getItem('token')"
+```
+
+## Bounding Box
+
+Get element position and size:
+
+```bash
+agent-browser get box @e1
+# {"x":100,"y":200,"width":150,"height":40}
+```
+
+## Custom Browser Executable
+
+Use system Chrome or lightweight builds:
+
+```bash
+agent-browser --executable-path /usr/bin/google-chrome open example.com
+
+# Or via environment
+AGENT_BROWSER_EXECUTABLE_PATH=/path/to/chromium agent-browser open example.com
+```
+
+Useful for:
+- Serverless (use `@sparticuz/chromium`)
+- System browser instead of bundled
+- Custom Chromium builds

--- a/plugins/flow-next/skills/browser/references/auth.md
+++ b/plugins/flow-next/skills/browser/references/auth.md
@@ -1,0 +1,111 @@
+# Authentication
+
+Patterns for handling login, sessions, and auth state.
+
+## State Persistence
+
+Save and restore full browser state (cookies, localStorage, sessionStorage):
+
+```bash
+# After successful login
+agent-browser state save auth.json
+
+# In new session
+agent-browser state load auth.json
+agent-browser open https://app.example.com/dashboard
+```
+
+## Token Auth via Headers
+
+Skip login flows entirely with auth headers:
+
+```bash
+# Headers scoped to origin only (safe!)
+agent-browser open api.example.com --headers '{"Authorization": "Bearer <token>"}'
+```
+
+Multiple origins:
+```bash
+agent-browser open api.example.com --headers '{"Authorization": "Bearer token1"}'
+agent-browser open api.acme.com --headers '{"Authorization": "Bearer token2"}'
+```
+
+Global headers (all domains):
+```bash
+agent-browser set headers '{"X-Custom-Header": "value"}'
+```
+
+## Cookies
+
+```bash
+agent-browser cookies                    # Get all cookies
+agent-browser cookies set name "value"   # Set cookie
+agent-browser cookies clear              # Clear all cookies
+```
+
+## Local Storage
+
+```bash
+agent-browser storage local              # Get all localStorage
+agent-browser storage local key          # Get specific key
+agent-browser storage local set key val  # Set value
+agent-browser storage local clear        # Clear all
+```
+
+## Session Storage
+
+```bash
+agent-browser storage session            # Get all sessionStorage
+agent-browser storage session key        # Get specific key
+agent-browser storage session set k v    # Set value
+agent-browser storage session clear      # Clear all
+```
+
+## HTTP Basic Auth
+
+```bash
+agent-browser set credentials username password
+agent-browser open https://protected-site.com
+```
+
+## Example: Full Login Flow with State Save
+
+```bash
+# First run: perform login
+agent-browser open https://app.example.com/login
+agent-browser snapshot -i
+agent-browser fill @e1 "user@example.com"
+agent-browser fill @e2 "password123"
+agent-browser click @e3
+agent-browser wait --url "**/dashboard"
+agent-browser wait --load networkidle
+
+# Verify logged in
+agent-browser snapshot -i
+# Should show dashboard elements, not login form
+
+# Save state for future runs
+agent-browser state save auth.json
+agent-browser close
+```
+
+```bash
+# Subsequent runs: skip login
+agent-browser state load auth.json
+agent-browser open https://app.example.com/dashboard
+# Already authenticated!
+```
+
+## Session Isolation
+
+Different auth states in parallel:
+
+```bash
+# Admin session
+agent-browser --session admin state load admin-auth.json
+agent-browser --session admin open https://app.example.com/admin
+
+# User session
+agent-browser --session user state load user-auth.json
+agent-browser --session user open https://app.example.com/profile
+```

--- a/plugins/flow-next/skills/browser/references/debugging.md
+++ b/plugins/flow-next/skills/browser/references/debugging.md
@@ -1,0 +1,92 @@
+# Debugging
+
+When browser automation fails or behaves unexpectedly.
+
+## Headed Mode
+
+Show visible browser window to see what's happening:
+
+```bash
+agent-browser --headed open example.com
+agent-browser --headed snapshot -i
+agent-browser --headed click @e1
+```
+
+## Console & Errors
+
+View browser console output and page errors:
+
+```bash
+agent-browser console          # View console messages
+agent-browser console --clear  # Clear console log
+agent-browser errors           # View page errors
+agent-browser errors --clear   # Clear error log
+```
+
+## Highlight Elements
+
+Visually identify elements (use with `--headed`):
+
+```bash
+agent-browser highlight @e1
+agent-browser highlight "#selector"
+```
+
+## Traces
+
+Record browser traces for detailed debugging:
+
+```bash
+agent-browser trace start           # Start recording
+# ... do interactions ...
+agent-browser trace stop trace.zip  # Save trace file
+```
+
+Open traces in Playwright Trace Viewer: `npx playwright show-trace trace.zip`
+
+## State Checks
+
+Verify element state before interacting:
+
+```bash
+agent-browser is visible @e1    # Returns true/false
+agent-browser is enabled @e1    # Check if interactive
+agent-browser is checked @e1    # Checkbox state
+```
+
+With JSON output:
+```bash
+agent-browser is visible @e1 --json
+# {"success":true,"data":true}
+```
+
+## Common Issues
+
+### Element not found
+- Re-snapshot: DOM may have changed
+- Check visibility: `is visible @e1`
+- Try `--headed` to see actual page state
+
+### Click does nothing
+- Element may be covered: try `scrollintoview @e1` first
+- Element may be disabled: check `is enabled @e1`
+- SPA not ready: add `wait --load networkidle`
+
+### Form not submitting
+- Check for validation errors in snapshot
+- Some forms need `press Enter` instead of button click
+- Wait for network: `wait --load networkidle`
+
+### Auth redirect loops
+- Save state after successful login: `state save auth.json`
+- Check cookies: `cookies`
+- Verify URL pattern: `get url`
+
+## Debug Output
+
+Add `--debug` for verbose output:
+
+```bash
+agent-browser --debug open example.com
+agent-browser --debug click @e1
+```

--- a/scripts/install-codex.sh
+++ b/scripts/install-codex.sh
@@ -56,19 +56,13 @@ fi
 mkdir -p "$CODEX_DIR/skills"
 mkdir -p "$CODEX_DIR/prompts"
 
-# Get skill list based on plugin
-if [ "$PLUGIN" = "flow" ]; then
-    SKILLS=(flow-plan flow-work flow-interview flow-plan-review flow-impl-review rp-explorer worktree-kit)
-else
-    SKILLS=(flow-next-plan flow-next-work flow-next-interview flow-next-plan-review flow-next-impl-review)
-fi
-
-# Install skills
+# Install all skills from plugin
 echo "Installing skills..."
-for skill in "${SKILLS[@]}"; do
-    if [ -d "$REPO_ROOT/plugins/$PLUGIN/skills/$skill" ]; then
+for skill_dir in "$REPO_ROOT/plugins/$PLUGIN/skills/"*/; do
+    if [ -d "$skill_dir" ]; then
+        skill=$(basename "$skill_dir")
         rm -rf "$CODEX_DIR/skills/$skill"
-        cp -r "$REPO_ROOT/plugins/$PLUGIN/skills/$skill" "$CODEX_DIR/skills/"
+        cp -r "$skill_dir" "$CODEX_DIR/skills/"
         echo -e "  ${GREEN}✓${NC} $skill"
     fi
 done


### PR DESCRIPTION
## Summary

- Add **browser** skill for web automation via Vercel's [agent-browser](https://github.com/vercel-labs/agent-browser) CLI
- Fix `install-codex.sh` to auto-discover all skills (was hardcoded, missing 7)
- Document bundled skills in README
- Bump to v0.9.0

## Browser Skill

Web automation for planning and implementation phases:

| Use Case | Example Trigger |
|----------|-----------------|
| Verify deployed UI | "check the page", "verify UI works" |
| Read online docs | "read docs at", "look up API" |
| Capture baseline | "see how it looks", "before redesign" |
| Test flows | "e2e test", "login flow" |
| Scrape data | "scrape", "extract from page" |

### Structure (Progressive Disclosure)

```
browser/
├── SKILL.md (200 lines) - core workflow, essential commands
└── references/
    ├── debugging.md - traces, console, common issues
    ├── auth.md - cookies, storage, state persistence
    └── advanced.md - network mocking, tabs, frames, CDP
```

### Core Workflow

```bash
agent-browser open https://example.com
agent-browser snapshot -i              # Get refs (@e1, @e2)
agent-browser click @e1
agent-browser wait --load networkidle
agent-browser snapshot -i              # Re-snapshot after change
```

## Other Changes

- **install-codex.sh**: Now loops through `plugins/$PLUGIN/skills/*/` instead of hardcoded list
- **README**: Added "Bundled Skills" section documenting utility skills
- **Version**: 0.8.0 → 0.9.0

## Test Plan

- [x] Smoke tested agent-browser (headless + headed modes)
- [x] Verified form fill, click, screenshot, navigation
- [x] JSON validation passes
- [ ] Verify skill triggers during `/flow-next:plan` or `/flow-next:work`