### PR TITLE
feat(flow-next): stdin support, task set-spec, checkpoint commands

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -31,7 +31,7 @@
     {
       "name": "flow-next",
       "description": "Zero-dependency planning + execution with .flow/ task tracking and Ralph autonomous mode (multi-model review gates). Includes 6 subagents, 8 commands, 12 skills.",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "author": {
         "name": "Gordon Mickel",
         "email": "gordon@mickel.tech",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to the gmickel-claude-marketplace.
 
+## [flow-next 0.10.0] - 2026-01-15
+
+### Added
+- **Stdin support** (`--file -`) for flowctl commands
+  - `epic set-plan`, `task set-description`, `task set-acceptance` now accept `-` to read from stdin
+  - Enables heredoc usage: `flowctl epic set-plan fn-1 --file - <<'EOF'`
+  - Eliminates temp file creation, solves shell escaping issues
+- **Combined task set-spec command**
+  - `flowctl task set-spec <id> --description <file> --acceptance <file>`
+  - Sets both sections in single call (2 atomic writes vs 4)
+- **Checkpoint commands** for compaction recovery
+  - `flowctl checkpoint save --epic <id>` - Snapshots epic + all tasks to `.flow/.checkpoint-<id>.json`
+  - `flowctl checkpoint restore --epic <id>` - Restores from checkpoint
+  - `flowctl checkpoint delete --epic <id>` - Removes checkpoint file
+
+### Changed
+- Updated skill files to use stdin heredocs and `task set-spec` where applicable
+- Plan-review workflow now saves checkpoint before review (recovery point)
+- Added smoke tests for stdin, set-spec, and checkpoint commands
+
 ## [flow-next 0.9.0] - 2026-01-15
 
 ### Added

--- a/plugins/flow-next/.claude-plugin/plugin.json
+++ b/plugins/flow-next/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "flow-next",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Zero-dependency planning + execution with .flow/ task tracking and Ralph autonomous mode (multi-model review gates). Includes 6 subagents, 8 commands, 12 skills.",
   "author": {
     "name": "Gordon Mickel",

--- a/plugins/flow-next/README.md
+++ b/plugins/flow-next/README.md
@@ -5,9 +5,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](../../LICENSE)
 [![Claude Code](https://img.shields.io/badge/Claude_Code-Plugin-blueviolet)](https://claude.ai/code)
 
-[![Version](https://img.shields.io/badge/Version-0.9.0-green)](../../CHANGELOG.md)
-
-[![Version](https://img.shields.io/badge/Version-0.9.0-green)](../../CHANGELOG.md)
+[![Version](https://img.shields.io/badge/Version-0.10.0-green)](../../CHANGELOG.md)
 
 [![Status](https://img.shields.io/badge/Status-Active_Development-brightgreen)](../../CHANGELOG.md)
 
@@ -224,6 +222,19 @@ ls scripts/ralph/runs/*/receipts/
 cat scripts/ralph/runs/*/receipts/impl-fn-1.1.json
 # Must have: {"type":"impl_review","id":"fn-1.1",...}
 ```
+
+### Custom rp-cli instructions conflicting
+
+> **Caution**: If you have custom instructions for `rp-cli` in your `CLAUDE.md` or `AGENTS.md`, they may conflict with Flow-Next's RepoPrompt integration.
+
+Flow-Next's plan-review and impl-review skills include specific instructions for `rp-cli` usage (window selection, builder workflow, chat commands). Custom rp-cli instructions can override these and cause unexpected behavior.
+
+**Symptoms:**
+- Reviews not using the correct RepoPrompt window
+- Builder not selecting expected files
+- Chat commands failing or behaving differently
+
+**Fix:** Remove or comment out custom rp-cli instructions from your `CLAUDE.md`/`AGENTS.md` when using Flow-Next reviews. The plugin provides complete rp-cli guidance.
 
 ---
 

--- a/plugins/flow-next/skills/flow-next-interview/SKILL.md
+++ b/plugins/flow-next/skills/flow-next-interview/SKILL.md
@@ -84,42 +84,52 @@ After interview complete, write everything back.
 
 ### For Flow Epic ID
 
-1. Create a temp file with the refined epic spec including:
-   - Clear problem statement
-   - Technical approach with specifics
-   - Key decisions made during interview
-   - Edge cases to handle
-   - Quick commands section (required)
-   - Acceptance criteria
+Update epic spec using stdin heredoc (preferred) or temp file:
+```bash
+# Preferred: stdin heredoc (no temp file)
+$FLOWCTL epic set-plan <id> --file - --json <<'EOF'
+# Epic Title
 
-2. Update epic spec:
-   ```bash
-   $FLOWCTL epic set-plan <id> --file <temp-md> --json
-   ```
+## Problem
+Clear problem statement
 
-3. Create/update tasks if interview revealed breakdown:
-   ```bash
-   $FLOWCTL task create --epic <id> --title "..." --json
-   $FLOWCTL task set-description <task-id> --file <temp-md> --json
-   $FLOWCTL task set-acceptance <task-id> --file <temp-md> --json
-   ```
+## Approach
+Technical approach with specifics, key decisions from interview
+
+## Edge Cases
+- Edge case 1
+- Edge case 2
+
+## Quick commands
+```bash
+# smoke test command
+```
+
+## Acceptance
+- [ ] Criterion 1
+- [ ] Criterion 2
+EOF
+```
+
+Create/update tasks if interview revealed breakdown:
+```bash
+$FLOWCTL task create --epic <id> --title "..." --json
+# Use set-spec for combined description + acceptance (fewer writes)
+$FLOWCTL task set-spec <task-id> --description /tmp/desc.md --acceptance /tmp/acc.md --json
+```
 
 ### For Flow Task ID
 
-1. Write description to temp file with:
-   - Clear task description
-   - Technical details from interview
-   - Edge cases
+Update task using combined set-spec (preferred) or separate calls:
+```bash
+# Preferred: combined set-spec (2 writes instead of 4)
+$FLOWCTL task set-spec <id> --description /tmp/desc.md --acceptance /tmp/acc.md --json
 
-2. Write acceptance to temp file with:
-   - Checkboxes for acceptance criteria
-   - Specific, testable conditions
-
-3. Update task:
-   ```bash
-   $FLOWCTL task set-description <id> --file <desc-temp.md> --json
-   $FLOWCTL task set-acceptance <id> --file <acc-temp.md> --json
-   ```
+# Or use stdin for description only:
+$FLOWCTL task set-description <id> --file - --json <<'EOF'
+Clear task description with technical details and edge cases from interview
+EOF
+```
 
 ### For File Path
 

--- a/plugins/flow-next/skills/flow-next-plan-review/SKILL.md
+++ b/plugins/flow-next/skills/flow-next-plan-review/SKILL.md
@@ -125,6 +125,9 @@ Run backend detection from SKILL.md above. Then branch:
 EPIC_ID="${1:-}"
 RECEIPT_PATH="${REVIEW_RECEIPT_PATH:-/tmp/plan-review-receipt.json}"
 
+# Save checkpoint before review (recovery point if context compacts)
+$FLOWCTL checkpoint save --epic "$EPIC_ID" --json
+
 $FLOWCTL codex plan-review "$EPIC_ID" --receipt "$RECEIPT_PATH"
 # Output includes VERDICT=SHIP|NEEDS_WORK|MAJOR_RETHINK
 ```
@@ -137,6 +140,9 @@ On NEEDS_WORK: fix plan via `$FLOWCTL epic set-plan`, then re-run (receipt enabl
 # Step 1: Get plan content
 $FLOWCTL show <id> --json
 $FLOWCTL cat <id>
+
+# Save checkpoint before review (recovery point if context compacts)
+$FLOWCTL checkpoint save --epic <id> --json
 
 # Step 2: Atomic setup
 eval "$($FLOWCTL rp setup-review --repo-root "$REPO_ROOT" --summary "Review plan for <EPIC_ID>: <summary>")"
@@ -158,10 +164,24 @@ $FLOWCTL epic set-plan-review-status <EPIC_ID> --status ship --json
 If verdict is NEEDS_WORK, loop internally until SHIP:
 
 1. **Parse issues** from reviewer feedback
-2. **Fix plan** via `$FLOWCTL epic set-plan <EPIC_ID> --file /tmp/updated-plan.md`
+2. **Fix plan** (stdin preferred, temp file if content has single quotes):
+   ```bash
+   # Preferred: stdin heredoc
+   $FLOWCTL epic set-plan <EPIC_ID> --file - --json <<'EOF'
+   <updated plan content>
+   EOF
+
+   # Or temp file
+   $FLOWCTL epic set-plan <EPIC_ID> --file /tmp/updated-plan.md --json
+   ```
 3. **Re-review**:
    - **Codex**: Re-run `flowctl codex plan-review` (receipt enables context)
    - **RP**: `$FLOWCTL rp chat-send --window "$W" --tab "$T" --message-file /tmp/re-review.md` (NO `--new-chat`)
 4. **Repeat** until `<verdict>SHIP</verdict>`
+
+**Recovery**: If context compaction occurred during review, restore from checkpoint:
+```bash
+$FLOWCTL checkpoint restore --epic <EPIC_ID> --json
+```
 
 **CRITICAL**: For RP, re-reviews must stay in the SAME chat so reviewer has context. Only use `--new-chat` on the FIRST review.

--- a/plugins/flow-next/skills/flow-next-plan-review/workflow.md
+++ b/plugins/flow-next/skills/flow-next-plan-review/workflow.md
@@ -47,10 +47,17 @@ echo "Review backend: $BACKEND"
 
 Use when `BACKEND="codex"`.
 
+### Step 0: Save Checkpoint
+
+**Before review** (protects against context compaction):
+```bash
+EPIC_ID="${1:-}"
+$FLOWCTL checkpoint save --epic "$EPIC_ID" --json
+```
+
 ### Step 1: Execute Review
 
 ```bash
-EPIC_ID="${1:-}"
 RECEIPT_PATH="${REVIEW_RECEIPT_PATH:-/tmp/plan-review-receipt.json}"
 
 $FLOWCTL codex plan-review "$EPIC_ID" --receipt "$RECEIPT_PATH"
@@ -114,6 +121,12 @@ $FLOWCTL cat <id>
 ```
 
 Save output for inclusion in review prompt. Compose a 1-2 sentence summary for the setup-review command.
+
+**Save checkpoint** (protects against context compaction during review):
+```bash
+$FLOWCTL checkpoint save --epic <id> --json
+```
+This creates `.flow/.checkpoint-<id>.json` with full state. If compaction occurs during review-fix cycles, restore with `$FLOWCTL checkpoint restore --epic <id>`.
 
 ---
 
@@ -240,12 +253,23 @@ If no verdict tag, output `<promise>RETRY</promise>` and stop.
 If verdict is NEEDS_WORK:
 
 1. **Parse issues** - Extract ALL issues by severity (Critical → Major → Minor)
-2. **Fix the plan** - Address each issue. Write updated plan to temp file.
+2. **Fix the plan** - Address each issue.
 3. **Update plan in flowctl** (MANDATORY before re-review):
    ```bash
+   # Option A: stdin heredoc (preferred, no temp file)
+   $FLOWCTL epic set-plan <EPIC_ID> --file - --json <<'EOF'
+   <updated plan content>
+   EOF
+
+   # Option B: temp file (if content has single quotes)
    $FLOWCTL epic set-plan <EPIC_ID> --file /tmp/updated-plan.md --json
    ```
    **If you skip this step and re-review with same content, reviewer will return NEEDS_WORK again.**
+
+   **Recovery**: If context compaction occurred, restore from checkpoint first:
+   ```bash
+   $FLOWCTL checkpoint restore --epic <EPIC_ID> --json
+   ```
 
 4. **Re-review with fix summary** (only AFTER step 3):
 

--- a/plugins/flow-next/skills/flow-next/SKILL.md
+++ b/plugins/flow-next/skills/flow-next/SKILL.md
@@ -57,13 +57,13 @@ $FLOWCTL ready --epic fn-1 --json
 # Create task under existing epic
 $FLOWCTL task create --epic fn-1 --title "Fix bug X" --json
 
-# Set task description (from file)
-echo "Description here" > /tmp/desc.md
-$FLOWCTL task set-description fn-1.2 --file /tmp/desc.md --json
+# Set task description and acceptance (combined, fewer writes)
+$FLOWCTL task set-spec fn-1.2 --description /tmp/desc.md --acceptance /tmp/accept.md --json
 
-# Set acceptance criteria (from file)
-echo "- [ ] Criterion 1" > /tmp/accept.md
-$FLOWCTL task set-acceptance fn-1.2 --file /tmp/accept.md --json
+# Or use stdin with heredoc (no temp file):
+$FLOWCTL task set-description fn-1.2 --file - --json <<'EOF'
+Description here
+EOF
 
 # Start working on task
 $FLOWCTL start fn-1.2 --json
@@ -96,7 +96,7 @@ $FLOWCTL validate --all --json
    $FLOWCTL task create --epic fn-N --title "Short title" --json
    ```
 
-3. Add description:
+3. Add description + acceptance (combined):
    ```bash
    cat > /tmp/desc.md << 'EOF'
    **Bug/Feature:** Brief description
@@ -105,16 +105,11 @@ $FLOWCTL validate --all --json
    - Point 1
    - Point 2
    EOF
-   $FLOWCTL task set-description fn-N.M --file /tmp/desc.md --json
-   ```
-
-4. Add acceptance:
-   ```bash
    cat > /tmp/accept.md << 'EOF'
    - [ ] Criterion 1
    - [ ] Criterion 2
    EOF
-   $FLOWCTL task set-acceptance fn-N.M --file /tmp/accept.md --json
+   $FLOWCTL task set-spec fn-N.M --description /tmp/desc.md --acceptance /tmp/accept.md --json
    ```
 
 ### "What tasks are there?"


### PR DESCRIPTION
## Summary

- **Stdin support** (`--file -`) for `epic set-plan`, `task set-description`, `task set-acceptance` - enables heredoc usage, eliminates temp files
- **Combined `task set-spec`** command - sets description + acceptance in one call (2 writes vs 4)
- **Checkpoint commands** (`save`/`restore`/`delete`) - snapshot epic state before reviews, recover from compaction
- Updated skill files with new patterns
- Added rp-cli conflict caution to README troubleshooting

## Impact

| Metric (5-task epic) | Before | After |
|---------------------|--------|-------|
| Temp files | 11 | 0-2 |
| Atomic writes | 37 | ~22 |
| Tool calls | 16+ | 8-10 |

## Test plan

- [x] Smoke tests pass (31 tests, 3 new)
- [x] Manual test: `/flow-next:plan` with stdin + set-spec (confirmed via jsonl)
- [x] Checkpoint restore triggered during plan-review
- [ ] Ralph smoke test (hooks verified compatible)