### PR TITLE
fix(ralph): close epics before selector to unblock dependent epics

### DIFF
--- a/plugins/flow-next/skills/flow-next-ralph-init/templates/ralph.sh
+++ b/plugins/flow-next/skills/flow-next-ralph-init/templates/ralph.sh
@@ -807,6 +807,10 @@ while (( iter <= MAX_ITERATIONS )); do
   # Check for pause/stop at start of iteration (before work selection)
   check_sentinels
 
+  # Close any epics with all tasks done BEFORE calling selector
+  # This ensures dependent epics become unblocked in the same iteration
+  maybe_close_epics
+
   selector_args=("$FLOWCTL" next --json)
   [[ -n "$EPICS_FILE" ]] && selector_args+=(--epics-file "$EPICS_FILE")
   [[ "$REQUIRE_PLAN_REVIEW" == "1" ]] && selector_args+=(--require-plan-review)
@@ -824,7 +828,7 @@ while (( iter <= MAX_ITERATIONS )); do
     if [[ "$reason" == "blocked_by_epic_deps" ]]; then
       log "blocked by epic deps"
     fi
-    maybe_close_epics
+    # maybe_close_epics already called at start of iteration
     ui_complete
     write_completion_marker "NO_WORK"
     exit 0


### PR DESCRIPTION
## Problem

When Ralph completes all tasks of an epic that has dependent epics, those dependent epics remain blocked until the next iteration because `maybe_close_epics()` is called AFTER the selector returns "none".

### Race condition timeline:
1. Ralph completes last task of epic A (e.g., `fn-8-lfy`)
2. Next iteration: selector runs
3. Selector sees epic A `status="open"` (not closed yet)
4. Selector sees epic B (`fn-9-usj`) blocked by A
5. Selector returns `status="none"` (no work available)
6. `maybe_close_epics()` closes epic A
7. Ralph exits with `NO_WORK`
8. **Epic B never gets picked up for plan review**

### Real-world impact:
In a multi-epic run with dependencies (e.g., infrastructure epic followed by feature epics), Ralph would complete the first epic then exit, leaving all dependent epics untouched.

## Solution

Move `maybe_close_epics()` to the START of each iteration, before calling the selector. This ensures:
1. Completed epics are closed before selector runs
2. Dependent epics are immediately unblocked
3. Selector correctly returns the next epic for plan review

## Testing

Verified with a 12-epic dependency chain where `fn-9-usj` through `fn-19-p5j` all depend on `fn-8-lfy`. After the fix:
- `flowctl next --require-plan-review` correctly returns `fn-9-usj`
- Ralph continues to the next epic instead of exiting

## Changes

- `plugins/flow-next/skills/flow-next-ralph-init/templates/ralph.sh`: Move `maybe_close_epics()` call from after `status=="none"` check to before selector call