### PR TITLE
feat(flow-next): epic-aware planning, docs-gap detection, cross-epic plan-sync

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Plan-first workflows for Claude Code. Two plugins: flow (Beads integration) and flow-next (zero-dep, Ralph autonomous mode).",
-    "version": "0.15.0"
+    "version": "0.16.0"
   },
   "plugins": [
     {
@@ -30,8 +30,8 @@
     },
     {
       "name": "flow-next",
-      "description": "Zero-dependency planning + execution with .flow/ task tracking and Ralph autonomous mode (multi-model review gates). Worker subagent per task for context isolation. Includes 10 subagents, 9 commands, 14 skills.",
-      "version": "0.15.0",
+      "description": "Zero-dependency planning + execution with .flow/ task tracking and Ralph autonomous mode (multi-model review gates). Worker subagent per task for context isolation. Includes 12 subagents, 9 commands, 14 skills.",
+      "version": "0.16.0",
       "author": {
         "name": "Gordon Mickel",
         "email": "gordon@mickel.tech",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to the gmickel-claude-marketplace.
 
+## [flow-next 0.16.0] - 2026-01-21
+
+### Added
+
+- **Epic-aware planning** — New `epic-scout` subagent runs during `/flow-next:plan` research phase (parallel with other scouts). Scans open epics for dependency relationships and auto-sets `depends_on_epics` when found. No user prompts needed — findings reported at end of planning.
+- **Docs-gap detection** — New `docs-gap-scout` subagent identifies documentation that may need updates (README, API docs, ADRs, CHANGELOG, etc.). Adds acceptance criteria to relevant tasks — implementer decides actual content.
+- **Cross-epic plan-sync** — Optional mode for plan-sync agent. When `planSync.crossEpic: true`, also checks other open epics for stale references after task completion. **Default: false** (avoids long Ralph loops).
+- **New config option** — `planSync.crossEpic` (boolean, default false). Enable via `/flow-next:setup` or `flowctl config set planSync.crossEpic true`.
+
+### Changed
+
+- Plan-sync agent now accepts `CROSS_EPIC` input and has new Phase 4b for cross-epic checking
+- Setup workflow shows new cross-epic config option (only asked if plan-sync is enabled)
+- `memory-scout` model changed from opus to haiku (task is mechanical grep/read, doesn't need reasoning)
+
+### Notes
+
+- **Re-run `/flow-next:setup`** to get the new config option and update local flowctl
+- Cross-epic sync is conservative — only flags clear API/pattern references, not general topic overlap
+
 ## [flow-next 0.15.0] - 2026-01-21
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Claude Code](https://img.shields.io/badge/Claude_Code-Plugin_Marketplace-blueviolet)](https://claude.ai/code)
 
-[![Flow-next](https://img.shields.io/badge/Flow--next-v0.15.0-green)](plugins/flow-next/)
+[![Flow-next](https://img.shields.io/badge/Flow--next-v0.16.0-green)](plugins/flow-next/)
 [![Flow-next Docs](https://img.shields.io/badge/Docs-📖-informational)](plugins/flow-next/README.md)
 
 [![Author](https://img.shields.io/badge/Author-Gordon_Mickel-orange)](https://mickel.tech)

--- a/plugins/flow-next/.claude-plugin/plugin.json
+++ b/plugins/flow-next/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "flow-next",
-  "version": "0.15.0",
-  "description": "Zero-dependency planning + execution with .flow/ task tracking and Ralph autonomous mode (multi-model review gates). Worker subagent per task for context isolation. Includes 10 subagents, 9 commands, 14 skills.",
+  "version": "0.16.0",
+  "description": "Zero-dependency planning + execution with .flow/ task tracking and Ralph autonomous mode (multi-model review gates). Worker subagent per task for context isolation. Includes 12 subagents, 9 commands, 14 skills.",
   "author": {
     "name": "Gordon Mickel",
     "email": "gordon@mickel.tech",

--- a/plugins/flow-next/README.md
+++ b/plugins/flow-next/README.md
@@ -5,7 +5,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](../../LICENSE)
 [![Claude Code](https://img.shields.io/badge/Claude_Code-Plugin-blueviolet)](https://claude.ai/code)
 
-[![Version](https://img.shields.io/badge/Version-0.15.0-green)](../../CHANGELOG.md)
+[![Version](https://img.shields.io/badge/Version-0.16.0-green)](../../CHANGELOG.md)
 
 [![Status](https://img.shields.io/badge/Status-Active_Development-brightgreen)](../../CHANGELOG.md)
 [![Discord](https://img.shields.io/badge/Discord-Join-5865F2?logo=discord&logoColor=white)](https://discord.gg/ST5Y39hQ)
@@ -639,6 +639,8 @@ Without a backend configured, reviews fail with a clear error. Run `/flow-next:s
 
 Tasks declare their blockers. `flowctl ready` shows what can start. Nothing executes until dependencies resolve.
 
+**Epic-level dependencies**: During planning, `epic-scout` runs in parallel with other research scouts to find relationships with existing open epics. If the new plan depends on APIs/patterns from another epic, dependencies are auto-set via `flowctl epic add-dep`. Findings reported at end of planning—no prompts needed.
+
 ### Auto-Block Stuck Tasks
 
 After MAX_ATTEMPTS_PER_TASK failures (default 5), Ralph:
@@ -663,6 +665,13 @@ When enabled, after each task completes, a plan-sync agent:
 3. Updates affected task specs with accurate info
 
 Skip conditions: disabled (default), task failed, no downstream tasks.
+
+**Cross-epic sync (opt-in, default false):**
+```bash
+flowctl config set planSync.crossEpic true
+```
+
+When enabled, plan-sync also checks other open epics for stale references. Useful when multiple epics share APIs/patterns, but increases sync time. Disabled by default to avoid long Ralph loops.
 
 **Manual trigger:**
 ```bash
@@ -771,10 +780,10 @@ Override via flags or `scripts/ralph/config.env`.
 
 ### Planning Phase
 
-1. **Research (parallel subagents)**: `repo-scout` (or `context-scout` if rp-cli) + `practice-scout` + `docs-scout` + `github-scout` (cross-repo code search)
+1. **Research (parallel subagents)**: `repo-scout` (or `context-scout` if rp-cli) + `practice-scout` + `docs-scout` + `github-scout` + `epic-scout` + `docs-gap-scout`
 2. **Gap analysis**: `flow-gap-analyst` finds edge cases + missing requirements
-3. **Epic creation**: Writes spec to `.flow/specs/fn-N.md`
-4. **Task breakdown**: Creates tasks + explicit dependencies in `.flow/tasks/`
+3. **Epic creation**: Writes spec to `.flow/specs/fn-N.md`, sets epic dependencies from `epic-scout` findings
+4. **Task breakdown**: Creates tasks + explicit dependencies in `.flow/tasks/`, adds doc update acceptance criteria from `docs-gap-scout`
 5. **Validate**: `flowctl validate --epic fn-N`
 6. **Review** (optional): `/flow-next:plan-review fn-N` with re-anchor + fix loop until "Ship"
 

--- a/plugins/flow-next/agents/docs-gap-scout.md
+++ b/plugins/flow-next/agents/docs-gap-scout.md
@@ -1,0 +1,112 @@
+---
+name: docs-gap-scout
+description: Identify documentation that may need updates based on the planned changes.
+tools: Read, Grep, Glob, Bash
+model: haiku
+color: "#06B6D4"
+---
+
+You are a documentation gap scout. Your job is to identify which docs may need updates when a feature is implemented.
+
+## Input
+
+You receive:
+- `REQUEST` - the feature/change being planned
+
+## Process
+
+### 1. Scan for doc locations
+
+Look for common documentation patterns:
+
+```bash
+# User-facing docs
+ls -la README* CHANGELOG* CONTRIBUTING* 2>/dev/null
+ls -la docs/ documentation/ 2>/dev/null
+ls -la website/ site/ pages/ 2>/dev/null
+
+# API docs
+ls -la openapi.* swagger.* api-docs/ 2>/dev/null
+find . -name "*.openapi.yaml" -o -name "*.swagger.json" 2>/dev/null | head -5
+
+# Component docs
+ls -la .storybook/ stories/ 2>/dev/null
+
+# Architecture
+ls -la adr/ adrs/ decisions/ architecture/ 2>/dev/null
+
+# Generated docs
+ls -la typedoc.json jsdoc.json mkdocs.yml 2>/dev/null
+```
+
+### 2. Categorize what exists
+
+Build a map:
+- **User docs**: README, docs site, getting started guides
+- **API docs**: OpenAPI specs, endpoint documentation
+- **Component docs**: Storybook, component library docs
+- **Architecture**: ADRs, design docs
+- **Changelog**: CHANGELOG.md or similar
+
+### 3. Match request to docs
+
+Based on the REQUEST, identify which docs likely need updates:
+
+| Change Type | Likely Doc Updates |
+|-------------|-------------------|
+| New feature | README usage, CHANGELOG |
+| New API endpoint | API docs, README if public |
+| New component | Storybook story, component docs |
+| Config change | README config section |
+| Breaking change | CHANGELOG, migration guide |
+| Architectural decision | ADR |
+| CLI change | README CLI section, --help text |
+
+### 4. Check current doc state
+
+For identified docs, quick scan to understand structure:
+- Does README have a usage section?
+- Does API doc cover related endpoints?
+- Are there existing ADRs to follow as template?
+
+## Output Format
+
+```markdown
+## Documentation Gap Analysis
+
+### Doc Locations Found
+- README.md (has: installation, usage, API sections)
+- docs/ (mkdocs site with guides)
+- CHANGELOG.md (keep-a-changelog format)
+- openapi.yaml (API spec)
+
+### Likely Updates Needed
+- **README.md**: Update usage section for new feature
+- **CHANGELOG.md**: Add entry under "Added"
+- **openapi.yaml**: Add new /auth endpoint spec
+
+### No Updates Expected
+- Storybook (no UI components in this change)
+- ADR (no architectural decisions)
+
+### Templates/Patterns to Follow
+- CHANGELOG uses keep-a-changelog format
+- ADRs follow MADR template in adr/
+```
+
+If no docs found or no updates needed:
+```markdown
+## Documentation Gap Analysis
+
+No documentation updates identified for this change.
+- No user-facing docs found in repo
+- Change is internal/refactor only
+```
+
+## Rules
+
+- Speed over completeness - quick scan, don't read full docs
+- Only flag docs that genuinely relate to the change
+- Don't flag CHANGELOG for every change - only user-visible ones
+- Note doc structure/templates so implementer can follow patterns
+- If uncertain, err on side of flagging (implementer can skip if not needed)

--- a/plugins/flow-next/agents/epic-scout.md
+++ b/plugins/flow-next/agents/epic-scout.md
@@ -1,0 +1,100 @@
+---
+name: epic-scout
+description: Scan existing epics to find dependencies and relationships for a new plan.
+tools: Read, Grep, Glob, Bash
+model: haiku
+color: "#F59E0B"
+---
+
+You are an epic dependency scout. Your job is to find relationships between a new plan and existing epics.
+
+## Input
+
+You receive:
+- `REQUEST` - the feature/change being planned
+- `FLOWCTL` - path to flowctl CLI
+
+## Process
+
+### 1. List open epics
+
+```bash
+<FLOWCTL> epics --json
+```
+
+Filter to `status: "open"` epics only. Skip done epics.
+
+### 2. For each open epic, read its spec
+
+```bash
+<FLOWCTL> cat <epic-id>
+```
+
+Extract:
+- Title and scope
+- Key files/paths mentioned
+- APIs, functions, data structures defined
+- Acceptance criteria
+
+### 3. Find relationships
+
+Compare the new REQUEST against each epic's scope. Look for:
+
+**Dependency signals** (new plan depends on epic):
+- New plan needs APIs/functions the epic is building
+- New plan touches files the epic owns
+- New plan extends data structures the epic creates
+- Explicit mentions ("after X is done", "requires Y")
+
+**Reverse dependency signals** (epic depends on new plan):
+- Epic mentions needing something the new plan provides
+- Epic blocked waiting for infrastructure the new plan adds
+
+**Overlap signals** (potential conflict, not dependency):
+- Both touch same files
+- Both modify same data structures
+- Risk of merge conflicts
+
+### 4. Check task-level overlap
+
+For epics with potential relationships:
+
+```bash
+<FLOWCTL> tasks --epic <epic-id> --json
+```
+
+Look at in_progress and todo tasks for specific overlaps.
+
+## Output Format
+
+```markdown
+## Epic Dependencies
+
+### Dependencies (new plan depends on these)
+- **fn-2** (Auth system): New plan uses `authService` from fn-2.1
+- **fn-5** (DB schema): New plan extends `User` model defined in fn-5.3
+
+### Reverse Dependencies (these may depend on new plan)
+- **fn-7** (Notifications): Waiting for event system this plan adds
+
+### Overlaps (potential conflicts, not dependencies)
+- **fn-3** (Refactor): Both touch `src/api/handlers.ts`
+
+### No Relationship
+- fn-4, fn-6, fn-8: Unrelated scope
+```
+
+If no relationships found:
+```markdown
+## Epic Dependencies
+
+No dependencies or overlaps detected with open epics.
+```
+
+## Rules
+
+- Speed over completeness - check titles/scope first, only read specs if relevant
+- Only report clear relationships, not maybes
+- Skip done epics entirely
+- Use haiku model - keep analysis fast and cheap
+- Return structured output for planner to auto-set deps

--- a/plugins/flow-next/agents/memory-scout.md
+++ b/plugins/flow-next/agents/memory-scout.md
@@ -2,7 +2,7 @@
 name: memory-scout
 description: Search .flow/memory/ for entries relevant to the current task or request.
 tools: Read, Grep, Glob, Bash
-model: opus
+model: haiku
 color: "#A855F7"
 ---
 

--- a/plugins/flow-next/agents/plan-sync.md
+++ b/plugins/flow-next/agents/plan-sync.md
@@ -17,6 +17,7 @@ You synchronize downstream task specs after implementation drift.
 - `FLOWCTL` - path to flowctl CLI
 - `DOWNSTREAM_TASK_IDS` - comma-separated list of remaining tasks
 - `DRY_RUN` - "true" or "false" (optional, defaults to false)
+- `CROSS_EPIC` - "true" or "false" (from config planSync.crossEpic, defaults to false)
 
 ## Phase 1: Re-anchor on Completed Task
 
@@ -81,6 +82,27 @@ Look for references to:
 
 Flag tasks that need updates.
 
+## Phase 4b: Check Other Epics (if CROSS_EPIC is "true")
+
+**Skip this phase if CROSS_EPIC is "false" or not set.**
+
+List all open epics:
+```bash
+<FLOWCTL> epics --json
+```
+
+For each open epic (excluding current EPIC_ID):
+1. Read the epic spec: `<FLOWCTL> cat <other-epic-id>`
+2. Check if it references patterns/APIs from completed task
+3. If references found, read affected task specs in that epic
+
+Look for:
+- References to APIs/functions from completed task spec (now potentially stale)
+- Data structure assumptions that may have changed
+- Integration points mentioned in other epic's scope
+
+**Note:** Cross-epic sync is more conservative - only flag clear references, not general topic overlap.
+
 ## Phase 5: Update Affected Tasks
 
 **If DRY_RUN is "true":**
@@ -112,7 +134,11 @@ Changes should:
 - Change task scope or requirements
 - Remove acceptance criteria
 - Add new features
-- Edit anything outside `.flow/tasks/`
+- Edit anything outside `.flow/tasks/` or `.flow/specs/`
+
+**Cross-epic edits** (if CROSS_EPIC enabled):
+- Update affected task specs in other epics: `.flow/tasks/<other-epic-task-id>.md`
+- Add note linking to source: `<!-- Updated by plan-sync (cross-epic): fn-X.Y changed <thing> -->`
 
 ## Phase 6: Return Summary
 
@@ -136,9 +162,12 @@ Drift detected: yes
 - fn-1.2 used `authService` singleton instead of `UserAuth` class
 - fn-1.2 returns `AuthResult` object instead of boolean
 
-Updated tasks:
+Updated tasks (same epic):
 - fn-1.3: Changed references from `UserAuth.login()` to `authService.authenticate()`
 - fn-1.4: Updated expected return type from `boolean` to `AuthResult`
+
+Updated tasks (cross-epic):  # Only if CROSS_EPIC enabled and found
+- fn-3.2: Updated authService import path
 ```
 
 ## Rules

--- a/plugins/flow-next/scripts/flowctl.py
+++ b/plugins/flow-next/scripts/flowctl.py
@@ -75,7 +75,11 @@ def ensure_flow_exists() -> bool:
 
 def get_default_config() -> dict:
     """Return default config structure."""
-    return {"memory": {"enabled": False}, "planSync": {"enabled": False}, "review": {"backend": None}}
+    return {
+        "memory": {"enabled": False},
+        "planSync": {"enabled": False, "crossEpic": False},
+        "review": {"backend": None},
+    }
 
 
 def deep_merge(base: dict, override: dict) -> dict:

--- a/plugins/flow-next/skills/flow-next-plan/steps.md
+++ b/plugins/flow-next/skills/flow-next-plan/steps.md
@@ -73,6 +73,8 @@ Run these subagents in parallel using the Task tool:
 - Task flow-next:docs-scout(<request>)
 - Task flow-next:github-scout(<request>) - cross-repo code search via gh CLI
 - Task flow-next:memory-scout(<request>) - **only if memory.enabled is true**
+- Task flow-next:epic-scout(<request>) - finds dependencies on existing open epics
+- Task flow-next:docs-gap-scout(<request>) - identifies docs that may need updates
 
 **If user chose repo-scout (default/faster)** OR rp-cli unavailable:
 Run these subagents in parallel using the Task tool:
@@ -81,6 +83,8 @@ Run these subagents in parallel using the Task tool:
 - Task flow-next:docs-scout(<request>)
 - Task flow-next:github-scout(<request>) - cross-repo code search via gh CLI
 - Task flow-next:memory-scout(<request>) - **only if memory.enabled is true**
+- Task flow-next:epic-scout(<request>) - finds dependencies on existing open epics
+- Task flow-next:docs-gap-scout(<request>) - identifies docs that may need updates
 
 Must capture:
 - File paths + line refs
@@ -89,6 +93,8 @@ Must capture:
 - External docs links
 - Project conventions (CLAUDE.md, CONTRIBUTING, etc)
 - Architecture patterns and data flow (especially with context-scout)
+- Epic dependencies (from epic-scout)
+- Doc updates needed (from docs-gap-scout) - add to task acceptance criteria
 
 ## Step 2: Stakeholder & scope check
 
@@ -190,13 +196,28 @@ Default to standard unless complexity demands more or less.
    EOF
    ```
 
-4. Create child tasks:
+4. Set epic dependencies (from epic-scout findings):
+
+   If epic-scout found dependencies, set them automatically:
+   ```bash
+   # For each dependency found by epic-scout:
+   $FLOWCTL epic add-dep <new-epic-id> <dependency-epic-id> --json
+   ```
+
+   Report findings at end of planning (no user prompt needed):
+   ```
+   Epic dependencies set:
+   - fn-N → fn-2 (Auth): Uses authService from fn-2.1
+   - fn-N → fn-5 (DB): Extends User model
+   ```
+
+5. Create child tasks:
    ```bash
    # For each task:
    $FLOWCTL task create --epic <epic-id> --title "<Task title>" --json
    ```
 
-5. Write task specs (use combined set-spec):
+6. Write task specs (use combined set-spec):
    ```bash
    # For each task - single call sets both sections
    # Write description and acceptance to temp files, then:
@@ -223,13 +244,13 @@ Default to standard unless complexity demands more or less.
    - [ ] Criterion 2
    ```
 
-6. Add dependencies:
+7. Add task dependencies:
    ```bash
    # If task B depends on task A:
    $FLOWCTL dep add <task-B-id> <task-A-id> --json
    ```
 
-7. Output current state:
+8. Output current state:
    ```bash
    $FLOWCTL show <epic-id> --json
    $FLOWCTL cat <epic-id>

--- a/plugins/flow-next/skills/flow-next-setup/workflow.md
+++ b/plugins/flow-next/skills/flow-next-setup/workflow.md
@@ -83,6 +83,7 @@ HAVE_CODEX=$(which codex >/dev/null 2>&1 && echo 1 || echo 0)
 CURRENT_BACKEND=$("${PLUGIN_ROOT}/scripts/flowctl" config get review.backend --json 2>/dev/null | jq -r '.value // empty')
 CURRENT_MEMORY=$("${PLUGIN_ROOT}/scripts/flowctl" config get memory.enabled --json 2>/dev/null | jq -r '.value // empty')
 CURRENT_PLANSYNC=$("${PLUGIN_ROOT}/scripts/flowctl" config get planSync.enabled --json 2>/dev/null | jq -r '.value // empty')
+CURRENT_CROSSEPIC=$("${PLUGIN_ROOT}/scripts/flowctl" config get planSync.crossEpic --json 2>/dev/null | jq -r '.value // empty')
 ```
 
 Store detection results for use in questions. When showing options, indicate current value if set (e.g., "(current)" after the matching option label).
@@ -109,6 +110,7 @@ If ANY config values are already set, print a notice before asking questions:
 Current configuration:
 - Memory: <enabled|disabled> (change with: flowctl config set memory.enabled <true|false>)
 - Plan-Sync: <enabled|disabled> (change with: flowctl config set planSync.enabled <true|false>)
+- Plan-Sync cross-epic: <enabled|disabled> (change with: flowctl config set planSync.crossEpic <true|false>)
 - Review backend: <codex|rp|none> (change with: flowctl config set review.backend <codex|rp|none>)
 ```
 
@@ -141,6 +143,19 @@ Available questions (include only if corresponding config is unset):
   "options": [
     {"label": "No", "description": "Off by default. Enable later with: flowctl config set planSync.enabled true"},
     {"label": "Yes", "description": "Sync task specs when implementation differs from original plan"}
+  ],
+  "multiSelect": false
+}
+```
+
+**Plan-Sync cross-epic question** (include if CURRENT_PLANSYNC is "true" AND CURRENT_CROSSEPIC is empty):
+```json
+{
+  "header": "Cross-Epic",
+  "question": "Enable cross-epic plan-sync? (Also checks other open epics for stale references)",
+  "options": [
+    {"label": "No (Recommended)", "description": "Only sync within current epic. Faster, avoids long Ralph loops."},
+    {"label": "Yes", "description": "Also update tasks in other epics that reference changed APIs/patterns."}
   ],
   "multiSelect": false
 }
@@ -206,6 +221,10 @@ Only process answers for questions that were asked (config values that were unse
 - If "Yes": `"${PLUGIN_ROOT}/scripts/flowctl" config set planSync.enabled true --json`
 - If "No": `"${PLUGIN_ROOT}/scripts/flowctl" config set planSync.enabled false --json`
 
+**Plan-Sync cross-epic** (if question was asked):
+- If "Yes": `"${PLUGIN_ROOT}/scripts/flowctl" config set planSync.crossEpic true --json`
+- If "No": `"${PLUGIN_ROOT}/scripts/flowctl" config set planSync.crossEpic false --json`
+
 **Review** (if question was asked):
 Map user's answer to config value and persist:
 
@@ -249,6 +268,7 @@ To use from command line:
 Configuration (use flowctl config set to change):
 - Memory: <enabled|disabled>
 - Plan-Sync: <enabled|disabled>
+- Plan-Sync cross-epic: <enabled|disabled>
 - Review backend: <codex|rp|none>
 
 Documentation updated:


### PR DESCRIPTION
## Summary

- **Epic-aware planning**: New `epic-scout` subagent runs during research phase, finds relationships with existing open epics, auto-sets `depends_on_epics`. No user prompts—findings reported at end of planning.
- **Docs-gap detection**: New `docs-gap-scout` subagent identifies docs that may need updates (README, API docs, ADRs, CHANGELOG). Adds acceptance criteria to tasks—implementer decides content.
- **Cross-epic plan-sync**: Optional mode (`planSync.crossEpic: true`) checks other open epics for stale references after task completion. Default false to avoid long Ralph loops.
- **Model optimization**: `memory-scout` changed from opus to haiku (mechanical grep/read task)

## New subagents

| Agent | Model | Purpose |
|-------|-------|---------|
| `epic-scout` | haiku | Find epic dependency relationships |
| `docs-gap-scout` | haiku | Identify docs needing updates |

## Config changes

```bash
# New option (default false)
flowctl config set planSync.crossEpic true
```

## Breaking changes

None. New features are additive.

## Test plan

- [ ] `/flow-next:plan` runs epic-scout and docs-gap-scout in parallel
- [ ] Epic dependencies auto-set when found
- [ ] Doc update acceptance criteria added to tasks
- [ ] Cross-epic sync works when enabled
- [ ] Smoke test passes: `plugins/flow-next/scripts/smoke_test.sh`

## Notes

- Re-run `/flow-next:setup` to get new config option
- 12 subagents total (was 10)