### PR TITLE
fix(worker): enforce impl-review completion before returning

### DIFF
--- a/plugins/flow-next/agents/worker.md
+++ b/plugins/flow-next/agents/worker.md
@@ -17,6 +17,21 @@ You implement a single flow-next task. Your prompt contains configuration values
 - `REVIEW_MODE` - none, rp, or codex
 - `RALPH_MODE` - true if running autonomously
 
+## CRITICAL: DO NOT RETURN EARLY
+
+**If REVIEW_MODE is `rp` or `codex`, you MUST complete Phase 4 (Review) before returning.**
+
+Returning without invoking `/flow-next:impl-review` when review is required will cause:
+- Ralph to block on missing receipt
+- Forced retries that waste time
+- Task stuck in retry loop
+
+**Checklist before returning:**
+- [ ] Implementation complete
+- [ ] Changes committed
+- [ ] If REVIEW_MODE != none: `/flow-next:impl-review` invoked and SHIP verdict received
+- [ ] `flowctl done` run and status verified as `done`
+
 ## Phase 1: Re-anchor (CRITICAL - DO NOT SKIP)
 
 Use the FLOWCTL path and IDs from your prompt:
@@ -82,9 +97,12 @@ Task: <TASK_ID>"
 
 Use conventional commits. Scope from task context.
 
-## Phase 4: Review (if REVIEW_MODE is rp or codex)
+## Phase 4: Review (MANDATORY if REVIEW_MODE is rp or codex)
 
-Skip if REVIEW_MODE is `none`.
+**Skip ONLY if REVIEW_MODE is `none`.**
+
+**If REVIEW_MODE is `rp` or `codex`, you MUST invoke impl-review before proceeding to Phase 5.**
+**DO NOT proceed to Phase 5 without completing this phase when review is required.**
 
 **IMPORTANT: Use the Skill tool to invoke impl-review, NOT flowctl directly.**
 
@@ -107,6 +125,10 @@ If NEEDS_WORK:
 3. Re-invoke the skill (NOT flowctl): `/flow-next:impl-review <TASK_ID> --base $BASE_COMMIT`
 
 Continue until SHIP verdict.
+
+**STOP: Before proceeding to Phase 5, verify:**
+- If REVIEW_MODE is `rp` or `codex`: Did you invoke `/flow-next:impl-review` and receive SHIP?
+- If NO: Go back and complete Phase 4 NOW. Do not proceed.
 
 ## Phase 5: Complete
 
@@ -142,11 +164,16 @@ Status must be `done`. If not, debug and retry.
 
 ## Phase 6: Return
 
+**FINAL CHECK before returning:**
+If REVIEW_MODE is `rp` or `codex` and you did NOT invoke `/flow-next:impl-review`:
+- STOP - go back to Phase 4 and invoke the review NOW
+- Returning without review will cause Ralph to block and retry
+
 Return a concise summary to the main conversation:
 - What was implemented (1-2 sentences)
 - Key files changed
 - Tests run (if any)
-- Review verdict (if review enabled)
+- Review verdict (MUST include if REVIEW_MODE != none)
 
 ## Rules
 
@@ -154,5 +181,6 @@ Return a concise summary to the main conversation:
 - **No TodoWrite** - flowctl tracks tasks
 - **git add -A** - never list files explicitly
 - **One task only** - implement only the task you were given
+- **Review before done** - if REVIEW_MODE != none, invoke `/flow-next:impl-review` BEFORE `flowctl done`
 - **Verify done** - flowctl show must report status: done
-- **Return summary** - main conversation needs outcome
+- **Return summary** - main conversation needs outcome INCLUDING review verdict


### PR DESCRIPTION
## Problem

Worker subagent returns early without invoking `/flow-next:impl-review` when `REVIEW_MODE` is `rp` or `codex`. This causes:
- Ralph to block on missing review receipt
- ralph-guard to reject receipt writes (no review done)
- Tasks stuck in 5-retry loop then auto-blocked

### Observed behavior:
1. Worker completes implementation (writes files, commits)
2. Worker runs `flowctl done` 
3. Worker returns WITHOUT invoking `/flow-next:impl-review`
4. Stop hook blocks: "Review receipt not written"
5. Ralph forces retry, same thing happens 5 times
6. Task auto-blocked

### Root cause:
The worker.md instructions weren't forceful enough about requiring impl-review before returning. The model was treating `flowctl done` as the completion signal and returning early.

## Solution

Add multiple checkpoints in `worker.md` to prevent early return:

1. **Top-level warning**: "CRITICAL: DO NOT RETURN EARLY" section with checklist
2. **Phase 4 header**: Changed to "MANDATORY if REVIEW_MODE is rp or codex"
3. **Pre-Phase 5 gate**: Explicit STOP check before proceeding to completion
4. **Phase 6 final check**: Another reminder before returning
5. **Rules update**: Added "Review before done" rule

These reinforcements make it harder for the model to skip the review phase when review is required.

## Testing

This fix addresses the issue observed in a Ralph run where all analysis tasks (fn-16-86a.1, fn-17-alg.1, fn-18-3nn.1) got blocked after 5 retries because the worker kept returning without invoking impl-review.