### PR TITLE
fix(flow-next): restore manual prompt building for RP reviews

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Plan-first workflows for Claude Code. Two plugins: flow (Beads integration) and flow-next (zero-dep, Ralph autonomous mode).",
-    "version": "0.18.14"
+    "version": "0.18.15"
   },
   "plugins": [
     {
@@ -31,7 +31,7 @@
     {
       "name": "flow-next",
       "description": "Zero-dependency planning + execution with .flow/ task tracking and Ralph autonomous mode (multi-model review gates). Worker subagent per task for context isolation. Includes 12 subagents, 9 commands, 14 skills.",
-      "version": "0.18.14",
+      "version": "0.18.15",
       "author": {
         "name": "Gordon Mickel",
         "email": "gordon@mickel.tech",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 All notable changes to the gmickel-claude-marketplace.
 
+## [flow-next 0.18.15] - 2026-01-24
+
+### Fixed
+
+- **Restored manual prompt building for RP reviews** — Reverted from the flaky two-step chat approach (`--response-type review` + follow-up) back to the reliable single-chat approach with custom review prompts.
+
+  **Why this was necessary:**
+  - The `--response-type review` mode introduced in 0.14.0 delegates prompt construction to RepoPrompt's builder, giving us no control over the exact prompt sent to the reviewer model
+  - RP returns its own verdict format (`request-changes`, `approve`, etc.) instead of our `<verdict>SHIP|NEEDS_WORK|MAJOR_RETHINK</verdict>` tags
+  - This required a follow-up message just to get the verdict in the correct format, making the flow fragile
+  - Versions 0.18.5 through 0.18.12 were all attempts to patch this two-step flow, adding warnings, stronger instructions, and format reminders — none fully resolved the flakiness
+  - In autonomous operation (Ralph), this unreliability breaks the review loop entirely when the model skips the follow-up or misparses the builder's verdict
+
+  **What changed:**
+  - Removed `--response-type review` from `setup-review` calls
+  - Restored Phase 2 manual file selection (explicitly add changed files)
+  - Restored Phase 3 `prompt-get` + custom review prompt with full Carmack criteria and verdict requirement baked in
+  - Single `chat-send --new-chat` returns verdict directly — no follow-up needed
+
+  **What was preserved:**
+  - MAX_REVIEW_ITERATIONS=3 (reduced from 5)
+  - Checkpoint save/restore for context compaction recovery
+  - Task spec inclusion and syncing in plan-review
+  - All flowctl.py improvements (`--chat-id`, `--mode`, etc. remain available)
+
 ## [flow-next 0.18.14] - 2026-01-24
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Claude Code](https://img.shields.io/badge/Claude_Code-Plugin_Marketplace-blueviolet)](https://claude.ai/code)
 
-[![Flow-next](https://img.shields.io/badge/Flow--next-v0.18.13-green)](plugins/flow-next/)
+[![Flow-next](https://img.shields.io/badge/Flow--next-v0.18.15-green)](plugins/flow-next/)
 [![Flow-next Docs](https://img.shields.io/badge/Docs-📖-informational)](plugins/flow-next/README.md)
 
 [![Author](https://img.shields.io/badge/Author-Gordon_Mickel-orange)](https://mickel.tech)

--- a/plugins/flow-next/.claude-plugin/plugin.json
+++ b/plugins/flow-next/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "flow-next",
-  "version": "0.18.14",
+  "version": "0.18.15",
   "description": "Zero-dependency planning + execution with .flow/ task tracking and Ralph autonomous mode (multi-model review gates). Worker subagent per task for context isolation. Prime assesses 8 pillars (48 criteria) with GitHub API integration. Includes 20 subagents, 10 commands, 14 skills.",
   "author": {
     "name": "Gordon Mickel",

--- a/plugins/flow-next/README.md
+++ b/plugins/flow-next/README.md
@@ -5,7 +5,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](../../LICENSE)
 [![Claude Code](https://img.shields.io/badge/Claude_Code-Plugin-blueviolet)](https://claude.ai/code)
 
-[![Version](https://img.shields.io/badge/Version-0.18.13-green)](../../CHANGELOG.md)
+[![Version](https://img.shields.io/badge/Version-0.18.15-green)](../../CHANGELOG.md)
 
 [![Status](https://img.shields.io/badge/Status-Active_Development-brightgreen)](../../CHANGELOG.md)
 [![Discord](https://img.shields.io/badge/Discord-Join-5865F2?logo=discord&logoColor=white)](https://discord.gg/ST5Y39hQ)

--- a/plugins/flow-next/skills/flow-next-impl-review/workflow.md
+++ b/plugins/flow-next/skills/flow-next-impl-review/workflow.md
@@ -86,9 +86,26 @@ Format: `{"mode":"codex","task":"<id>","verdict":"<verdict>","session_id":"<thre
 
 Use when `BACKEND="rp"`.
 
-**Requires RepoPrompt 1.6.0+** for the builder review mode. Check version with `rp-cli --version`.
+### Atomic Setup Block
 
-### Phase 1: Identify Changes (RP)
+```bash
+# Atomic: pick-window + builder
+eval "$($FLOWCTL rp setup-review --repo-root "$REPO_ROOT" --summary "Review implementation of <summary> on current branch")"
+
+# Verify we have W and T
+if [[ -z "${W:-}" || -z "${T:-}" ]]; then
+  echo "<promise>RETRY</promise>"
+  exit 0
+fi
+
+echo "Setup complete: W=$W T=$T"
+```
+
+If this block fails, output `<promise>RETRY</promise>` and stop. Do not improvise.
+
+---
+
+## Phase 1: Identify Changes (RP)
 
 ```bash
 BRANCH="$(git branch --show-current)"
@@ -102,110 +119,140 @@ else
   DIFF_BASE="$BASE_COMMIT"
 fi
 
-# Get commit info for instructions
-COMMITS="$(git log ${DIFF_BASE}..HEAD --oneline)"
+git log ${DIFF_BASE}..HEAD --oneline
 CHANGED_FILES="$(git diff ${DIFF_BASE}..HEAD --name-only)"
+git diff ${DIFF_BASE}..HEAD --stat
 ```
 
-### Phase 2: Build Review Instructions (RP)
+Save:
+- Branch name
+- Changed files list
+- Commit summary
+- DIFF_BASE (for reference in review prompt)
 
-Build XML-structured instructions for the builder review mode:
+Compose a 1-2 sentence summary for the setup-review command.
+
+---
+
+## Phase 2: Augment Selection (RP)
+
+Builder selects context automatically. Review and add must-haves:
 
 ```bash
-cat > /tmp/review-instructions.txt << EOF
-<task>Review changes from ${DIFF_BASE}..HEAD for correctness, simplicity, and potential issues.
+# See what builder selected
+$FLOWCTL rp select-get --window "$W" --tab "$T"
 
-Focus on:
-- Correctness - Logic errors, spec compliance
-- Simplicity - Over-engineering, unnecessary complexity
-- Edge cases - Failure modes, boundary conditions
-- Security - Injection, auth gaps
+# Add ALL changed files
+for f in $CHANGED_FILES; do
+  $FLOWCTL rp select-add --window "$W" --tab "$T" "$f"
+done
 
-Only flag issues in the changed code - not pre-existing patterns.
+# Add task spec if known
+$FLOWCTL rp select-add --window "$W" --tab "$T" .flow/specs/<task-id>.md
+```
 
-**REQUIRED**: End your review with exactly one verdict tag:
-- \`<verdict>SHIP</verdict>\` - Code is production-ready
-- \`<verdict>NEEDS_WORK</verdict>\` - Issues must be fixed before shipping
-- \`<verdict>MAJOR_RETHINK</verdict>\` - Fundamental approach problems
-</task>
+**Why this matters:** Chat only sees selected files.
 
-<context>
-Branch: $BRANCH
-Commits:
-$COMMITS
+---
 
-Changed files:
-$CHANGED_FILES
-$([ -n "$TASK_ID" ] && echo "Task: $TASK_ID")
-$([ -n "$FOCUS_AREAS" ] && echo "Focus areas: $FOCUS_AREAS")
-</context>
+## Phase 3: Execute Review (RP)
 
-<discovery_agent-guidelines>
-Focus on directories containing the changed files. Include git diffs for the commits.
-</discovery_agent-guidelines>
+### Build combined prompt
+
+Get builder's handoff:
+```bash
+HANDOFF="$($FLOWCTL rp prompt-get --window "$W" --tab "$T")"
+```
+
+Write combined prompt:
+```bash
+cat > /tmp/review-prompt.md << 'EOF'
+[PASTE HANDOFF HERE]
+
+---
+
+## IMPORTANT: File Contents
+RepoPrompt includes the actual source code of selected files in a `<file_contents>` XML section at the end of this message. You MUST:
+1. Locate the `<file_contents>` section
+2. Read and analyze the actual source code within it
+3. Base your review on the code, not summaries or descriptions
+
+If you cannot find `<file_contents>`, ask for the files to be re-attached before proceeding.
+
+## Changes Under Review
+Branch: [BRANCH_NAME]
+Files: [LIST CHANGED FILES]
+Commits: [COMMIT SUMMARY]
+
+## Original Spec
+[PASTE flowctl show OUTPUT if known]
+
+## Review Focus
+[USER'S FOCUS AREAS]
+
+## Review Criteria
+
+Conduct a John Carmack-level review:
+
+1. **Correctness** - Matches spec? Logic errors?
+2. **Simplicity** - Simplest solution? Over-engineering?
+3. **DRY** - Duplicated logic? Existing patterns?
+4. **Architecture** - Data flow? Clear boundaries?
+5. **Edge Cases** - Failure modes? Race conditions?
+6. **Tests** - Adequate coverage? Testing behavior?
+7. **Security** - Injection? Auth gaps?
+
+## Scenario Exploration (for changed code only)
+
+Walk through these scenarios mentally for any new/modified code paths:
+
+- [ ] Happy path - Normal operation with valid inputs
+- [ ] Invalid inputs - Null, empty, malformed data
+- [ ] Boundary conditions - Min/max values, empty collections
+- [ ] Concurrent access - Race conditions, deadlocks
+- [ ] Network issues - Timeouts, partial failures
+- [ ] Resource exhaustion - Memory, disk, connections
+- [ ] Security attacks - Injection, overflow, DoS vectors
+- [ ] Data corruption - Partial writes, inconsistency
+- [ ] Cascading failures - Downstream service issues
+
+Only flag issues that apply to the **changed code** - not pre-existing patterns.
+
+## Output Format
+
+For each issue:
+- **Severity**: Critical / Major / Minor / Nitpick
+- **File:Line**: Exact location
+- **Problem**: What's wrong
+- **Suggestion**: How to fix
+
+**REQUIRED**: You MUST end your response with exactly one verdict tag. This is mandatory:
+`<verdict>SHIP</verdict>` or `<verdict>NEEDS_WORK</verdict>` or `<verdict>MAJOR_RETHINK</verdict>`
+
+Do NOT skip this tag. The automation depends on it.
 EOF
 ```
 
-### Phase 3: Execute Review (RP)
-
-Use `setup-review` with `--response-type review` (RP 1.6.0+). The builder's discovery agent automatically:
-- Selects relevant files and git diffs
-- Analyzes code with full codebase context
-- Returns structured review findings
+### Send to RepoPrompt
 
 ```bash
-# Run builder review mode
-REVIEW_OUTPUT=$($FLOWCTL rp setup-review \
-  --repo-root "$REPO_ROOT" \
-  --summary "$(cat /tmp/review-instructions.txt)" \
-  --response-type review \
-  --json)
-
-# Parse output
-W=$(echo "$REVIEW_OUTPUT" | jq -r '.window')
-T=$(echo "$REVIEW_OUTPUT" | jq -r '.tab')
-CHAT_ID=$(echo "$REVIEW_OUTPUT" | jq -r '.chat_id')
-REVIEW_FINDINGS=$(echo "$REVIEW_OUTPUT" | jq -r '.review')
-
-if [[ -z "$W" || -z "$T" ]]; then
-  echo "<promise>RETRY</promise>"
-  exit 0
-fi
-
-echo "Setup complete: W=$W T=$T CHAT_ID=$CHAT_ID"
-echo "Review findings:"
-echo "$REVIEW_FINDINGS"
+$FLOWCTL rp chat-send --window "$W" --tab "$T" --message-file /tmp/review-prompt.md --new-chat --chat-name "Impl Review: $BRANCH"
 ```
 
-The builder returns review findings but may use **RP's own verdict format** (like `request-changes`). **IGNORE any verdict in the builder response.** Request verdict in OUR format via follow-up:
+**WAIT** for response. Takes 1-5+ minutes.
 
-```bash
-cat > /tmp/verdict-request.md << 'EOF'
-Based on your review findings above, provide your final verdict using EXACTLY one of these tags:
+---
 
-`<verdict>SHIP</verdict>` - Code is production-ready
-`<verdict>NEEDS_WORK</verdict>` - Issues must be fixed before shipping
-`<verdict>MAJOR_RETHINK</verdict>` - Fundamental approach problems
+## Phase 4: Receipt + Status (RP)
 
-Do NOT use any other verdict format. Use exactly one of the three tags above.
-EOF
-
-$FLOWCTL rp chat-send --window "$W" --tab "$T" \
-  --message-file /tmp/verdict-request.md \
-  --chat-id "$CHAT_ID" \
-  --mode review
-```
-
-**WAIT** for response. Extract verdict **ONLY from this follow-up response**, not from builder output.
-
-### Phase 4: Receipt + Status (RP)
+### Write receipt (if REVIEW_RECEIPT_PATH set)
 
 ```bash
 if [[ -n "${REVIEW_RECEIPT_PATH:-}" ]]; then
   ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
   mkdir -p "$(dirname "$REVIEW_RECEIPT_PATH")"
   cat > "$REVIEW_RECEIPT_PATH" <<EOF
-{"type":"impl_review","id":"$TASK_ID","mode":"rp","timestamp":"$ts","chat_id":"$CHAT_ID"}
+{"type":"impl_review","id":"<TASK_ID>","mode":"rp","timestamp":"$ts"}
 EOF
   echo "REVIEW_RECEIPT_WRITTEN: $REVIEW_RECEIPT_PATH"
 fi
@@ -237,7 +284,18 @@ If verdict is NEEDS_WORK:
 
 5. **Request re-review** (only AFTER step 4):
 
-   Use `--chat-id` to continue in the same conversation (reviewer has context):
+   **IMPORTANT**: Do NOT re-add files already in the selection. RepoPrompt auto-refreshes
+   file contents on every message. Only use `select-add` for NEW files created during fixes:
+   ```bash
+   # Only if fixes created new files not in original selection
+   if [[ -n "$NEW_FILES" ]]; then
+     $FLOWCTL rp select-add --window "$W" --tab "$T" $NEW_FILES
+   fi
+   ```
+
+   Then send re-review request (NO --new-chat, stay in same chat).
+
+   **CRITICAL: Do NOT summarize fixes.** RP auto-refreshes file contents - reviewer sees your changes automatically. Just request re-review. Any summary wastes tokens and duplicates what reviewer already sees.
 
    ```bash
    cat > /tmp/re-review.md << 'EOF'
@@ -246,15 +304,11 @@ If verdict is NEEDS_WORK:
    **REQUIRED**: End with `<verdict>SHIP</verdict>` or `<verdict>NEEDS_WORK</verdict>` or `<verdict>MAJOR_RETHINK</verdict>`
    EOF
 
-   $FLOWCTL rp chat-send --window "$W" --tab "$T" \
-     --message-file /tmp/re-review.md \
-     --chat-id "$CHAT_ID" \
-     --mode review
+   $FLOWCTL rp chat-send --window "$W" --tab "$T" --message-file /tmp/re-review.md
    ```
+6. **Repeat** until Ship
 
-6. **Repeat** until SHIP
-
-**Note**: RP auto-refreshes file contents on every message. No need to re-add files to selection.
+**Anti-pattern**: Re-adding already-selected files before re-review. RP auto-refreshes; re-adding can cause issues.
 
 ---
 

--- a/plugins/flow-next/skills/flow-next-plan-review/flowctl-reference.md
+++ b/plugins/flow-next/skills/flow-next-plan-review/flowctl-reference.md
@@ -6,8 +6,8 @@ Use `flowctl rp` wrappers only.
 
 ```bash
 # Atomic setup: pick-window + builder
-eval "$($FLOWCTL rp setup-review --repo-root "$REPO_ROOT" --summary "..." --response-type review)"
-# Returns: W=<window> T=<tab> CHAT_ID=<id>
+eval "$($FLOWCTL rp setup-review --repo-root "$REPO_ROOT" --summary "...")"
+# Returns: W=<window> T=<tab>
 ```
 
 This is the **only** way to initialize a review session. Do not call `pick-window` or `builder` individually.

--- a/plugins/flow-next/skills/flow-next-plan-review/workflow.md
+++ b/plugins/flow-next/skills/flow-next-plan-review/workflow.md
@@ -89,7 +89,7 @@ Use when `BACKEND="rp"`.
 
 ```bash
 # Atomic: pick-window + builder
-eval "$($FLOWCTL rp setup-review --repo-root "$REPO_ROOT" --summary "Review plan for <EPIC_ID>: <summary>" --response-type review)"
+eval "$($FLOWCTL rp setup-review --repo-root "$REPO_ROOT" --summary "Review plan for <EPIC_ID>: <summary>")"
 
 # Verify we have W and T
 if [[ -z "${W:-}" || -z "${T:-}" ]]; then


### PR DESCRIPTION
## Summary

Reverts from the flaky two-step chat approach (`--response-type review` + follow-up) back to the reliable single-chat approach with custom review prompts.

**Why this was necessary:**
- The `--response-type review` mode introduced in 0.14.0 delegates prompt construction to RepoPrompt's builder, giving us no control over the exact prompt sent to the reviewer model
- RP returns its own verdict format (`request-changes`, `approve`, etc.) instead of our `<verdict>SHIP|NEEDS_WORK|MAJOR_RETHINK</verdict>` tags
- This required a follow-up message just to get the verdict in the correct format, making the flow fragile
- Versions 0.18.5 through 0.18.12 were all attempts to patch this two-step flow — none fully resolved the flakiness
- In autonomous operation (Ralph), this unreliability breaks the review loop entirely

**What changed:**
- Removed `--response-type review` from `setup-review` calls
- Restored Phase 2 manual file selection
- Restored Phase 3 `prompt-get` + custom review prompt with verdict requirement baked in
- Single `chat-send --new-chat` returns verdict directly

**What was preserved:**
- MAX_REVIEW_ITERATIONS=3
- Checkpoint save/restore
- Task spec inclusion and syncing in plan-review
- All flowctl.py improvements

## Test plan

- [ ] CI passes (syntax checks + comprehensive tests)
- [ ] Manual test with `/flow-next:impl-review --review=rp`