### PR TITLE
feat(flow-next): RP 1.6.0 builder review mode for impl-review

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Plan-first workflows for Claude Code. Two plugins: flow (Beads integration) and flow-next (zero-dep, Ralph autonomous mode).",
-    "version": "0.13.0"
+    "version": "0.14.0"
   },
   "plugins": [
     {
@@ -31,7 +31,7 @@
     {
       "name": "flow-next",
       "description": "Zero-dependency planning + execution with .flow/ task tracking and Ralph autonomous mode (multi-model review gates). Worker subagent per task for context isolation. Includes 10 subagents, 9 commands, 14 skills.",
-      "version": "0.13.0",
+      "version": "0.14.0",
       "author": {
         "name": "Gordon Mickel",
         "email": "gordon@mickel.tech",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,41 @@
 
 All notable changes to the gmickel-claude-marketplace.
 
+## [flow-next 0.14.0] - 2026-01-21
+
+### ⚠️ Breaking Change: RepoPrompt 1.6.0+ Required
+
+The RepoPrompt (rp) backend for `/flow-next:impl-review` now uses the new **builder review mode** introduced in RepoPrompt 1.6.0. This provides better context discovery and more focused reviews.
+
+**Before upgrading**: Check your RepoPrompt version with `rp-cli --version`. If you're on an older version, update RepoPrompt first or use `--review=codex` as an alternative.
+
+### Changed
+
+- **RP impl-review uses builder review mode** — Instead of manually building review prompts and selecting files, the builder's discovery agent now:
+  - Automatically includes git diffs for the commits being reviewed
+  - Selects relevant context files with full codebase awareness
+  - Produces structured review findings before verdict
+  - Lower token usage (~26K vs ~71K) with better coverage
+
+- **New flowctl rp commands**:
+  - `--response-type review` on `rp builder` and `rp setup-review`
+  - `--chat-id` on `rp chat-send` for conversation continuity
+  - `--mode` on `rp chat-send` (chat/review/plan/edit)
+
+- **Simplified RP workflow** — Removed manual file selection (Phase 2) and elaborate prompt building (Phase 3). Builder handles context discovery; follow-up chat requests verdict.
+
+- **Fix loop uses `--chat-id`** — Re-reviews now use explicit chat ID for session continuity instead of relying on tab state.
+
+### Added
+
+- RP 1.6.0 requirement notice in SKILL.md and workflow.md
+
+### Unchanged
+
+- Codex backend — No changes, works as before
+- Plan-review — No changes, only impl-review affected
+- Receipt format — Compatible with Ralph
+
 ## [flow-next 0.13.0] - 2026-01-19
 
 ### ⚠️ Significant Planning Workflow Changes

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Claude Code](https://img.shields.io/badge/Claude_Code-Plugin_Marketplace-blueviolet)](https://claude.ai/code)
 
-[![Flow-next](https://img.shields.io/badge/Flow--next-v0.13.0-green)](plugins/flow-next/)
+[![Flow-next](https://img.shields.io/badge/Flow--next-v0.14.0-green)](plugins/flow-next/)
 [![Flow-next Docs](https://img.shields.io/badge/Docs-📖-informational)](plugins/flow-next/README.md)
 
 [![Author](https://img.shields.io/badge/Author-Gordon_Mickel-orange)](https://mickel.tech)

--- a/plugins/flow-next/.claude-plugin/plugin.json
+++ b/plugins/flow-next/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "flow-next",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Zero-dependency planning + execution with .flow/ task tracking and Ralph autonomous mode (multi-model review gates). Worker subagent per task for context isolation. Includes 10 subagents, 9 commands, 14 skills.",
   "author": {
     "name": "Gordon Mickel",

--- a/plugins/flow-next/README.md
+++ b/plugins/flow-next/README.md
@@ -5,7 +5,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](../../LICENSE)
 [![Claude Code](https://img.shields.io/badge/Claude_Code-Plugin-blueviolet)](https://claude.ai/code)
 
-[![Version](https://img.shields.io/badge/Version-0.13.0-green)](../../CHANGELOG.md)
+[![Version](https://img.shields.io/badge/Version-0.14.0-green)](../../CHANGELOG.md)
 
 [![Status](https://img.shields.io/badge/Status-Active_Development-brightgreen)](../../CHANGELOG.md)
 [![Discord](https://img.shields.io/badge/Discord-Join-5865F2?logo=discord&logoColor=white)](https://discord.gg/ST5Y39hQ)
@@ -21,6 +21,16 @@
 🌐 **Prefer a visual overview?** See the [Flow-Next app page](https://mickel.tech/apps/flow-next) for diagrams and examples.
 
 > **New: Codex Review Backend.** Cross-model reviews now work on Linux/Windows via OpenAI Codex CLI. Same Carmack-level criteria as RepoPrompt. See [Cross-Model Reviews](#cross-model-reviews) for setup.
+
+---
+
+> ### ⚠️ RepoPrompt 1.6.0+ Required (v0.14.0)
+>
+> If you use the **RepoPrompt (rp) backend** for `/flow-next:impl-review`, you must upgrade to **RepoPrompt 1.6.0 or later**.
+>
+> Check your version: `rp-cli --version`
+>
+> The new builder review mode provides better context discovery and more focused reviews. If you can't upgrade yet, use `--review=codex` or `--review=none` as alternatives.
 
 ---
 

--- a/plugins/flow-next/scripts/flowctl.py
+++ b/plugins/flow-next/scripts/flowctl.py
@@ -274,6 +274,7 @@ def build_chat_payload(
     mode: str,
     new_chat: bool = False,
     chat_name: Optional[str] = None,
+    chat_id: Optional[str] = None,
     selected_paths: Optional[list[str]] = None,
 ) -> str:
     payload: dict[str, Any] = {
@@ -284,6 +285,8 @@ def build_chat_payload(
         payload["new_chat"] = True
     if chat_name:
         payload["chat_name"] = chat_name
+    if chat_id:
+        payload["chat_id"] = chat_id
     if selected_paths:
         payload["selected_paths"] = selected_paths
     return json.dumps(payload, ensure_ascii=False, separators=(",", ":"))
@@ -3906,19 +3909,60 @@ def cmd_rp_ensure_workspace(args: argparse.Namespace) -> None:
 def cmd_rp_builder(args: argparse.Namespace) -> None:
     window = args.window
     summary = args.summary
+    response_type = getattr(args, "response_type", None)
+
+    # Build builder command with optional response-type
+    builder_expr = f"builder {json.dumps(summary)}"
+    if response_type:
+        builder_expr += f" --response-type {response_type}"
+
     cmd = [
         "-w",
         str(window),
+        "--raw-json" if response_type else "",
         "-e",
-        f"builder {json.dumps(summary)}",
+        builder_expr,
     ]
+    cmd = [c for c in cmd if c]  # Remove empty strings
     res = run_rp_cli(cmd)
     output = (res.stdout or "") + ("\n" + res.stderr if res.stderr else "")
-    tab = parse_builder_tab(output)
-    if args.json:
-        print(json.dumps({"window": window, "tab": tab}))
+
+    # For review response-type, parse the full JSON response
+    if response_type == "review":
+        try:
+            data = json.loads(res.stdout or "{}")
+            tab = data.get("tab_id", "")
+            chat_id = data.get("review", {}).get("chat_id", "")
+            review_response = data.get("review", {}).get("response", "")
+            if args.json:
+                print(
+                    json.dumps(
+                        {
+                            "window": window,
+                            "tab": tab,
+                            "chat_id": chat_id,
+                            "review": review_response,
+                            "file_count": data.get("file_count", 0),
+                            "total_tokens": data.get("total_tokens", 0),
+                        }
+                    )
+                )
+            else:
+                print(f"T={tab} CHAT_ID={chat_id}")
+                if review_response:
+                    print(review_response)
+        except json.JSONDecodeError:
+            tab = parse_builder_tab(output)
+            if args.json:
+                print(json.dumps({"window": window, "tab": tab, "error": "parse_failed"}))
+            else:
+                print(tab)
     else:
-        print(tab)
+        tab = parse_builder_tab(output)
+        if args.json:
+            print(json.dumps({"window": window, "tab": tab}))
+        else:
+            print(tab)
 
 
 def cmd_rp_prompt_get(args: argparse.Namespace) -> None:
@@ -3959,11 +4003,14 @@ def cmd_rp_select_add(args: argparse.Namespace) -> None:
 
 def cmd_rp_chat_send(args: argparse.Namespace) -> None:
     message = read_text_or_exit(Path(args.message_file), "Message file", use_json=False)
+    chat_id_arg = getattr(args, "chat_id", None)
+    mode = getattr(args, "mode", "chat") or "chat"
     payload = build_chat_payload(
         message=message,
-        mode="chat",
+        mode=mode,
         new_chat=args.new_chat,
         chat_name=args.chat_name,
+        chat_id=chat_id_arg,
         selected_paths=args.selected_paths,
     )
     cmd = [
@@ -4000,15 +4047,19 @@ def cmd_rp_setup_review(args: argparse.Namespace) -> None:
     """Atomic setup: pick-window + builder.
 
     Returns W=<window> T=<tab> on success, exits non-zero on failure.
+    With --response-type review, also returns CHAT_ID and review findings.
     Writes state file for ralph-guard to verify pick-window ran.
 
     Note: ensure-workspace removed - if user opens RP on a folder, workspace
     already exists. pick-window matches by folder path.
+
+    Requires RepoPrompt 1.6.0+ for --response-type review.
     """
     import hashlib
 
     repo_root = os.path.realpath(args.repo_root)
     summary = args.summary
+    response_type = getattr(args, "response_type", None)
 
     # Step 1: pick-window
     roots = normalize_repo_root(repo_root)
@@ -4059,27 +4110,64 @@ def cmd_rp_setup_review(args: argparse.Namespace) -> None:
     state_file = Path(f"/tmp/.ralph-pick-window-{repo_hash}")
     state_file.write_text(f"{win_id}\n{repo_root}\n")
 
-    # Step 2: builder
+    # Step 2: builder (with optional response-type for RP 1.6.0+)
+    builder_expr = f"builder {json.dumps(summary)}"
+    if response_type:
+        builder_expr += f" --response-type {response_type}"
+
     builder_cmd = [
         "-w",
         str(win_id),
+        "--raw-json" if response_type else "",
         "-e",
-        f"builder {json.dumps(summary)}",
+        builder_expr,
     ]
+    builder_cmd = [c for c in builder_cmd if c]  # Remove empty strings
     builder_res = run_rp_cli(builder_cmd)
     output = (builder_res.stdout or "") + (
         "\n" + builder_res.stderr if builder_res.stderr else ""
     )
-    tab = parse_builder_tab(output)
 
-    if not tab:
-        error_exit("Builder did not return a tab id", use_json=False, code=2)
+    # Parse response based on response-type
+    if response_type == "review":
+        try:
+            data = json.loads(builder_res.stdout or "{}")
+            tab = data.get("tab_id", "")
+            chat_id = data.get("review", {}).get("chat_id", "")
+            review_response = data.get("review", {}).get("response", "")
 
-    # Output
-    if args.json:
-        print(json.dumps({"window": win_id, "tab": tab, "repo_root": repo_root}))
+            if not tab:
+                error_exit("Builder did not return a tab id", use_json=False, code=2)
+
+            if args.json:
+                print(
+                    json.dumps(
+                        {
+                            "window": win_id,
+                            "tab": tab,
+                            "chat_id": chat_id,
+                            "review": review_response,
+                            "repo_root": repo_root,
+                            "file_count": data.get("file_count", 0),
+                            "total_tokens": data.get("total_tokens", 0),
+                        }
+                    )
+                )
+            else:
+                print(f"W={win_id} T={tab} CHAT_ID={chat_id}")
+                if review_response:
+                    print(review_response)
+        except json.JSONDecodeError:
+            error_exit("Failed to parse builder review response", use_json=False, code=2)
     else:
-        print(f"W={win_id} T={tab}")
+        tab = parse_builder_tab(output)
+        if not tab:
+            error_exit("Builder did not return a tab id", use_json=False, code=2)
+
+        if args.json:
+            print(json.dumps({"window": win_id, "tab": tab, "repo_root": repo_root}))
+        else:
+            print(f"W={win_id} T={tab}")
 
 
 # --- Codex Commands ---
@@ -5080,6 +5168,12 @@ def main() -> None:
     p_rp_builder = rp_sub.add_parser("builder", help="Run builder and return tab")
     p_rp_builder.add_argument("--window", type=int, required=True, help="Window id")
     p_rp_builder.add_argument("--summary", required=True, help="Builder summary")
+    p_rp_builder.add_argument(
+        "--response-type",
+        dest="response_type",
+        choices=["review", "plan", "question"],
+        help="Builder response type (requires RP 1.6.0+)",
+    )
     p_rp_builder.add_argument("--json", action="store_true", help="JSON output")
     p_rp_builder.set_defaults(func=cmd_rp_builder)
 
@@ -5112,6 +5206,17 @@ def main() -> None:
     p_rp_chat.add_argument("--new-chat", action="store_true", help="Start new chat")
     p_rp_chat.add_argument("--chat-name", help="Chat name (with --new-chat)")
     p_rp_chat.add_argument(
+        "--chat-id",
+        dest="chat_id",
+        help="Continue specific chat by ID (RP 1.6.0+)",
+    )
+    p_rp_chat.add_argument(
+        "--mode",
+        choices=["chat", "review", "plan", "edit"],
+        default="chat",
+        help="Chat mode (default: chat)",
+    )
+    p_rp_chat.add_argument(
         "--selected-paths", nargs="*", help="Override selected paths"
     )
     p_rp_chat.add_argument(
@@ -5129,7 +5234,13 @@ def main() -> None:
         "setup-review", help="Atomic: pick-window + workspace + builder"
     )
     p_rp_setup.add_argument("--repo-root", required=True, help="Repo root path")
-    p_rp_setup.add_argument("--summary", required=True, help="Builder summary")
+    p_rp_setup.add_argument("--summary", required=True, help="Builder summary/instructions")
+    p_rp_setup.add_argument(
+        "--response-type",
+        dest="response_type",
+        choices=["review"],
+        help="Use builder review mode (requires RP 1.6.0+)",
+    )
     p_rp_setup.add_argument(
         "--create",
         action="store_true",

--- a/plugins/flow-next/skills/flow-next-impl-review/SKILL.md
+++ b/plugins/flow-next/skills/flow-next-impl-review/SKILL.md
@@ -12,6 +12,8 @@ Conduct a John Carmack-level review of implementation changes on the current bra
 **Role**: Code Review Coordinator (NOT the reviewer)
 **Backends**: RepoPrompt (rp) or Codex CLI (codex)
 
+**⚠️ RepoPrompt 1.6.0+ Required**: The RP backend now uses builder review mode which requires RepoPrompt 1.6.0 or later. Check version: `rp-cli --version`
+
 **CRITICAL: flowctl is BUNDLED — NOT installed globally.** `which flowctl` will fail (expected). Always use:
 ```bash
 FLOWCTL="${CLAUDE_PLUGIN_ROOT}/scripts/flowctl"


### PR DESCRIPTION
## Summary

Upgrades the RepoPrompt backend for `/flow-next:impl-review` to use the new **builder review mode** introduced in RepoPrompt 1.6.0.

### ⚠️ Breaking Change

**Requires RepoPrompt 1.6.0+** for the `rp` backend. Users on older versions should:
- Upgrade RepoPrompt, or
- Use `--review=codex` or `--review=none` as alternatives

### What Changed

- **Builder review mode** — Instead of manually building review prompts and selecting files, the builder's discovery agent now:
  - Automatically includes git diffs for commits being reviewed
  - Selects relevant context files with full codebase awareness
  - Produces structured review findings before verdict
  - Lower token usage (~26K vs ~71K) with better coverage

- **New flowctl rp commands**:
  - `--response-type review` on `rp builder` and `rp setup-review`
  - `--chat-id` on `rp chat-send` for conversation continuity
  - `--mode` on `rp chat-send` (chat/review/plan/edit)

- **Simplified RP workflow** — Removed manual file selection and elaborate prompt building. Builder handles context discovery; follow-up chat requests verdict.

### Unchanged

- Codex backend — No changes
- Plan-review — No changes  
- Receipt format — Ralph compatible

## Testing

- [x] Smoke tests (43/43 passed)
- [x] Manual RP 1.6.0 builder review mode test
- [x] Side-by-side comparison (new vs old approach)
- [x] Full Ralph e2e test with RP review backend
  - Task implemented correctly
  - SHIP verdict received
  - Receipt written with correct schema
  - Task marked done

## Test Plan

1. Verify CI passes
2. Test `/flow-next:impl-review` with RP 1.6.0 on a real repo
3. Verify Ralph mode works with `WORK_REVIEW=rp`