### PR TITLE
docs: restructure READMEs for clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@
 [![Flow-next](https://img.shields.io/badge/Flow--next-v0.11.5-green)](plugins/flow-next/)
 [![Flow-next Docs](https://img.shields.io/badge/Docs-📖_Full_Guide-informational)](plugins/flow-next/README.md)
 
-[![Flow](https://img.shields.io/badge/Flow-v0.8.4-blue)](plugins/flow/)
 [![Author](https://img.shields.io/badge/Author-Gordon_Mickel-orange)](https://mickel.tech)
 [![Twitter](https://img.shields.io/badge/@gmickel-black?logo=x)](https://twitter.com/gmickel)
 [![Sponsor](https://img.shields.io/badge/Sponsor-❤-ea4aaa)](https://github.com/sponsors/gmickel)
@@ -19,13 +18,11 @@
 
 > 🔄 **Update issues?** Run: `claude plugin update flow-next@gmickel-claude-marketplace`
 >
-> 🆕 **v0.9.0**: Async control for Ralph — `flowctl ralph pause/resume/stop`, `flowctl task reset --cascade`, external agent integration
->
 > 🤖 **[Ralph mode](plugins/flow-next/docs/ralph.md)**: Ship features while you sleep. Fresh context per iteration, multi-model review gates, auto-blocks stuck tasks.
 >
 > 💪 **Stable features**: Plan-first workflow, re-anchoring, receipt-based gating, structured task management
 >
-> 📡 **Cross-platform reviews**: [RepoPrompt](https://repoprompt.com/?atp=KJbuL4) (macOS) or [Codex CLI](plugins/flow-next/README.md#codex-review-backend) (any OS)
+> 📡 **Cross-platform reviews**: [RepoPrompt](https://repoprompt.com/?atp=KJbuL4) (macOS) or [Codex CLI](plugins/flow-next/README.md#cross-model-reviews) (any OS)
 >
 > 🧪 **OpenCode user?** Try [flow-next-opencode](https://github.com/gmickel/flow-next-opencode) (experimental port)
 
@@ -44,289 +41,70 @@ This marketplace ships plugins that fix these problems.
 
 ---
 
-## Plugins
-
-| Plugin | What It Does |
-|--------|--------------|
-| [**flow-next**](#flow-next) | Plan-first workflow with `.flow/` task tracking. Zero deps. Multi-user safe. **Recommended.** |
-| ~~flow~~ | Legacy. Use flow-next instead. |
-
-> **New here?** Install **flow-next**. It does everything flow does plus Ralph mode, better tooling, and active development. Flow is kept for existing users only.
-
----
-
 ## Flow-Next
-
-📖 **Full guide (CLI, workflow, .flow layout):** [plugins/flow-next/README.md](plugins/flow-next/README.md)
-
-🌐 **Prefer a visual overview?** See the [Flow-Next app page](https://mickel.tech/apps/flow-next) for diagrams and examples.
 
 **Plan first, work second. Zero external dependencies.**
 
 ```bash
-# 1. Install
+# Install
 /plugin marketplace add https://github.com/gmickel/gmickel-claude-marketplace
 /plugin install flow-next
 
-# 2. Setup (recommended - adds CLI access + project docs)
-/flow-next:setup
-
-# 3. Use
+# Use
 /flow-next:plan Add a contact form with validation
 /flow-next:work fn-1
 ```
 
-**What setup unlocks:**
-- CLI access: `flowctl epics`, `flowctl ready`, `flowctl show` (no Claude needed)
-- Project docs: Adds instructions for other AI tools (Codex, Cursor, etc.)
-- Local guide: `.flow/usage.md` reference
-
-Idempotent - safe to re-run. Skip if you only need `/flow-next:plan` and `/flow-next:work`.
-
-### Choose Your Path
-
-| I want to... | Command | Automation Level |
-|--------------|---------|------------------|
-| Plan + work one task at a time | `/flow-next:work fn-1.1` | Manual |
-| Plan an epic, work with reviews | `/flow-next:plan` -> `/flow-next:work fn-1` | Manual + optional review |
-| Run overnight unattended | `/flow-next:ralph-init` -> `scripts/ralph/ralph.sh` | Full autonomous |
-
-**Agents that finish what they start.**
-
-```mermaid
-flowchart TD
-  A[Idea or short spec<br/>prompt or doc] --> B{Need deeper spec?}
-  B -- yes --> C[Optional: /flow-next:interview fn-N or spec.md<br/>40+ deep questions to refine spec]
-  C --> D[Refined spec]
-  B -- no --> D
-  D --> E[/flow-next:plan idea or fn-N/]
-  E --> F[Parallel subagents: repo patterns + online docs + best practices]
-  F --> G[flow-gap-analyst: edge cases + missing reqs]
-  G --> H[Writes .flow/ epic + tasks + deps]
-  H --> I{Plan review? rp-cli only}
-  I -- yes --> J[/flow-next:plan-review fn-N/]
-  J --> K{Plan passes review?}
-  K -- no --> L[Re-anchor + fix plan]
-  L --> J
-  K -- yes --> M[/flow-next:work fn-N/]
-  I -- no --> M
-  M --> N[Re-anchor before EVERY task]
-  N --> O[Implement]
-  O --> P[Test + verify acceptance]
-  P --> Q[flowctl done: write done summary + evidence]
-  Q --> R{Impl review? rp-cli only}
-  R -- yes --> S[/flow-next:impl-review/]
-  S --> T{Next ready task?}
-  R -- no --> T
-  T -- yes --> N
-  T -- no --> U[flowctl epic close fn-N]
-  classDef optional stroke-dasharray: 6 4,stroke:#999;
-  class C,J,S optional;
-```
-
-<table>
-<tr>
-<td><img src="assets/flow-next-plan.png" alt="Planning Phase" width="400"/></td>
-<td><img src="assets/flow-next-work.png" alt="Implementation Phase" width="400"/></td>
-</tr>
-<tr>
-<td align="center"><em>Planning: dependency-ordered tasks</em></td>
-<td align="center"><em>Execution: fixes, evidence, review</em></td>
-</tr>
-</table>
-
-### How to Start
-
-**1. Write a short spec**
-
-Start with a rough idea - 1-5 sentences describing what you want to build. Save it as a markdown file or just keep it in your head.
-
-**2. Flesh it out (optional but recommended)**
-
-```bash
-/flow-next:interview "Add user authentication with OAuth"
-# or point to a spec file:
-/flow-next:interview specs/auth.md
-```
-
-The interview asks 40+ deep questions to surface edge cases, requirements, and decisions before you start coding.
-
-**3. Plan it**
-
-```bash
-/flow-next:plan "Add user authentication with OAuth"
-# or if you have a refined spec:
-/flow-next:plan fn-1  # refine existing epic
-```
-
-Creates an epic with dependency-ordered tasks in `.flow/`.
-
-**4. Work it**
-
-Choose your mode:
-
-```bash
-# Interactive - one task at a time, full control
-/flow-next:work fn-1.1
-
-# Interactive - whole epic, still in Claude
-/flow-next:work fn-1
-
-# Autonomous - run overnight, walk away
-/flow-next:ralph-init  # one-time setup
-scripts/ralph/ralph.sh  # run from terminal
-```
-
-That's it. Spec -> Interview -> Plan -> Work.
-
 ### Why It Works
 
-**You control the granularity:**
-- `/flow-next:work fn-1.1` — one task at a time with full review cycles
-- `/flow-next:work fn-1` — throw the whole epic at it, walk away
-
-Either way you get the same guarantees: re-anchoring, evidence, cross-model review.
-
-**No context length worries:**
-- Planning ensures every task fits one work iteration
-- Re-anchoring after each task (and after compaction) prevents drift
-- Fresh context window every iteration in Ralph mode
-
-**Reviewer as safety net:**
-- If drift happens despite re-anchoring, a different model catches it
-- Reviews block until `SHIP` verdict - no "LGTM with nits" that get ignored
-
-**What reviewers check:**
-
-| Plan Reviews | Implementation Reviews |
-|--------------|------------------------|
-| Completeness & feasibility | Correctness & simplicity |
-| Architecture & scope | DRY & edge cases |
-| Dependencies & risks | Test coverage & security |
-| Task breakdown quality | Evidence of completion |
-
-**Re-anchoring prevents drift:**
-
-Before EVERY task, Flow-Next re-reads the epic spec, task spec, and git state from `.flow/`. This forces Claude back to the source of truth - no hallucinated scope creep, no forgotten requirements. In Ralph mode, this happens automatically each iteration.
-
-Unlike agents that carry accumulated context (where early mistakes compound), re-anchoring gives each task a fresh, accurate starting point.
-
-Bundles everything in a single Python script. No npm. No daemons. No config edits. Try it in 30 seconds. Uninstall by deleting `.flow/` (and `scripts/ralph/` if enabled).
-
-## Ralph (Autonomous Mode)
-
-> **⚠️ Safety first**: Ralph defaults to `YOLO=1` (skips permission prompts).
-> - Start with `ralph_once.sh` to observe one iteration
-> - Consider [Docker sandbox](https://docs.docker.com/ai/sandboxes/claude-code/) for isolation
-
-**Setup (one-time, inside Claude):**
-```bash
-/flow-next:ralph-init
-```
-
-Or from terminal without entering Claude:
-```bash
-claude -p "/flow-next:ralph-init"
-```
-
-**Run (outside Claude):**
-```bash
-scripts/ralph/ralph.sh
-```
-
-**How Ralph differs from other autonomous agents:**
-
-Most agents gate by tests alone. Ralph adds production-grade quality gates:
-
-- **Multi-model reviews**: Uses [RepoPrompt](https://repoprompt.com/?atp=KJbuL4) to send code to a *different* model. Two models catch what one misses.
-- **Review loops until SHIP**: Reviews block progress until `<verdict>SHIP</verdict>`. Fix → re-review cycles continue until approved.
-- **Receipt-based gating**: Every review must produce a receipt JSON proving it ran. No receipt = no progress. At-least-once delivery with idempotent retry—treats agent as untrusted actor; receipts are proof-of-work.
-
-<details>
-<summary><strong>📸 Ralph in action</strong> (click to expand)</summary>
-<br>
-<img src="assets/ralph.png" alt="Ralph Autonomous Loop" width="600"/>
-</details>
-
-📖 **[Ralph deep dive](plugins/flow-next/docs/ralph.md)**
-
-🖥️ **[Ralph TUI](flow-next-tui/)** — Terminal UI for monitoring runs in real-time (`bun add -g @gmickel/flow-next-tui`)
-
-### Why Flow-Next Ralph vs Anthropic's ralph-wiggum?
-
-Anthropic's official ralph-wiggum plugin uses a Stop hook to keep Claude in the same session. Flow-Next inverts this architecture for production-grade reliability.
-
-| Aspect | ralph-wiggum | Flow-Next Ralph |
-|--------|--------------|-----------------|
-| **Session model** | Single session, accumulating context | Fresh context per iteration |
-| **Loop mechanism** | Stop hook re-feeds prompt in SAME session | External bash loop, new `claude -p` each iteration |
-| **Context management** | Transcript grows, context fills up | Clean slate every time |
-| **Failed attempts** | Pollute future iterations | Gone with the session |
-| **Re-anchoring** | None | Re-reads epic/task spec EVERY iteration |
-| **Quality gates** | None (test-based only) | Multi-model reviews block until SHIP |
-| **Stuck detection** | `--max-iterations` safety limit | Auto-blocks task after N failures |
-| **State storage** | In-memory transcript | File I/O (`.flow/`, receipts, evidence) |
-| **Auditability** | Session transcript | Per-iteration logs + receipts + evidence |
-
-**The Core Problem with ralph-wiggum**
-
-1. **Context pollution** - Every failed attempt stays in context, potentially misleading future iterations
-2. **No re-anchoring** - As context fills, Claude loses sight of the original task spec
-3. **Single model** - No external validation; Claude grades its own homework
-4. **Binary outcome** - Either completion promise triggers, or you hit max iterations
-
-**Flow-Next's Solution**
-
-Fresh context every iteration + multi-model review gates + receipt-based proof-of-work.
-
-Two models catch what one misses. Process failures, not model failures.
-
-### Features
-
-| | |
-|:--|:--|
-| **Re-anchoring** | Before EVERY task, re-reads epic/task specs + git state. No drift. |
-| **Multi-user safe** | Scan-based IDs. Soft claims via assignee. Actor auto-detect. |
-| **Zero deps** | Bundled `flowctl.py`. No external CLI. Just Python 3. |
-| **Non-invasive** | No daemons or CLAUDE.md edits. Delete `.flow/` (and `scripts/ralph/` if enabled) to uninstall. |
-| **CI-ready** | `flowctl validate --all` exits 1 on errors. Drop into pre-commit or GitHub Actions. |
-| **One file per task** | Merge-friendly. Conflict surface is minimal. |
-| **Automated reviews** | Require [RepoPrompt](https://repoprompt.com/?atp=KJbuL4) (rp-cli). Without it, reviews are skipped. |
-| **Dependency graphs** | Tasks declare blockers. Nothing starts until dependencies resolve. |
-| **Auto-block stuck tasks** | After MAX_ATTEMPTS_PER_TASK failures (default 5), task is blocked with failure context. Prevents infinite retry loops. |
+| Problem | Solution |
+|---------|----------|
+| Context drift | **Re-anchoring** before EVERY task — re-reads specs + git state from `.flow/` |
+| 200K token limits | **Fresh context per task** — worker subagent starts clean each task |
+| Single-model blind spots | **Cross-model reviews** — RepoPrompt or Codex as second opinion |
+| Forgotten requirements | **Dependency graphs** — tasks declare blockers, nothing runs out of order |
+| "It worked on my machine" | **Evidence recording** — commits, test output, PRs tracked per task |
+| Infinite retry loops | **Auto-block stuck tasks** — fails after N attempts, moves on |
+| Team conflicts | **Multi-user safe** — scan-based IDs, soft claims, no coordination server |
 
 ### Commands
 
 | Command | What It Does |
 |---------|--------------|
-| `/flow-next:plan` | Research, create epic + tasks in `.flow/` |
-| `/flow-next:work` | Execute epic end-to-end, task by task |
-| `/flow-next:interview` | Deep interview to flesh out a spec |
-| `/flow-next:plan-review` | Carmack-level plan review via rp-cli |
-| `/flow-next:impl-review` | Carmack-level impl review (current branch) |
-| `/flow-next:ralph-init` | Scaffold autonomous loop in `scripts/ralph/` |
-| `/flow-next:setup` | Install flowctl locally + add project docs |
-| `/flow-next:uninstall` | Remove flow-next from project |
+| `/flow-next:plan` | Research codebase, create epic + tasks |
+| `/flow-next:work` | Execute tasks with re-anchoring |
+| `/flow-next:interview` | Deep spec refinement (40+ questions) |
+| `/flow-next:plan-review` | Cross-model plan review |
+| `/flow-next:impl-review` | Cross-model implementation review |
+| `/flow-next:ralph-init` | Scaffold autonomous loop |
 
-### Autonomous Flags
+📖 **[Full documentation](plugins/flow-next/README.md)** — CLI reference, workflow details, troubleshooting
 
-All commands accept flags to bypass interactive questions:
+🤔 **Confused when to use Interview vs Plan vs Work?** See [When to Use What](plugins/flow-next/README.md#when-to-use-what)
+
+---
+
+## Ralph (Autonomous Mode)
+
+Run overnight, walk away. Fresh context per iteration + multi-model review gates.
 
 ```bash
-# Interactive (asks questions)
-/flow-next:plan Add caching
-/flow-next:work fn-1
-
-# Autonomous (flags)
-/flow-next:plan Add caching --research=grep --no-review
-/flow-next:work fn-1 --branch=current --no-review
-
-# Autonomous (natural language)
-/flow-next:plan Add caching, use context-scout, skip review
-/flow-next:work fn-1 current branch, no review
+/flow-next:ralph-init           # One-time setup
+scripts/ralph/ralph.sh          # Run from terminal
 ```
 
-📖 **[Full documentation](plugins/flow-next/README.md)**
+**How Ralph differs:**
+
+| Aspect | Typical Agents | Ralph |
+|--------|---------------|-------|
+| Context | Accumulates (drift) | Fresh each iteration |
+| Review | Self-review only | Cross-model gates |
+| Stuck tasks | Infinite retry | Auto-block after N failures |
+| Validation | Tests only | Tests + receipts + reviews |
+
+📖 **[Ralph deep dive](plugins/flow-next/docs/ralph.md)** — guard hooks, receipt gating, sentinel controls
+
+🖥️ **[Ralph TUI](flow-next-tui/)** — Terminal UI for monitoring (`bun add -g @gmickel/flow-next-tui`)
 
 ---
 
@@ -336,65 +114,30 @@ All commands accept flags to bypass interactive questions:
 # Add marketplace
 /plugin marketplace add https://github.com/gmickel/gmickel-claude-marketplace
 
-# Install plugin
-/plugin install flow-next    # Recommended: zero deps, simpler
-# or: /plugin install flow   # If you use Beads or want plan files
+# Install flow-next
+/plugin install flow-next
 
-# Setup (recommended for flow-next)
-/flow-next:setup             # Adds CLI access + project docs
+# Optional: CLI access + project docs
+/flow-next:setup
 ```
 
 ---
 
-## Flow (Legacy)
+## Other Plugins
 
-> **⚠️ Legacy plugin.** New users should install [flow-next](#flow-next) instead.
-
-**Plan first, work second.** The original, with optional Beads integration. Kept for existing users.
-
-```bash
-/plugin install flow
-
-/flow:plan Add OAuth login for users
-/flow:work plans/add-oauth-login.md
-```
-
-### How It Works
-
-| Failure Mode | How Flow Fixes It |
-|--------------|-------------------|
-| Weak research | Parallel agents gather context *before* coding starts |
-| Ignoring existing code | Explicit pattern reuse from your repo |
-| Drifting from plan | Plan re-read between every task |
-| Shallow self-review | Cross-model review via RepoPrompt |
-
-### Commands
-
-| Command | What It Does |
-|---------|--------------|
-| `/flow:plan` | Research + produce `plans/<slug>.md` |
-| `/flow:work` | Execute plan end-to-end with task tracking |
-| `/flow:interview` | Deep interview to flesh out spec/bead |
-| `/flow:plan-review` | Carmack-level plan review via rp-cli |
-| `/flow:impl-review` | Carmack-level impl review (current branch) |
-
-### Integrations
-
-- **[RepoPrompt](https://repoprompt.com/?atp=KJbuL4)** for token-efficient codebase exploration + cross-model reviews
-- **[Beads](https://github.com/steveyegge/beads)** for dependency-aware issue tracking (auto-detected)
-
-📖 **[Full documentation](plugins/flow/README.md)** · **[Changelog](CHANGELOG.md)**
+| Plugin | Status |
+|--------|--------|
+| **flow-next** | Active development. Recommended. |
+| **flow** | Legacy. [Documentation](plugins/flow/README.md) |
 
 ---
 
 ## Ecosystem
 
-Community ports and inspired projects:
-
-| Project | Platform | Based On |
-|---------|----------|----------|
-| [flow-next-opencode](https://github.com/gmickel/flow-next-opencode) | OpenCode | Flow-Next |
-| [FlowFactory](https://github.com/Gitmaxd/flowfactory) | Factory.ai Droid | Flow |
+| Project | Platform |
+|---------|----------|
+| [flow-next-opencode](https://github.com/gmickel/flow-next-opencode) | OpenCode |
+| [FlowFactory](https://github.com/Gitmaxd/flowfactory) | Factory.ai Droid |
 
 ---
 

--- a/plugins/flow-next/README.md
+++ b/plugins/flow-next/README.md
@@ -23,6 +23,22 @@
 
 ---
 
+## Table of Contents
+
+- [What Is This?](#what-is-this)
+- [Why It Works](#why-it-works)
+- [Quick Start](#quick-start) — Install, setup, use
+- [When to Use What](#when-to-use-what) — Interview vs Plan vs Work
+- [Troubleshooting](#troubleshooting)
+- [Ralph (Autonomous Mode)](#ralph-autonomous-mode) — Run overnight
+- [Features](#features) — Re-anchoring, multi-user, reviews, dependencies
+- [Commands](#commands) — All slash commands + flags
+- [The Workflow](#the-workflow) — Planning and work phases
+- [.flow/ Directory](#flow-directory) — File structure
+- [flowctl CLI](#flowctl-cli) — Direct CLI usage
+
+---
+
 ## What Is This?
 
 Flow-Next is a Claude Code plugin for plan-first orchestration. Bundled task tracking, dependency graphs, re-anchoring, and cross-model reviews.
@@ -157,18 +173,68 @@ flowctl ready --epic fn-1    # What's ready to work on
 
 That's it. Flow-Next handles research, task ordering, reviews, and audit trails.
 
-### Recommended Workflow
+### When to Use What
 
-**Spec -> Interview -> Plan -> Work**
+Flow-next is flexible. There's no single "correct" order — the right sequence depends on how well-defined your spec already is.
 
-1. **Write a short spec** - 1-5 sentences describing what you want to build
-2. **Interview** (optional) - `/flow-next:interview "your idea"` - 40+ questions to surface edge cases
-3. **Plan** - `/flow-next:plan "your idea"` - creates epic with dependency-ordered tasks
-4. **Work** - `/flow-next:work fn-1` - executes tasks with re-anchoring and reviews
+**The key question: How fleshed out is your idea?**
 
-Start simple. Add interview when specs are fuzzy. Add reviews when quality matters.
+#### Vague idea or rough concept
 
-### 4. Autonomous Mode (Optional)
+```
+Interview → Plan → Work
+```
+
+1. **Interview first** — `/flow-next:interview "your rough idea"` asks 40+ deep questions to surface requirements, edge cases, and decisions you haven't thought about
+2. **Plan** — `/flow-next:plan fn-1` takes the refined spec and researches best practices, current docs, repo patterns, then splits into properly-sized tasks
+3. **Work** — `/flow-next:work fn-1` executes with re-anchoring and reviews
+
+#### Well-written spec or PRD
+
+```
+Plan → Interview → Work
+```
+
+1. **Plan first** — `/flow-next:plan specs/my-feature.md` researches best practices and current patterns, then breaks your spec into epic + tasks
+2. **Interview after** — `/flow-next:interview fn-1` runs deep questions against the plan to catch edge cases, missing requirements, or assumptions
+3. **Work** — `/flow-next:work fn-1` executes
+
+#### Minimal planning
+
+```
+Plan → Work
+```
+
+Skip interview entirely for well-understood changes. Plan still researches best practices and splits into tasks.
+
+#### Quick single-task (spec already complete)
+
+```
+Work directly
+```
+
+```bash
+/flow-next:work specs/small-fix.md
+```
+
+For small, self-contained changes where you already have a complete spec. Creates an epic with **one task** and executes immediately. You get flow tracking, re-anchoring, and optional review — without full planning overhead.
+
+Best for: bug fixes, small features, well-scoped changes that don't need task splitting.
+
+**Note:** This does NOT split into multiple tasks. For detailed specs that need breakdown, use Plan first.
+
+**Summary:**
+
+| Starting point | Recommended sequence |
+|----------------|---------------------|
+| Vague idea, rough notes | Interview → Plan → Work |
+| Detailed spec/PRD | Plan → Interview → Work |
+| Well-understood, needs task splitting | Plan → Work |
+| Small single-task, spec complete | Work directly (creates 1 epic + 1 task) |
+
+You can always run interview again after planning to catch anything missed. Interview writes back to the spec, so iterations refine rather than replace.
+
+### Autonomous Mode (Optional)
 
 Want to run overnight? See [Ralph Mode](#ralph-autonomous-mode).
 

--- a/plugins/flow-next/docs/ralph.md
+++ b/plugins/flow-next/docs/ralph.md
@@ -2,6 +2,21 @@
 
 Ralph is Flow-Next's repo-local autonomous harness. It loops over tasks, applies multi-model review gates, and produces production-quality code overnight.
 
+## Table of Contents
+
+- [Quick Start](#quick-start) — Setup, configure, run
+- [How It Works](#how-it-works) — Loop architecture
+- [Why Ralph vs ralph-wiggum](#why-flow-next-ralph-vs-anthropics-ralph-wiggum)
+- [Quality Gates](#quality-gates) — Reviews, receipts, memory
+- [Configuration](#configuration) — All config.env options
+- [Run Artifacts](#run-artifacts) — Logs, receipts, blocks
+- [RepoPrompt Integration](#repoprompt-integration)
+- [Codex Integration](#codex-integration)
+- [Troubleshooting](#troubleshooting)
+- [Testing Ralph](#testing-ralph) — Single iteration, sandbox, watch mode
+- [Guard Hooks](#guard-hooks) — Workflow enforcement
+- [Morning Review Workflow](#morning-review-workflow) — What to check after overnight runs
+
 ---
 
 ## Quick Start


### PR DESCRIPTION
## Summary

- Slim root README from 427 → 167 lines (landing page only)
- Add "When to Use What" section to flow-next README
- Add TOCs to flow-next README and ralph.md
- Link from root to "When to Use What" for confused users

## Changes

**Root README:**
- Removed duplicated content (mermaid, features, ralph comparison)
- Kept engaging callouts, problem statement, quick start
- Links to full docs

**flow-next README:**
- New "When to Use What" section with 4 paths:
  - Vague idea → Interview → Plan → Work
  - Detailed spec → Plan → Interview → Work
  - Minimal → Plan → Work
  - Single-task → Work directly (creates 1 epic + 1 task)
- Added TOC

**ralph.md:**
- Added TOC

No version bump (docs only).