### PR TITLE
fix(flow-next): auto-close epics in unscoped Ralph runs

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Plan-first workflows for Claude Code. Two plugins: flow (Beads integration) and flow-next (zero-dep, Ralph autonomous mode).",
-    "version": "0.18.3"
+    "version": "0.18.4"
   },
   "plugins": [
     {
@@ -31,7 +31,7 @@
     {
       "name": "flow-next",
       "description": "Zero-dependency planning + execution with .flow/ task tracking and Ralph autonomous mode (multi-model review gates). Worker subagent per task for context isolation. Includes 12 subagents, 9 commands, 14 skills.",
-      "version": "0.18.3",
+      "version": "0.18.4",
       "author": {
         "name": "Gordon Mickel",
         "email": "gordon@mickel.tech",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the gmickel-claude-marketplace.
 
+## [flow-next 0.18.4] - 2026-01-23
+
+### Fixed
+
+- **Ralph now auto-closes epics in unscoped runs** — Previously `maybe_close_epics()` only ran when `EPICS=...` was specified, meaning unscoped Ralph runs would never auto-close epics even when all tasks were done. This blocked downstream epics that depended on them. Now Ralph checks all open epics and closes any with all tasks completed. Thanks to [@VexyCats](https://github.com/VexyCats) for the report!
+
+- **Added `list_open_epics()` helper** — New function to get all non-done epic IDs from flowctl for unscoped runs.
+
 ## [flow-next 0.18.3] - 2026-01-23
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Claude Code](https://img.shields.io/badge/Claude_Code-Plugin_Marketplace-blueviolet)](https://claude.ai/code)
 
-[![Flow-next](https://img.shields.io/badge/Flow--next-v0.18.3-green)](plugins/flow-next/)
+[![Flow-next](https://img.shields.io/badge/Flow--next-v0.18.4-green)](plugins/flow-next/)
 [![Flow-next Docs](https://img.shields.io/badge/Docs-📖-informational)](plugins/flow-next/README.md)
 
 [![Author](https://img.shields.io/badge/Author-Gordon_Mickel-orange)](https://mickel.tech)

--- a/plugins/flow-next/.claude-plugin/plugin.json
+++ b/plugins/flow-next/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "flow-next",
-  "version": "0.18.3",
+  "version": "0.18.4",
   "description": "Zero-dependency planning + execution with .flow/ task tracking and Ralph autonomous mode (multi-model review gates). Worker subagent per task for context isolation. Prime assesses 8 pillars (48 criteria) with GitHub API integration. Includes 20 subagents, 10 commands, 14 skills.",
   "author": {
     "name": "Gordon Mickel",

--- a/plugins/flow-next/README.md
+++ b/plugins/flow-next/README.md
@@ -5,7 +5,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](../../LICENSE)
 [![Claude Code](https://img.shields.io/badge/Claude_Code-Plugin-blueviolet)](https://claude.ai/code)
 
-[![Version](https://img.shields.io/badge/Version-0.18.3-green)](../../CHANGELOG.md)
+[![Version](https://img.shields.io/badge/Version-0.18.4-green)](../../CHANGELOG.md)
 
 [![Status](https://img.shields.io/badge/Status-Active_Development-brightgreen)](../../CHANGELOG.md)
 [![Discord](https://img.shields.io/badge/Discord-Join-5865F2?logo=discord&logoColor=white)](https://discord.gg/ST5Y39hQ)


### PR DESCRIPTION
## Summary

Fixes issue where unscoped Ralph runs never auto-close epics, blocking downstream epics.

**Problem**: `maybe_close_epics()` returned early when `EPICS_FILE` was empty (line 697). Unscoped runs never set this variable, so epics with all tasks done would stay open and block dependent epics.

**Fix**:
- Add `list_open_epics()` helper to get all non-done epic IDs from `flowctl epics --json`
- Update `maybe_close_epics()` to check all open epics when unscoped
- Use temp file approach to avoid heredoc/pipe race conditions

## Test plan

- [x] Syntax check passes
- [x] Smoke tests pass (45/45)
- [x] Manual test: unscoped run correctly closes epic with all tasks done

## Code changes

| File | Change |
|------|--------|
| `ralph.sh` | Add `list_open_epics()` helper (~15 lines) |
| `ralph.sh` | Update `maybe_close_epics()` to handle unscoped case |
| `CHANGELOG.md` | Document fix |

Thanks to @VexyCats for the report!