### PR TITLE
fix(flow-next): plan-review now includes task specs in review

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Plan-first workflows for Claude Code. Two plugins: flow (Beads integration) and flow-next (zero-dep, Ralph autonomous mode).",
-    "version": "0.17.0"
+    "version": "0.17.1"
   },
   "plugins": [
     {
@@ -31,7 +31,7 @@
     {
       "name": "flow-next",
       "description": "Zero-dependency planning + execution with .flow/ task tracking and Ralph autonomous mode (multi-model review gates). Worker subagent per task for context isolation. Includes 12 subagents, 9 commands, 14 skills.",
-      "version": "0.17.0",
+      "version": "0.17.1",
       "author": {
         "name": "Gordon Mickel",
         "email": "gordon@mickel.tech",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 All notable changes to the gmickel-claude-marketplace.
 
+## [flow-next 0.17.1] - 2026-01-21
+
+### Fixed
+
+- **Plan review now includes task specs** — `/flow-next:plan-review` previously reviewed only the epic spec, leaving task specs stale when epic changes occurred during the fix loop. Now both RP and Codex backends include task specs in the review. Reviewers can flag inconsistencies between epic and task specs, and the fix loop instructs the agent to sync affected task specs.
+
+### Added
+
+- **`task set-spec --file`** — Full spec replacement mode for task specs (like `epic set-plan --file`). Supports both file paths and stdin (`-`). Use in plan-review fix loops to sync task specs after epic changes.
+- **Consistency checking in review criteria** — Both plan review backends now explicitly check for epic/task consistency: contradicting requirements, misaligned acceptance criteria, stale state/enum references.
+- **Task sync instructions in re-review preamble** — When re-reviewing, Codex backend now instructs the agent to sync task specs if epic changes affected them.
+
+### Changed
+
+- **Review prompt expanded** — Plan review now includes `<task_specs>` section with all task spec content (Codex backend). RP backend adds task spec files to selection.
+- **Fix loop steps updated** — Both SKILL.md and workflow.md now include task spec sync as explicit step (step 3 in SKILL.md, step 4 in workflow.md) before re-review.
+- **Anti-pattern added** — "Updating epic spec without syncing affected task specs" documented as anti-pattern in workflow.md.
+
+### Technical Details
+
+Task specs need syncing when epic changes affect:
+- State/enum values referenced in tasks
+- Acceptance criteria that tasks implement
+- Approach/design decisions tasks depend on
+- Lock/retry/error handling semantics
+- API signatures or type definitions
+
 ## [flow-next 0.17.0] - 2026-01-21
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Claude Code](https://img.shields.io/badge/Claude_Code-Plugin_Marketplace-blueviolet)](https://claude.ai/code)
 
-[![Flow-next](https://img.shields.io/badge/Flow--next-v0.17.0-green)](plugins/flow-next/)
+[![Flow-next](https://img.shields.io/badge/Flow--next-v0.17.1-green)](plugins/flow-next/)
 [![Flow-next Docs](https://img.shields.io/badge/Docs-📖-informational)](plugins/flow-next/README.md)
 
 [![Author](https://img.shields.io/badge/Author-Gordon_Mickel-orange)](https://mickel.tech)

--- a/plugins/flow-next/.claude-plugin/plugin.json
+++ b/plugins/flow-next/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "flow-next",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "Zero-dependency planning + execution with .flow/ task tracking and Ralph autonomous mode (multi-model review gates). Worker subagent per task for context isolation. Includes 12 subagents, 9 commands, 14 skills.",
   "author": {
     "name": "Gordon Mickel",

--- a/plugins/flow-next/README.md
+++ b/plugins/flow-next/README.md
@@ -5,7 +5,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](../../LICENSE)
 [![Claude Code](https://img.shields.io/badge/Claude_Code-Plugin-blueviolet)](https://claude.ai/code)
 
-[![Version](https://img.shields.io/badge/Version-0.17.0-green)](../../CHANGELOG.md)
+[![Version](https://img.shields.io/badge/Version-0.17.1-green)](../../CHANGELOG.md)
 
 [![Status](https://img.shields.io/badge/Status-Active_Development-brightgreen)](../../CHANGELOG.md)
 [![Discord](https://img.shields.io/badge/Discord-Join-5865F2?logo=discord&logoColor=white)](https://discord.gg/ST5Y39hQ)

--- a/plugins/flow-next/scripts/smoke_test.sh
+++ b/plugins/flow-next/scripts/smoke_test.sh
@@ -715,6 +715,51 @@ echo "$task_spec" | grep -q "Check 1" || { echo "set-spec acceptance failed"; FA
 echo -e "${GREEN}✓${NC} task set-spec combined"
 PASS=$((PASS + 1))
 
+echo -e "${YELLOW}--- task set-spec --file (full replacement) ---${NC}"
+scripts/flowctl task create --epic "$STDIN_EPIC" --title "Full replacement test" --json >/dev/null
+FULLREPLACE_TASK="${STDIN_EPIC}.2"
+# Write complete spec file
+cat > "$TEST_DIR/full_spec.md" << 'FULLSPEC'
+# Task: Full replacement test
+
+## Description
+
+This is a completely new spec that replaces everything.
+
+## Acceptance
+
+- [ ] Verify full replacement works
+- [ ] Original content is gone
+FULLSPEC
+scripts/flowctl task set-spec "$FULLREPLACE_TASK" --file "$TEST_DIR/full_spec.md" --json >/dev/null
+# Verify full replacement
+full_spec="$(scripts/flowctl cat "$FULLREPLACE_TASK")"
+echo "$full_spec" | grep -q "completely new spec that replaces everything" || { echo "set-spec --file content failed"; FAIL=$((FAIL + 1)); }
+echo "$full_spec" | grep -q "Verify full replacement works" || { echo "set-spec --file acceptance failed"; FAIL=$((FAIL + 1)); }
+echo -e "${GREEN}✓${NC} task set-spec --file"
+PASS=$((PASS + 1))
+
+echo -e "${YELLOW}--- task set-spec --file stdin ---${NC}"
+scripts/flowctl task create --epic "$STDIN_EPIC" --title "Stdin replacement test" --json >/dev/null
+STDIN_REPLACE_TASK="${STDIN_EPIC}.3"
+# Full replacement via stdin
+scripts/flowctl task set-spec "$STDIN_REPLACE_TASK" --file - --json <<'EOF'
+# Task: Stdin replacement test
+
+## Description
+
+This spec was written via stdin.
+
+## Acceptance
+
+- [ ] Stdin replacement works
+EOF
+# Verify stdin replacement
+stdin_spec="$(scripts/flowctl cat "$STDIN_REPLACE_TASK")"
+echo "$stdin_spec" | grep -q "spec was written via stdin" || { echo "set-spec --file stdin failed"; FAIL=$((FAIL + 1)); }
+echo -e "${GREEN}✓${NC} task set-spec --file stdin"
+PASS=$((PASS + 1))
+
 echo -e "${YELLOW}--- checkpoint save/restore ---${NC}"
 # Save checkpoint
 scripts/flowctl checkpoint save --epic "$STDIN_EPIC" --json >/dev/null


### PR DESCRIPTION
## Summary

Fixes a significant workflow bug where `/flow-next:plan-review` reviewed **only the epic spec**, leaving task specs stale when epic changes occurred during the fix loop.

**Before**: Reviewer sees epic spec → flags issues → fix loop updates epic → task specs become inconsistent → manual cleanup needed after SHIP verdict

**After**: Reviewer sees epic + task specs → flags consistency issues → fix loop updates both → all specs aligned at SHIP

## Problem

When running plan-review, the fix loop would update the epic spec based on reviewer feedback, but task specs were never:
1. Included in the review (so reviewer couldn't flag inconsistencies)
2. Updated during the fix loop (so they'd drift from the epic)

Real example: Epic added a `finalizing` MergeStatus state, changed lock takeover rules, added `rotateEntry()` — but task specs still had old content. Got SHIP verdict, then had to manually update 7 task specs.

## Solution

| Component | Change |
|-----------|--------|
| `task set-spec --file` | New full replacement mode (like `epic set-plan --file`) |
| Codex backend | Loads task specs, includes `<task_specs>` section in prompt |
| RP backend | Adds task spec files to selection via loop |
| Review criteria | Added "Consistency" check for epic/task alignment |
| Fix loop | New step to sync affected task specs before re-review |
| Re-review preamble | Instructs agent when/how to sync task specs |

## Changes

- **flowctl.py**: `task set-spec --file`, `build_review_prompt(task_specs=)`, `cmd_codex_plan_review` loads tasks, `build_rereview_preamble` task sync note
- **SKILL.md**: RP selection loop, fix loop step 3 (task sync)
- **workflow.md**: Phase 2 task selection, Review Scope section, fix loop step 4
- **smoke_test.sh**: 2 new tests for `--file` and stdin modes

## Backwards Compatibility

Fully compatible:
- `--description`/`--acceptance` options unchanged
- `task_specs=""` default — existing callers work
- Empty task list handled gracefully
- RP loop has existence guard

## Test Plan

- [x] `smoke_test.sh` passes (45/45, including 2 new tests)
- [x] `task set-spec --file` replaces full spec
- [x] `task set-spec --file -` works with stdin
- [ ] CI passes