### PR TITLE
feat(flow-next): add copilot review backend

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -31,7 +31,7 @@
     {
       "name": "flow-next",
       "description": "Zero-dependency planning + execution with .flow/ task tracking and Ralph autonomous mode (multi-model review gates). Worker subagent per task for context isolation. Includes 20 subagents, 11 commands, 16 skills.",
-      "version": "0.20.1",
+      "version": "0.20.2",
       "author": {
         "name": "Gordon Mickel",
         "email": "gordon@mickel.tech",

--- a/.flow/bin/flowctl.py
+++ b/.flow/bin/flowctl.py
@@ -670,7 +670,7 @@ def epic_id_from_task(task_id: str) -> str:
     return task_id.rsplit(".", 1)[0]
 
 
-# --- Context Hints (for codex reviews) ---
+# --- Context Hints (for codex/copilot reviews) ---
 
 
 def get_changed_files(base_branch: str) -> list[str]:
@@ -1162,6 +1162,36 @@ def get_codex_version() -> Optional[str]:
         return None
 
 
+# --- Copilot Backend Helpers ---
+
+
+def require_copilot() -> str:
+    """Ensure copilot CLI is available. Returns path to copilot."""
+    copilot = shutil.which("copilot")
+    if not copilot:
+        error_exit("copilot not found in PATH", use_json=False, code=2)
+    return copilot
+
+
+def get_copilot_version() -> Optional[str]:
+    """Get copilot version, or None if not available."""
+    copilot = shutil.which("copilot")
+    if not copilot:
+        return None
+    try:
+        result = subprocess.run(
+            [copilot, "--version"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        output = result.stdout.strip()
+        match = re.search(r"(\d+\.\d+\.\d+)", output)
+        return match.group(1) if match else output
+    except subprocess.CalledProcessError:
+        return None
+
+
 CODEX_SANDBOX_MODES = {"read-only", "workspace-write", "danger-full-access", "auto"}
 
 
@@ -1279,6 +1309,35 @@ def run_codex_exec(
         return "", None, 2, "codex exec timed out (600s)"
 
 
+def run_copilot_exec(
+    prompt: str,
+    session_id: Optional[str] = None,
+) -> tuple[str, Optional[str], int, str]:
+    """Run copilot CLI and return (stdout, session_id, exit_code, stderr).
+
+    Note: uses --resume=<session_id> when available to continue review sessions.
+    """
+    copilot = require_copilot()
+    cmd = [copilot]
+    if session_id:
+        cmd.append(f"--resume={session_id}")
+    cmd.extend(["--stream", "--prompt", "-"])
+    try:
+        result = subprocess.run(
+            cmd,
+            input=prompt,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=600,
+        )
+        output = result.stdout
+        new_session_id = parse_copilot_session_id(output) or session_id
+        return output, new_session_id, result.returncode, result.stderr
+    except subprocess.TimeoutExpired:
+        return "", session_id, 2, "copilot exec timed out (600s)"
+
+
 def parse_codex_thread_id(output: str) -> Optional[str]:
     """Extract thread_id from codex --json output.
 
@@ -1291,6 +1350,28 @@ def parse_codex_thread_id(output: str) -> Optional[str]:
             data = json.loads(line)
             if data.get("type") == "thread.started" and "thread_id" in data:
                 return data["thread_id"]
+        except json.JSONDecodeError:
+            continue
+    return None
+
+
+def parse_copilot_session_id(output: str) -> Optional[str]:
+    """Extract session id from copilot output if present."""
+    for line in output.split("\n"):
+        if not line.strip():
+            continue
+        try:
+            data = json.loads(line)
+            if isinstance(data, dict):
+                for key in ("session_id", "thread_id", "conversation_id", "id"):
+                    value = data.get(key)
+                    if isinstance(value, str) and value:
+                        return value
+                session = data.get("session")
+                if isinstance(session, dict):
+                    value = session.get("id")
+                    if isinstance(value, str) and value:
+                        return value
         except json.JSONDecodeError:
             continue
     return None
@@ -1372,13 +1453,13 @@ def build_review_prompt(
     diff_content: str = "",
     files_embedded: bool = False,
 ) -> str:
-    """Build XML-structured review prompt for codex.
+    """Build XML-structured review prompt for codex/copilot.
 
     review_type: 'impl' or 'plan'
     task_specs: Combined task spec content (plan reviews only)
-    embedded_files: Pre-read file contents for codex sandbox mode
+    embedded_files: Pre-read file contents for sandboxed review
     diff_content: Actual git diff output (impl reviews only)
-    files_embedded: True if files are embedded (Windows), False if Codex can read from disk (Unix)
+    files_embedded: True if files are embedded (Windows), False if CLI can read from disk (Unix)
 
     Uses same Carmack-level criteria as RepoPrompt workflow to ensure parity.
     """
@@ -2351,12 +2432,12 @@ def cmd_review_backend(args: argparse.Namespace) -> None:
     """Get review backend for skill conditionals. Returns ASK if not configured."""
     # Priority: FLOW_REVIEW_BACKEND env > config > ASK
     env_val = os.environ.get("FLOW_REVIEW_BACKEND", "").strip()
-    if env_val and env_val in ("rp", "codex", "none"):
+    if env_val and env_val in ("rp", "codex", "copilot", "none"):
         backend = env_val
         source = "env"
     elif ensure_flow_exists():
         cfg_val = get_config("review.backend")
-        if cfg_val and cfg_val in ("rp", "codex", "none"):
+        if cfg_val and cfg_val in ("rp", "codex", "copilot", "none"):
             backend = cfg_val
             source = "config"
         else:
@@ -5230,6 +5311,21 @@ def cmd_codex_check(args: argparse.Namespace) -> None:
             print("codex not available")
 
 
+def cmd_copilot_check(args: argparse.Namespace) -> None:
+    """Check if copilot CLI is available and return version."""
+    copilot = shutil.which("copilot")
+    available = copilot is not None
+    version = get_copilot_version() if available else None
+
+    if args.json:
+        json_output({"available": available, "version": version})
+    else:
+        if available:
+            print(f"copilot available: {version or 'unknown version'}")
+        else:
+            print("copilot not available")
+
+
 def build_standalone_review_prompt(
     base_branch: str, focus: Optional[str], diff_summary: str, files_embedded: bool = True
 ) -> str:
@@ -5555,6 +5651,193 @@ def cmd_codex_impl_review(args: argparse.Namespace) -> None:
         print(f"\nVERDICT={verdict or 'UNKNOWN'}")
 
 
+def cmd_copilot_impl_review(args: argparse.Namespace) -> None:
+    """Run implementation review via copilot."""
+    task_id = args.task
+    base_branch = args.base
+    focus = getattr(args, "focus", None)
+
+    standalone = task_id is None
+
+    if not standalone:
+        if not ensure_flow_exists():
+            error_exit(".flow/ does not exist", use_json=args.json)
+        if not is_task_id(task_id):
+            error_exit(f"Invalid task ID: {task_id}", use_json=args.json)
+
+        flow_dir = get_flow_dir()
+        task_spec_path = flow_dir / TASKS_DIR / f"{task_id}.md"
+        if not task_spec_path.exists():
+            error_exit(f"Task spec not found: {task_spec_path}", use_json=args.json)
+        task_spec = task_spec_path.read_text(encoding="utf-8")
+
+    diff_summary = ""
+    try:
+        diff_result = subprocess.run(
+            ["git", "diff", "--stat", f"{base_branch}..HEAD"],
+            capture_output=True,
+            text=True,
+            cwd=get_repo_root(),
+        )
+        if diff_result.returncode == 0:
+            diff_summary = diff_result.stdout.strip()
+    except (subprocess.CalledProcessError, OSError):
+        pass
+
+    diff_content = ""
+    max_diff_bytes = 50000
+    try:
+        proc = subprocess.Popen(
+            ["git", "diff", f"{base_branch}..HEAD"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            cwd=get_repo_root(),
+        )
+        diff_bytes = proc.stdout.read(max_diff_bytes + 1)
+        was_truncated = len(diff_bytes) > max_diff_bytes
+        if was_truncated:
+            diff_bytes = diff_bytes[:max_diff_bytes]
+        while proc.stdout.read(65536):
+            pass
+        stderr_bytes = proc.stderr.read()
+        proc.stdout.close()
+        proc.stderr.close()
+        returncode = proc.wait()
+
+        if returncode != 0 and stderr_bytes:
+            diff_content = f"[git diff failed: {stderr_bytes.decode('utf-8', errors='replace').strip()}]"
+        else:
+            diff_content = diff_bytes.decode("utf-8", errors="replace").strip()
+            if was_truncated:
+                diff_content += "\n\n... [diff truncated at 50KB]"
+    except (subprocess.CalledProcessError, OSError):
+        pass
+
+    if os.name == "nt":
+        changed_files = get_changed_files(base_branch)
+        embedded_content, embed_stats = get_embedded_file_contents(changed_files)
+    else:
+        embedded_content = ""
+        embed_stats = {
+            "embedded": 0,
+            "total": 0,
+            "bytes": 0,
+            "binary_skipped": [],
+            "deleted_skipped": [],
+            "outside_repo_skipped": [],
+            "budget_skipped": [],
+        }
+
+    files_embedded = os.name == "nt"
+    if standalone:
+        prompt = build_standalone_review_prompt(base_branch, focus, diff_summary, files_embedded)
+        if diff_content:
+            prompt += f"\n\n<diff_content>\n{diff_content}\n</diff_content>"
+        if embedded_content:
+            prompt += f"\n\n<embedded_files>\n{embedded_content}\n</embedded_files>"
+    else:
+        context_hints = gather_context_hints(base_branch)
+        prompt = build_review_prompt(
+            "impl",
+            task_spec,
+            context_hints,
+            diff_summary,
+            embedded_files=embedded_content,
+            diff_content=diff_content,
+            files_embedded=files_embedded,
+        )
+
+    receipt_path = args.receipt if hasattr(args, "receipt") and args.receipt else None
+    session_id = None
+    is_rereview = False
+    if receipt_path:
+        receipt_file = Path(receipt_path)
+        if receipt_file.exists():
+            try:
+                receipt_data = json.loads(receipt_file.read_text(encoding="utf-8"))
+                session_id = receipt_data.get("session_id")
+                is_rereview = session_id is not None
+            except (json.JSONDecodeError, Exception):
+                pass
+
+    if is_rereview:
+        changed_files = get_changed_files(base_branch)
+        if changed_files:
+            rereview_preamble = build_rereview_preamble(
+                changed_files, "implementation", files_embedded
+            )
+            prompt = rereview_preamble + prompt
+
+    output, new_session_id, exit_code, stderr = run_copilot_exec(
+        prompt, session_id=session_id
+    )
+
+    if exit_code != 0:
+        if receipt_path:
+            try:
+                Path(receipt_path).unlink(missing_ok=True)
+            except OSError:
+                pass
+        msg = (stderr or output or "copilot exec failed").strip()
+        error_exit(f"copilot exec failed: {msg}", use_json=args.json, code=2)
+
+    verdict = parse_codex_verdict(output)
+    if not verdict:
+        if receipt_path:
+            try:
+                Path(receipt_path).unlink(missing_ok=True)
+            except OSError:
+                pass
+        error_exit(
+            "Copilot review completed but no verdict found in output. "
+            "Expected <verdict>SHIP</verdict> or <verdict>NEEDS_WORK</verdict>",
+            use_json=args.json,
+            code=2,
+        )
+
+    review_id = task_id if task_id else "branch"
+    session_id_to_write = new_session_id or session_id
+
+    if receipt_path:
+        receipt_data = {
+            "type": "impl_review",
+            "id": review_id,
+            "mode": "copilot",
+            "base": base_branch,
+            "verdict": verdict,
+            "session_id": session_id_to_write,
+            "timestamp": now_iso(),
+            "review": output,
+        }
+        ralph_iter = os.environ.get("RALPH_ITERATION")
+        if ralph_iter:
+            try:
+                receipt_data["iteration"] = int(ralph_iter)
+            except ValueError:
+                pass
+        if focus:
+            receipt_data["focus"] = focus
+        Path(receipt_path).write_text(
+            json.dumps(receipt_data, indent=2) + "\n", encoding="utf-8"
+        )
+
+    if args.json:
+        json_output(
+            {
+                "type": "impl_review",
+                "id": review_id,
+                "verdict": verdict,
+                "session_id": session_id_to_write,
+                "mode": "copilot",
+                "standalone": standalone,
+                "review": output,
+            }
+        )
+    else:
+        print(output)
+        print(f"\nVERDICT={verdict or 'UNKNOWN'}")
+
+
 def cmd_codex_plan_review(args: argparse.Namespace) -> None:
     """Run plan review via codex exec."""
     if not ensure_flow_exists():
@@ -5769,6 +6052,185 @@ def cmd_codex_plan_review(args: argparse.Namespace) -> None:
                 "session_id": thread_id,
                 "mode": "codex",
                 "review": output,  # Full review feedback for fix loop
+            }
+        )
+    else:
+        print(output)
+        print(f"\nVERDICT={verdict or 'UNKNOWN'}")
+
+
+def cmd_copilot_plan_review(args: argparse.Namespace) -> None:
+    """Run plan review via copilot."""
+    if not ensure_flow_exists():
+        error_exit(".flow/ does not exist", use_json=args.json)
+
+    epic_id = args.epic
+    if not is_epic_id(epic_id):
+        error_exit(f"Invalid epic ID: {epic_id}", use_json=args.json)
+
+    files_arg = getattr(args, "files", None)
+    if not files_arg:
+        error_exit(
+            "plan-review requires --files argument (comma-separated CODE file paths). "
+            "On Windows: files are embedded for context. On Unix: used as relevance list. "
+            "Example: --files src/main.py,src/utils.py",
+            use_json=args.json,
+        )
+
+    repo_root = get_repo_root()
+    file_paths = []
+    invalid_paths = []
+    for f in files_arg.split(","):
+        f = f.strip()
+        if not f:
+            continue
+        full_path = (repo_root / f).resolve()
+        try:
+            full_path.relative_to(repo_root)
+            if full_path.exists():
+                file_paths.append(f)
+            else:
+                invalid_paths.append(f"{f} (not found)")
+        except ValueError:
+            invalid_paths.append(f"{f} (outside repo)")
+
+    if invalid_paths:
+        print(f"Warning: Skipping invalid paths: {', '.join(invalid_paths)}", file=sys.stderr)
+
+    if not file_paths:
+        error_exit(
+            "No valid file paths provided. Use --files with comma-separated repo-relative code paths.",
+            use_json=args.json,
+        )
+
+    flow_dir = get_flow_dir()
+    epic_spec_path = flow_dir / SPECS_DIR / f"{epic_id}.md"
+    if not epic_spec_path.exists():
+        error_exit(f"Epic spec not found: {epic_spec_path}", use_json=args.json)
+    epic_spec = epic_spec_path.read_text(encoding="utf-8")
+
+    tasks_dir = flow_dir / TASKS_DIR
+    task_specs_parts = []
+    for task_file in sorted(tasks_dir.glob(f"{epic_id}.*.md")):
+        task_id = task_file.stem
+        task_content = task_file.read_text(encoding="utf-8")
+        task_specs_parts.append(f"### {task_id}\n\n{task_content}")
+
+    task_specs = "\n\n---\n\n".join(task_specs_parts) if task_specs_parts else ""
+
+    if os.name == "nt":
+        embedded_content, embed_stats = get_embedded_file_contents(file_paths)
+    else:
+        embedded_content = ""
+        embed_stats = {
+            "embedded": 0,
+            "total": 0,
+            "bytes": 0,
+            "binary_skipped": [],
+            "deleted_skipped": [],
+            "outside_repo_skipped": [],
+            "budget_skipped": [],
+        }
+
+    base_branch = args.base if hasattr(args, "base") and args.base else "main"
+    context_hints = gather_context_hints(base_branch)
+
+    files_embedded = os.name == "nt"
+    prompt = build_review_prompt(
+        "plan",
+        epic_spec,
+        context_hints,
+        task_specs=task_specs,
+        embedded_files=embedded_content,
+        files_embedded=files_embedded,
+    )
+
+    if file_paths:
+        files_list = "\n".join(f"- {f}" for f in file_paths)
+        prompt += (
+            "\n\n<requested_files>\nThe following code files are relevant to this plan:\n"
+            f"{files_list}\n</requested_files>"
+        )
+
+    receipt_path = args.receipt if hasattr(args, "receipt") and args.receipt else None
+    session_id = None
+    is_rereview = False
+    if receipt_path:
+        receipt_file = Path(receipt_path)
+        if receipt_file.exists():
+            try:
+                receipt_data = json.loads(receipt_file.read_text(encoding="utf-8"))
+                session_id = receipt_data.get("session_id")
+                is_rereview = session_id is not None
+            except (json.JSONDecodeError, Exception):
+                pass
+
+    if is_rereview:
+        repo_root = get_repo_root()
+        spec_files = [str(epic_spec_path.relative_to(repo_root))]
+        for task_file in sorted(tasks_dir.glob(f"{epic_id}.*.md")):
+            spec_files.append(str(task_file.relative_to(repo_root)))
+        rereview_preamble = build_rereview_preamble(spec_files, "plan", files_embedded)
+        prompt = rereview_preamble + prompt
+
+    output, new_session_id, exit_code, stderr = run_copilot_exec(
+        prompt, session_id=session_id
+    )
+
+    if exit_code != 0:
+        if receipt_path:
+            try:
+                Path(receipt_path).unlink(missing_ok=True)
+            except OSError:
+                pass
+        msg = (stderr or output or "copilot exec failed").strip()
+        error_exit(f"copilot exec failed: {msg}", use_json=args.json, code=2)
+
+    verdict = parse_codex_verdict(output)
+    if not verdict:
+        if receipt_path:
+            try:
+                Path(receipt_path).unlink(missing_ok=True)
+            except OSError:
+                pass
+        error_exit(
+            "Copilot review completed but no verdict found in output. "
+            "Expected <verdict>SHIP</verdict> or <verdict>NEEDS_WORK</verdict>",
+            use_json=args.json,
+            code=2,
+        )
+
+    session_id_to_write = new_session_id or session_id
+
+    if receipt_path:
+        receipt_data = {
+            "type": "plan_review",
+            "id": epic_id,
+            "mode": "copilot",
+            "verdict": verdict,
+            "session_id": session_id_to_write,
+            "timestamp": now_iso(),
+            "review": output,
+        }
+        ralph_iter = os.environ.get("RALPH_ITERATION")
+        if ralph_iter:
+            try:
+                receipt_data["iteration"] = int(ralph_iter)
+            except ValueError:
+                pass
+        Path(receipt_path).write_text(
+            json.dumps(receipt_data, indent=2) + "\n", encoding="utf-8"
+        )
+
+    if args.json:
+        json_output(
+            {
+                "type": "plan_review",
+                "id": epic_id,
+                "verdict": verdict,
+                "session_id": session_id_to_write,
+                "mode": "copilot",
+                "review": output,
             }
         )
     else:
@@ -6126,6 +6588,182 @@ def cmd_codex_completion_review(args: argparse.Namespace) -> None:
                 "verdict": verdict,
                 "session_id": session_id_to_write,
                 "mode": "codex",
+                "review": output,
+            }
+        )
+    else:
+        print(output)
+        print(f"\nVERDICT={verdict or 'UNKNOWN'}")
+
+
+def cmd_copilot_completion_review(args: argparse.Namespace) -> None:
+    """Run epic completion review via copilot.
+
+    Verifies that all epic requirements are implemented before closing.
+    Two-phase approach: extract requirements, then verify coverage.
+    """
+    if not ensure_flow_exists():
+        error_exit(".flow/ does not exist", use_json=args.json)
+
+    epic_id = args.epic
+    if not is_epic_id(epic_id):
+        error_exit(f"Invalid epic ID: {epic_id}", use_json=args.json)
+
+    flow_dir = get_flow_dir()
+
+    epic_spec_path = flow_dir / SPECS_DIR / f"{epic_id}.md"
+    if not epic_spec_path.exists():
+        error_exit(f"Epic spec not found: {epic_spec_path}", use_json=args.json)
+    epic_spec = epic_spec_path.read_text(encoding="utf-8")
+
+    tasks_dir = flow_dir / TASKS_DIR
+    task_specs_parts = []
+    for task_file in sorted(tasks_dir.glob(f"{epic_id}.*.md")):
+        task_id = task_file.stem
+        task_content = task_file.read_text(encoding="utf-8")
+        task_specs_parts.append(f"### {task_id}\n\n{task_content}")
+    task_specs = "\n\n---\n\n".join(task_specs_parts) if task_specs_parts else ""
+
+    base_branch = args.base if hasattr(args, "base") and args.base else "main"
+
+    diff_summary = ""
+    try:
+        diff_result = subprocess.run(
+            ["git", "diff", "--stat", f"{base_branch}..HEAD"],
+            capture_output=True,
+            text=True,
+            cwd=get_repo_root(),
+        )
+        if diff_result.returncode == 0:
+            diff_summary = diff_result.stdout.strip()
+    except (subprocess.CalledProcessError, OSError):
+        pass
+
+    diff_content = ""
+    max_diff_bytes = 50000
+    try:
+        proc = subprocess.Popen(
+            ["git", "diff", f"{base_branch}..HEAD"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            cwd=get_repo_root(),
+        )
+        diff_bytes = proc.stdout.read(max_diff_bytes + 1)
+        was_truncated = len(diff_bytes) > max_diff_bytes
+        if was_truncated:
+            diff_bytes = diff_bytes[:max_diff_bytes]
+        while proc.stdout.read(65536):
+            pass
+        stderr_bytes = proc.stderr.read()
+        proc.stdout.close()
+        proc.stderr.close()
+        returncode = proc.wait()
+
+        if returncode != 0 and stderr_bytes:
+            diff_content = f"[git diff failed: {stderr_bytes.decode('utf-8', errors='replace').strip()}]"
+        else:
+            diff_content = diff_bytes.decode("utf-8", errors="replace").strip()
+            if was_truncated:
+                diff_content += "\n\n... [diff truncated at 50KB]"
+    except (subprocess.CalledProcessError, OSError):
+        pass
+
+    if os.name == "nt":
+        changed_files = get_changed_files(base_branch)
+        embedded_content, _ = get_embedded_file_contents(changed_files)
+    else:
+        embedded_content = ""
+
+    files_embedded = os.name == "nt"
+    prompt = build_completion_review_prompt(
+        epic_spec,
+        task_specs,
+        diff_summary,
+        diff_content,
+        embedded_files=embedded_content,
+        files_embedded=files_embedded,
+    )
+
+    receipt_path = args.receipt if hasattr(args, "receipt") and args.receipt else None
+    session_id = None
+    is_rereview = False
+    if receipt_path:
+        receipt_file = Path(receipt_path)
+        if receipt_file.exists():
+            try:
+                receipt_data = json.loads(receipt_file.read_text(encoding="utf-8"))
+                session_id = receipt_data.get("session_id")
+                is_rereview = session_id is not None
+            except (json.JSONDecodeError, Exception):
+                pass
+
+    if is_rereview:
+        changed_files = get_changed_files(base_branch)
+        if changed_files:
+            rereview_preamble = build_rereview_preamble(
+                changed_files, "completion", files_embedded
+            )
+            prompt = rereview_preamble + prompt
+
+    output, new_session_id, exit_code, stderr = run_copilot_exec(
+        prompt, session_id=session_id
+    )
+
+    if exit_code != 0:
+        if receipt_path:
+            try:
+                Path(receipt_path).unlink(missing_ok=True)
+            except OSError:
+                pass
+        msg = (stderr or output or "copilot exec failed").strip()
+        error_exit(f"copilot exec failed: {msg}", use_json=args.json, code=2)
+
+    verdict = parse_codex_verdict(output)
+    if not verdict:
+        if receipt_path:
+            try:
+                Path(receipt_path).unlink(missing_ok=True)
+            except OSError:
+                pass
+        error_exit(
+            "Copilot review completed but no verdict found in output. "
+            "Expected <verdict>SHIP</verdict> or <verdict>NEEDS_WORK</verdict>",
+            use_json=args.json,
+            code=2,
+        )
+
+    session_id_to_write = new_session_id or session_id
+
+    if receipt_path:
+        receipt_data = {
+            "type": "completion_review",
+            "id": epic_id,
+            "mode": "copilot",
+            "base": base_branch,
+            "verdict": verdict,
+            "session_id": session_id_to_write,
+            "timestamp": now_iso(),
+            "review": output,
+        }
+        ralph_iter = os.environ.get("RALPH_ITERATION")
+        if ralph_iter:
+            try:
+                receipt_data["iteration"] = int(ralph_iter)
+            except ValueError:
+                pass
+        Path(receipt_path).write_text(
+            json.dumps(receipt_data, indent=2) + "\n", encoding="utf-8"
+        )
+
+    if args.json:
+        json_output(
+            {
+                "type": "completion_review",
+                "id": epic_id,
+                "base": base_branch,
+                "verdict": verdict,
+                "session_id": session_id_to_write,
+                "mode": "copilot",
                 "review": output,
             }
         )
@@ -7074,6 +7712,58 @@ def main() -> None:
         help="Sandbox mode (auto: danger-full-access on Windows, read-only on Unix)",
     )
     p_codex_completion.set_defaults(func=cmd_codex_completion_review)
+
+    # copilot (Copilot CLI wrappers)
+    p_copilot = subparsers.add_parser("copilot", help="Copilot CLI helpers")
+    copilot_sub = p_copilot.add_subparsers(dest="copilot_cmd", required=True)
+
+    p_copilot_check = copilot_sub.add_parser("check", help="Check copilot availability")
+    p_copilot_check.add_argument("--json", action="store_true", help="JSON output")
+    p_copilot_check.set_defaults(func=cmd_copilot_check)
+
+    p_copilot_impl = copilot_sub.add_parser("impl-review", help="Implementation review")
+    p_copilot_impl.add_argument(
+        "task",
+        nargs="?",
+        default=None,
+        help="Task ID (fn-N.M), optional for standalone",
+    )
+    p_copilot_impl.add_argument("--base", required=True, help="Base branch for diff")
+    p_copilot_impl.add_argument(
+        "--focus", help="Focus areas for standalone review (comma-separated)"
+    )
+    p_copilot_impl.add_argument(
+        "--receipt", help="Receipt file path for session continuity"
+    )
+    p_copilot_impl.add_argument("--json", action="store_true", help="JSON output")
+    p_copilot_impl.set_defaults(func=cmd_copilot_impl_review)
+
+    p_copilot_plan = copilot_sub.add_parser("plan-review", help="Plan review")
+    p_copilot_plan.add_argument("epic", help="Epic ID (fn-N)")
+    p_copilot_plan.add_argument(
+        "--files",
+        required=True,
+        help="Comma-separated file paths to embed for context (required)",
+    )
+    p_copilot_plan.add_argument("--base", default="main", help="Base branch for context")
+    p_copilot_plan.add_argument(
+        "--receipt", help="Receipt file path for session continuity"
+    )
+    p_copilot_plan.add_argument("--json", action="store_true", help="JSON output")
+    p_copilot_plan.set_defaults(func=cmd_copilot_plan_review)
+
+    p_copilot_completion = copilot_sub.add_parser(
+        "completion-review", help="Epic completion review"
+    )
+    p_copilot_completion.add_argument("epic", help="Epic ID (fn-N)")
+    p_copilot_completion.add_argument(
+        "--base", default="main", help="Base branch for diff"
+    )
+    p_copilot_completion.add_argument(
+        "--receipt", help="Receipt file path for session continuity"
+    )
+    p_copilot_completion.add_argument("--json", action="store_true", help="JSON output")
+    p_copilot_completion.set_defaults(func=cmd_copilot_completion_review)
 
     args = parser.parse_args()
     args.func(args)

--- a/.flow/bin/flowctl.py
+++ b/.flow/bin/flowctl.py
@@ -1319,9 +1319,11 @@ def run_copilot_exec(
     Note: uses --resume=<session_id> when available to continue review sessions.
     """
     copilot = require_copilot()
-    if not model:
-        error_exit("Copilot model is required (use --model or COPILOT_MODEL)", use_json=False, code=2)
-    cmd = [copilot, "--model", model]
+    # Model priority: env > parameter (required, no default).
+    effective_model = os.environ.get("FLOW_COPILOT_MODEL") or model
+    if not effective_model:
+        error_exit("Copilot model is required (set FLOW_COPILOT_MODEL or pass --model)", use_json=False, code=2)
+    cmd = [copilot, "--model", effective_model]
     if session_id:
         cmd.append(f"--resume={session_id}")
     cmd.extend(["--allow-all", "--stream", "--prompt", "-"])
@@ -5659,7 +5661,7 @@ def cmd_copilot_impl_review(args: argparse.Namespace) -> None:
     task_id = args.task
     base_branch = args.base
     focus = getattr(args, "focus", None)
-    model = getattr(args, "model", None) or os.environ.get("COPILOT_MODEL")
+    model = getattr(args, "model", None)
 
     standalone = task_id is None
 
@@ -6177,7 +6179,7 @@ def cmd_copilot_plan_review(args: argparse.Namespace) -> None:
         rereview_preamble = build_rereview_preamble(spec_files, "plan", files_embedded)
         prompt = rereview_preamble + prompt
 
-    model = getattr(args, "model", None) or os.environ.get("COPILOT_MODEL")
+    model = getattr(args, "model", None)
     output, new_session_id, exit_code, stderr = run_copilot_exec(
         prompt, session_id=session_id, model=model
     )
@@ -6710,7 +6712,7 @@ def cmd_copilot_completion_review(args: argparse.Namespace) -> None:
             )
             prompt = rereview_preamble + prompt
 
-    model = getattr(args, "model", None) or os.environ.get("COPILOT_MODEL")
+    model = getattr(args, "model", None)
     output, new_session_id, exit_code, stderr = run_copilot_exec(
         prompt, session_id=session_id, model=model
     )
@@ -7735,7 +7737,7 @@ def main() -> None:
         help="Task ID (fn-N.M), optional for standalone",
     )
     p_copilot_impl.add_argument("--base", required=True, help="Base branch for diff")
-    p_copilot_impl.add_argument("--model", required=True, help="Copilot model name")
+    p_copilot_impl.add_argument("--model", help="Copilot model name")
     p_copilot_impl.add_argument(
         "--focus", help="Focus areas for standalone review (comma-separated)"
     )
@@ -7753,7 +7755,7 @@ def main() -> None:
         help="Comma-separated file paths to embed for context (required)",
     )
     p_copilot_plan.add_argument("--base", default="main", help="Base branch for context")
-    p_copilot_plan.add_argument("--model", required=True, help="Copilot model name")
+    p_copilot_plan.add_argument("--model", help="Copilot model name")
     p_copilot_plan.add_argument(
         "--receipt", help="Receipt file path for session continuity"
     )
@@ -7767,7 +7769,7 @@ def main() -> None:
     p_copilot_completion.add_argument(
         "--base", default="main", help="Base branch for diff"
     )
-    p_copilot_completion.add_argument("--model", required=True, help="Copilot model name")
+    p_copilot_completion.add_argument("--model", help="Copilot model name")
     p_copilot_completion.add_argument(
         "--receipt", help="Receipt file path for session continuity"
     )

--- a/.flow/bin/flowctl.py
+++ b/.flow/bin/flowctl.py
@@ -1312,16 +1312,19 @@ def run_codex_exec(
 def run_copilot_exec(
     prompt: str,
     session_id: Optional[str] = None,
+    model: Optional[str] = None,
 ) -> tuple[str, Optional[str], int, str]:
     """Run copilot CLI and return (stdout, session_id, exit_code, stderr).
 
     Note: uses --resume=<session_id> when available to continue review sessions.
     """
     copilot = require_copilot()
-    cmd = [copilot]
+    if not model:
+        error_exit("Copilot model is required (use --model or COPILOT_MODEL)", use_json=False, code=2)
+    cmd = [copilot, "--model", model]
     if session_id:
         cmd.append(f"--resume={session_id}")
-    cmd.extend(["--stream", "--prompt", "-"])
+    cmd.extend(["--allow-all", "--stream", "--prompt", "-"])
     try:
         result = subprocess.run(
             cmd,
@@ -5656,6 +5659,7 @@ def cmd_copilot_impl_review(args: argparse.Namespace) -> None:
     task_id = args.task
     base_branch = args.base
     focus = getattr(args, "focus", None)
+    model = getattr(args, "model", None) or os.environ.get("COPILOT_MODEL")
 
     standalone = task_id is None
 
@@ -5769,7 +5773,7 @@ def cmd_copilot_impl_review(args: argparse.Namespace) -> None:
             prompt = rereview_preamble + prompt
 
     output, new_session_id, exit_code, stderr = run_copilot_exec(
-        prompt, session_id=session_id
+        prompt, session_id=session_id, model=model
     )
 
     if exit_code != 0:
@@ -6173,8 +6177,9 @@ def cmd_copilot_plan_review(args: argparse.Namespace) -> None:
         rereview_preamble = build_rereview_preamble(spec_files, "plan", files_embedded)
         prompt = rereview_preamble + prompt
 
+    model = getattr(args, "model", None) or os.environ.get("COPILOT_MODEL")
     output, new_session_id, exit_code, stderr = run_copilot_exec(
-        prompt, session_id=session_id
+        prompt, session_id=session_id, model=model
     )
 
     if exit_code != 0:
@@ -6705,8 +6710,9 @@ def cmd_copilot_completion_review(args: argparse.Namespace) -> None:
             )
             prompt = rereview_preamble + prompt
 
+    model = getattr(args, "model", None) or os.environ.get("COPILOT_MODEL")
     output, new_session_id, exit_code, stderr = run_copilot_exec(
-        prompt, session_id=session_id
+        prompt, session_id=session_id, model=model
     )
 
     if exit_code != 0:
@@ -7729,6 +7735,7 @@ def main() -> None:
         help="Task ID (fn-N.M), optional for standalone",
     )
     p_copilot_impl.add_argument("--base", required=True, help="Base branch for diff")
+    p_copilot_impl.add_argument("--model", required=True, help="Copilot model name")
     p_copilot_impl.add_argument(
         "--focus", help="Focus areas for standalone review (comma-separated)"
     )
@@ -7746,6 +7753,7 @@ def main() -> None:
         help="Comma-separated file paths to embed for context (required)",
     )
     p_copilot_plan.add_argument("--base", default="main", help="Base branch for context")
+    p_copilot_plan.add_argument("--model", required=True, help="Copilot model name")
     p_copilot_plan.add_argument(
         "--receipt", help="Receipt file path for session continuity"
     )
@@ -7759,6 +7767,7 @@ def main() -> None:
     p_copilot_completion.add_argument(
         "--base", default="main", help="Base branch for diff"
     )
+    p_copilot_completion.add_argument("--model", required=True, help="Copilot model name")
     p_copilot_completion.add_argument(
         "--receipt", help="Receipt file path for session continuity"
     )

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the gmickel-claude-marketplace.
 ### Added
 
 - **Epic dependency visualization skill** — New `flow-next-deps` skill shows epic dependency graphs, blocking chains, and execution phases. Triggers on "what's blocking", "execution order", "critical path", "which epics can run in parallel". Uses flowctl for data access with jq-based phase computation. Thanks [@clairernovotny](https://github.com/clairernovotny)! (PR #85)
+- **Copilot review backend** — Added GitHub Copilot CLI review backend with the same prompts/verdict parsing/receipts as Codex. Updated Ralph guard enforcement and documentation across flowctl/README/Ralph.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 >
 > 🤖 **[Ralph mode](plugins/flow-next/docs/ralph.md)**: Ship features while you sleep. Fresh context per iteration, multi-model review gates, auto-blocks stuck tasks.
 >
-> 📡 **Cross-platform reviews**: [RepoPrompt](https://repoprompt.com/?atp=KJbuL4) (macOS) or [Codex CLI](plugins/flow-next/README.md#cross-model-reviews) (any OS)
+> 📡 **Cross-platform reviews**: [RepoPrompt](https://repoprompt.com/?atp=KJbuL4) (macOS) or [Codex/Copilot CLI](plugins/flow-next/README.md#cross-model-reviews) (any OS)
 >
 > 🧪 **OpenCode user?** Try [flow-next-opencode](https://github.com/gmickel/flow-next-opencode) (experimental port)
 
@@ -67,7 +67,7 @@ This marketplace ships plugins that fix these problems.
 |---------|----------|
 | Context drift | **Re-anchoring** before EVERY task — re-reads specs + git state from `.flow/` |
 | 200K token limits | **Fresh context per task** — worker subagent starts clean each task |
-| Single-model blind spots | **Cross-model reviews** — RepoPrompt or Codex as second opinion |
+| Single-model blind spots | **Cross-model reviews** — RepoPrompt, Codex, or Copilot as second opinion |
 | Forgotten requirements | **Dependency graphs** — tasks declare blockers, nothing runs out of order |
 | "It worked on my machine" | **Evidence recording** — commits, test output, PRs tracked per task |
 | Infinite retry loops | **Auto-block stuck tasks** — fails after N attempts, moves on |

--- a/plugins/flow-next/.claude-plugin/plugin.json
+++ b/plugins/flow-next/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "flow-next",
-  "version": "0.20.1",
+  "version": "0.20.2",
   "description": "Zero-dependency planning + execution with .flow/ task tracking and Ralph autonomous mode (multi-model review gates). Worker subagent per task for context isolation. Prime assesses 8 pillars (48 criteria) with GitHub API integration. Includes 20 subagents, 11 commands, 16 skills.",
   "author": {
     "name": "Gordon Mickel",

--- a/plugins/flow-next/README.md
+++ b/plugins/flow-next/README.md
@@ -862,8 +862,8 @@ copilot auth
 /flow-next:impl-review --review=copilot
 
 # Or via flowctl directly
-flowctl copilot plan-review fn-1 --files "src/auth.ts,src/config.ts"
-flowctl copilot impl-review fn-1.3 --base main
+flowctl copilot plan-review fn-1 --files "src/auth.ts,src/config.ts" --model gpt-5.1
+flowctl copilot impl-review fn-1.3 --base main --model gpt-5.1
 ```
 
 **Verify installation:**

--- a/plugins/flow-next/README.md
+++ b/plugins/flow-next/README.md
@@ -20,7 +20,7 @@
 
 🌐 **Prefer a visual overview?** See the [Flow-Next app page](https://mickel.tech/apps/flow-next) for diagrams and examples.
 
-> **New: Codex Review Backend.** Cross-model reviews now work on Linux/Windows via OpenAI Codex CLI. Same Carmack-level criteria as RepoPrompt. See [Cross-Model Reviews](#cross-model-reviews) for setup.
+> **New: Copilot Review Backend.** Cross-model reviews now work on Linux/Windows via GitHub Copilot CLI. Same Carmack-level criteria as RepoPrompt. See [Cross-Model Reviews](#cross-model-reviews) for setup.
 
 ---
 
@@ -145,7 +145,7 @@ Two models catch what one misses.
 ```
 
 This is technically optional but **highly recommended**. It:
-- **Configures review backend** (RepoPrompt, Codex, or none) — required for cross-model reviews
+- **Configures review backend** (RepoPrompt, Codex, Copilot, or none) — required for cross-model reviews
 - Copies `flowctl` to `.flow/bin/` for direct CLI access
 - Adds flow-next instructions to CLAUDE.md/AGENTS.md (helps other AI tools understand your project)
 - Creates `.flow/usage.md` with full CLI reference
@@ -551,7 +551,7 @@ Ralph writes run artifacts under `scripts/ralph/runs/`, including review receipt
 
 Autonomous coding agents are taking the industry by storm—loop until done, commit, repeat. Most solutions gate progress by tests and linting alone. Ralph goes further.
 
-**Multi-model review gates**: Ralph uses [RepoPrompt](https://repoprompt.com/?atp=KJbuL4) (macOS) or OpenAI Codex CLI (cross-platform) to send plan and implementation reviews to a *different* model. A second set of eyes catches blind spots that self-review misses. RepoPrompt's builder provides full file context; Codex uses context hints from changed files.
+**Multi-model review gates**: Ralph uses [RepoPrompt](https://repoprompt.com/?atp=KJbuL4) (macOS), OpenAI Codex CLI, or GitHub Copilot CLI (cross-platform) to send plan and implementation reviews to a *different* model. A second set of eyes catches blind spots that self-review misses. RepoPrompt's builder provides full file context; Codex and Copilot use context hints from changed files.
 
 **Review loops until Ship**: Reviews don't just flag issues—they block progress until resolved. Ralph runs fix → re-review cycles until the reviewer returns `<verdict>SHIP</verdict>`. No "LGTM with nits" that get ignored.
 
@@ -766,7 +766,7 @@ Each epic and task gets its own JSON + markdown file pair. Merge conflicts are r
 
 ### Cross-Model Reviews
 
-Two models catch what one misses. Reviews use a second model (via RepoPrompt or Codex) to verify plans and implementations before they ship.
+Two models catch what one misses. Reviews use a second model (via RepoPrompt, Codex, or Copilot) to verify plans and implementations before they ship.
 
 **Three review types:**
 - **Plan reviews** — Verify architecture before coding starts
@@ -840,12 +840,43 @@ flowctl codex impl-review fn-1.3 --base main
 flowctl codex check
 ```
 
+#### Copilot (Cross-Platform Alternative)
+
+GitHub Copilot CLI works on any platform (macOS, Linux, Windows).
+
+**Why use Copilot:**
+- Cross-platform (no macOS requirement)
+- Terminal-based (no GUI needed)
+- Same Carmack-level review criteria as RepoPrompt
+
+**Trade-off:** Uses heuristic context hints from changed files rather than RepoPrompt's intelligent file selection.
+
+**Setup:**
+```bash
+copilot auth
+```
+
+**Usage:**
+```bash
+/flow-next:plan-review fn-1 --review=copilot
+/flow-next:impl-review --review=copilot
+
+# Or via flowctl directly
+flowctl copilot plan-review fn-1 --files "src/auth.ts,src/config.ts"
+flowctl copilot impl-review fn-1.3 --base main
+```
+
+**Verify installation:**
+```bash
+flowctl copilot check
+```
+
 #### Configuration
 
 Set default review backend:
 ```bash
 # Per-project (saved in .flow/config.json)
-flowctl config set review.backend rp      # or codex, or none
+flowctl config set review.backend rp      # or codex, copilot, or none
 
 # Per-session (environment variable)
 export FLOW_REVIEW_BACKEND=codex
@@ -860,8 +891,8 @@ Priority: `--review=...` argument > `FLOW_REVIEW_BACKEND` env > `.flow/config.js
 | Scenario | Recommendation |
 |----------|----------------|
 | macOS with GUI available | RepoPrompt (better context) |
-| Linux/Windows | Codex (only option) |
-| CI/headless environments | Codex (no GUI needed) |
+| Linux/Windows | Codex or Copilot |
+| CI/headless environments | Codex or Copilot |
 | Ralph overnight runs | Either works; RP auto-opens with --create (1.5.68+) |
 
 Without a backend configured, reviews fail with a clear error. Run `/flow-next:setup` or pass `--review=X`.
@@ -991,10 +1022,10 @@ Natural language also works:
 
 | Command | Available Flags |
 |---------|-----------------|
-| `/flow-next:plan` | `--research=rp\|grep`, `--review=rp\|codex\|export\|none`, `--no-review` |
-| `/flow-next:work` | `--branch=current\|new\|worktree`, `--review=rp\|codex\|export\|none`, `--no-review` |
-| `/flow-next:plan-review` | `--review=rp\|codex\|export` |
-| `/flow-next:impl-review` | `--review=rp\|codex\|export` |
+| `/flow-next:plan` | `--research=rp\|grep`, `--review=rp\|codex\|copilot\|export\|none`, `--no-review` |
+| `/flow-next:work` | `--branch=current\|new\|worktree`, `--review=rp\|codex\|copilot\|export\|none`, `--no-review` |
+| `/flow-next:plan-review` | `--review=rp\|codex\|copilot\|export` |
+| `/flow-next:impl-review` | `--review=rp\|codex\|copilot\|export` |
 | `/flow-next:prime` | `--report-only`, `--fix-all` |
 | `/flow-next:sync` | `--dry-run` |
 
@@ -1005,7 +1036,7 @@ Detailed input documentation for each command.
 #### `/flow-next:plan`
 
 ```
-/flow-next:plan <idea or fn-N> [--research=rp|grep] [--review=rp|codex|export|none]
+/flow-next:plan <idea or fn-N> [--research=rp|grep] [--review=rp|codex|copilot|export|none]
 ```
 
 | Input | Description |
@@ -1014,13 +1045,13 @@ Detailed input documentation for each command.
 | `fn-N` | Existing epic ID to update the plan |
 | `--research=rp` | Use RepoPrompt context-scout for deeper codebase discovery |
 | `--research=grep` | Use grep-based repo-scout (default, faster) |
-| `--review=rp\|codex\|export\|none` | Review backend after planning |
+| `--review=rp\|codex\|copilot\|export\|none` | Review backend after planning |
 | `--no-review` | Shorthand for `--review=none` |
 
 #### `/flow-next:work`
 
 ```
-/flow-next:work <id|file> [--branch=current|new|worktree] [--review=rp|codex|export|none]
+/flow-next:work <id|file> [--branch=current|new|worktree] [--review=rp|codex|copilot|export|none]
 ```
 
 | Input | Description |
@@ -1031,7 +1062,7 @@ Detailed input documentation for each command.
 | `--branch=current` | Work on current branch |
 | `--branch=new` | Create new branch `fn-N-slug` (default) |
 | `--branch=worktree` | Create git worktree for isolated work |
-| `--review=rp\|codex\|export\|none` | Review backend after work |
+| `--review=rp\|codex\|copilot\|export\|none` | Review backend after work |
 | `--no-review` | Shorthand for `--review=none` |
 
 #### `/flow-next:interview`
@@ -1052,7 +1083,7 @@ Deep questioning (40+ questions) to surface requirements, edge cases, and decisi
 #### `/flow-next:plan-review`
 
 ```
-/flow-next:plan-review <fn-N> [--review=rp|codex|export] [focus areas]
+/flow-next:plan-review <fn-N> [--review=rp|codex|copilot|export] [focus areas]
 ```
 
 | Input | Description |
@@ -1060,6 +1091,7 @@ Deep questioning (40+ questions) to surface requirements, edge cases, and decisi
 | `fn-N` | Epic ID to review |
 | `--review=rp` | Use RepoPrompt (macOS, visual builder) |
 | `--review=codex` | Use OpenAI Codex CLI (cross-platform) |
+| `--review=copilot` | Use GitHub Copilot CLI (cross-platform) |
 | `--review=export` | Export context for manual review |
 | `[focus areas]` | Optional: "focus on security" or "check API design" |
 
@@ -1068,13 +1100,14 @@ Carmack-level criteria: Completeness, Feasibility, Clarity, Architecture, Risks,
 #### `/flow-next:impl-review`
 
 ```
-/flow-next:impl-review [--review=rp|codex|export] [focus areas]
+/flow-next:impl-review [--review=rp|codex|copilot|export] [focus areas]
 ```
 
 | Input | Description |
 |-------|-------------|
 | `--review=rp` | Use RepoPrompt (macOS, visual builder) |
 | `--review=codex` | Use OpenAI Codex CLI (cross-platform) |
+| `--review=copilot` | Use GitHub Copilot CLI (cross-platform) |
 | `--review=export` | Export context for manual review |
 | `[focus areas]` | Optional: "focus on performance" or "check error handling" |
 
@@ -1083,7 +1116,7 @@ Reviews current branch changes. Carmack-level criteria: Correctness, Simplicity,
 #### `/flow-next:epic-review`
 
 ```
-/flow-next:epic-review <fn-N> [--review=rp|codex|none]
+/flow-next:epic-review <fn-N> [--review=rp|codex|copilot|none]
 ```
 
 | Input | Description |
@@ -1091,6 +1124,7 @@ Reviews current branch changes. Carmack-level criteria: Correctness, Simplicity,
 | `fn-N` | Epic ID to review |
 | `--review=rp` | Use RepoPrompt (macOS, visual builder) |
 | `--review=codex` | Use OpenAI Codex CLI (cross-platform) |
+| `--review=copilot` | Use GitHub Copilot CLI (cross-platform) |
 | `--review=none` | Skip review |
 
 Reviews epic implementation against spec. Runs after all tasks complete. Catches requirement gaps, missing functionality, incomplete doc updates.
@@ -1139,7 +1173,7 @@ No arguments. Scaffolds `scripts/ralph/` for autonomous operation.
 ```
 
 No arguments. Optional setup that:
-- Configures review backend (rp, codex, or none)
+- Configures review backend (rp, codex, copilot, or none)
 - Copies flowctl to `.flow/bin/`
 - Adds flow-next instructions to CLAUDE.md/AGENTS.md
 
@@ -1417,8 +1451,9 @@ This creates a complete audit trail: what was planned, what was done, how it was
 
 - Python 3.8+
 - git
-- Optional: [RepoPrompt](https://repoprompt.com/?atp=KJbuL4) for macOS GUI reviews + enables **context-scout** (deeper codebase discovery than repo-scout). Reviews work without it via Codex backend.
+- Optional: [RepoPrompt](https://repoprompt.com/?atp=KJbuL4) for macOS GUI reviews + enables **context-scout** (deeper codebase discovery than repo-scout). Reviews work without it via Codex or Copilot backend.
 - Optional: OpenAI Codex CLI (`npm install -g @openai/codex`) for cross-platform terminal-based reviews
+- Optional: GitHub Copilot CLI (`copilot auth`) for cross-platform terminal-based reviews
 
 Without a review backend, reviews are skipped.
 

--- a/plugins/flow-next/README.md
+++ b/plugins/flow-next/README.md
@@ -862,8 +862,8 @@ copilot auth
 /flow-next:impl-review --review=copilot
 
 # Or via flowctl directly
-flowctl copilot plan-review fn-1 --files "src/auth.ts,src/config.ts" --model gpt-5.1
-flowctl copilot impl-review fn-1.3 --base main --model gpt-5.1
+flowctl copilot plan-review fn-1 --files "src/auth.ts,src/config.ts" --model gpt-5.2
+flowctl copilot impl-review fn-1.3 --base main --model gpt-5.2
 ```
 
 **Verify installation:**

--- a/plugins/flow-next/commands/flow-next/epic-review.md
+++ b/plugins/flow-next/commands/flow-next/epic-review.md
@@ -1,7 +1,7 @@
 ---
 name: flow-next:epic-review
 description: Epic completion review - verify implementation matches spec
-argument-hint: "<fn-N> [--review=rp|codex|none]"
+argument-hint: "<fn-N> [--review=rp|codex|copilot|none]"
 ---
 
 # IMPORTANT: This command MUST invoke the skill `flow-next-epic-review`

--- a/plugins/flow-next/commands/flow-next/impl-review.md
+++ b/plugins/flow-next/commands/flow-next/impl-review.md
@@ -1,7 +1,7 @@
 ---
 name: flow-next:impl-review
-description: John Carmack-level implementation review via RepoPrompt or Codex
-argument-hint: "[--review=rp|codex|export] [focus areas]"
+description: John Carmack-level implementation review via RepoPrompt, Codex, or Copilot
+argument-hint: "[--review=rp|codex|copilot|export] [focus areas]"
 ---
 
 # IMPORTANT: This command MUST invoke the skill `flow-next-impl-review`

--- a/plugins/flow-next/commands/flow-next/plan-review.md
+++ b/plugins/flow-next/commands/flow-next/plan-review.md
@@ -1,7 +1,7 @@
 ---
 name: flow-next:plan-review
-description: Carmack-level plan review via RepoPrompt or Codex
-argument-hint: "<fn-N> [--review=rp|codex|export] [focus areas]"
+description: Carmack-level plan review via RepoPrompt, Codex, or Copilot
+argument-hint: "<fn-N> [--review=rp|codex|copilot|export] [focus areas]"
 ---
 
 # IMPORTANT: This command MUST invoke the skill `flow-next-plan-review`

--- a/plugins/flow-next/docs/flowctl.md
+++ b/plugins/flow-next/docs/flowctl.md
@@ -668,16 +668,16 @@ flowctl copilot check [--json]
 
 # Implementation review (reviews code changes for a task)
 flowctl copilot impl-review <task-id> --base <branch> --model <model> [--receipt <path>] [--json]
-# Example: flowctl copilot impl-review fn-1.3 --base main --model gpt-5.1 --receipt /tmp/impl-fn-1.3.json
+# Example: flowctl copilot impl-review fn-1.3 --base main --model gpt-5.2 --receipt /tmp/impl-fn-1.3.json
 
 # Plan review (reviews epic spec before implementation)
 flowctl copilot plan-review <epic-id> --files <file1,file2,...> --model <model> [--receipt <path>] [--json]
-# Example: flowctl copilot plan-review fn-1 --files "src/auth.ts,src/config.ts" --model gpt-5.1 --receipt /tmp/plan-fn-1.json
+# Example: flowctl copilot plan-review fn-1 --files "src/auth.ts,src/config.ts" --model gpt-5.2 --receipt /tmp/plan-fn-1.json
 # Note: Epic/task specs are included automatically; --files should be CODE files for repository context.
 
 # Completion review (reviews epic implementation against spec)
 flowctl copilot completion-review <epic-id> --model <model> [--receipt <path>] [--json]
-# Example: flowctl copilot completion-review fn-1 --model gpt-5.1 --receipt /tmp/completion-fn-1.json
+# Example: flowctl copilot completion-review fn-1 --model gpt-5.2 --receipt /tmp/completion-fn-1.json
 # Runs after all tasks done; verifies implementation matches spec requirements
 ```
 
@@ -685,7 +685,7 @@ flowctl copilot completion-review <epic-id> --model <model> [--receipt <path>] [
 
 1. **Gather context hints** — Analyzes changed files, extracts symbols (functions, classes), finds references in unchanged files
 2. **Build review prompt** — Uses same Carmack-level criteria as RepoPrompt (7 criteria each for plan/impl)
-3. **Run copilot** — Executes `copilot --model <model> --allow-all --stream --prompt -` with the prompt on stdin (model required; flowctl uses `--model` or `COPILOT_MODEL`)
+3. **Run copilot** — Executes `copilot --model <model> --allow-all --stream --prompt -` with the prompt on stdin (model required via `--model` or `FLOW_COPILOT_MODEL`)
 4. **Parse verdict** — Extracts `<verdict>SHIP|NEEDS_WORK|MAJOR_RETHINK</verdict>` from output
 5. **Write receipt** — If `--receipt` provided, writes JSON for Ralph gating
 

--- a/plugins/flow-next/docs/flowctl.md
+++ b/plugins/flow-next/docs/flowctl.md
@@ -7,7 +7,7 @@ CLI for `.flow/` task tracking. Agents must use flowctl for all writes.
 ## Available Commands
 
 ```
-init, detect, epic, task, dep, show, epics, tasks, list, cat, ready, next, start, done, block, validate, config, memory, prep-chat, rp, codex, checkpoint, status, state-path, migrate-state
+init, detect, epic, task, dep, show, epics, tasks, list, cat, ready, next, start, done, block, validate, config, memory, prep-chat, rp, codex, copilot, checkpoint, status, state-path, migrate-state
 ```
 
 ## Multi-User Safety
@@ -446,7 +446,7 @@ flowctl config get review.backend [--json]
 
 # Set a config value
 flowctl config set memory.enabled true [--json]
-flowctl config set review.backend codex [--json]  # rp, codex, or none
+flowctl config set review.backend codex [--json]  # rp, codex, copilot, or none
 
 # Toggle boolean config
 flowctl config toggle memory.enabled [--json]
@@ -458,7 +458,7 @@ flowctl config toggle memory.enabled [--json]
 |-----|------|---------|-------------|
 | `memory.enabled` | bool | `false` | Enable memory system |
 | `planSync.enabled` | bool | `false` | Enable plan-sync after task completion |
-| `review.backend` | string | `null` | Default review backend (`rp`, `codex`, `none`). If unset, review commands require `--review` or `FLOW_REVIEW_BACKEND`. |
+| `review.backend` | string | `null` | Default review backend (`rp`, `codex`, `copilot`, `none`). If unset, review commands require `--review` or `FLOW_REVIEW_BACKEND`. |
 
 Priority: `--review=...` argument > `FLOW_REVIEW_BACKEND` env > `.flow/config.json` > error.
 
@@ -651,6 +651,79 @@ Completion review receipt:
 
 **Note:** After plugin update, re-run `/flow-next:setup` or `/flow-next:ralph-init` to get sandbox fixes.
 
+### copilot
+
+GitHub Copilot CLI wrappers — cross-platform alternative to RepoPrompt.
+
+**Requirements:**
+```bash
+copilot auth
+```
+
+**Commands:**
+
+```bash
+# Verify copilot is available
+flowctl copilot check [--json]
+
+# Implementation review (reviews code changes for a task)
+flowctl copilot impl-review <task-id> --base <branch> [--receipt <path>] [--json]
+# Example: flowctl copilot impl-review fn-1.3 --base main --receipt /tmp/impl-fn-1.3.json
+
+# Plan review (reviews epic spec before implementation)
+flowctl copilot plan-review <epic-id> --files <file1,file2,...> [--receipt <path>] [--json]
+# Example: flowctl copilot plan-review fn-1 --files "src/auth.ts,src/config.ts" --receipt /tmp/plan-fn-1.json
+# Note: Epic/task specs are included automatically; --files should be CODE files for repository context.
+
+# Completion review (reviews epic implementation against spec)
+flowctl copilot completion-review <epic-id> [--receipt <path>] [--json]
+# Example: flowctl copilot completion-review fn-1 --receipt /tmp/completion-fn-1.json
+# Runs after all tasks done; verifies implementation matches spec requirements
+```
+
+**How it works:**
+
+1. **Gather context hints** — Analyzes changed files, extracts symbols (functions, classes), finds references in unchanged files
+2. **Build review prompt** — Uses same Carmack-level criteria as RepoPrompt (7 criteria each for plan/impl)
+3. **Run copilot** — Executes `copilot --prompt -` with the prompt on stdin
+4. **Parse verdict** — Extracts `<verdict>SHIP|NEEDS_WORK|MAJOR_RETHINK</verdict>` from output
+5. **Write receipt** — If `--receipt` provided, writes JSON for Ralph gating
+
+**Review criteria (identical to RepoPrompt):**
+
+| Review | Criteria |
+|--------|----------|
+| Plan | Completeness, Feasibility, Clarity, Architecture, Risks, Scope, Testability |
+| Impl | Correctness, Simplicity, DRY, Architecture, Edge Cases, Tests, Security |
+
+**Receipt schema (Ralph-compatible):**
+
+Impl review receipt:
+```json
+{
+  "type": "impl_review",
+  "id": "fn-1.3",
+  "mode": "copilot",
+  "verdict": "SHIP",
+  "session_id": "copilot-session-xyz",
+  "timestamp": "2026-01-11T10:30:00Z"
+}
+```
+
+Completion review receipt:
+```json
+{
+  "type": "completion_review",
+  "id": "fn-1",
+  "mode": "copilot",
+  "verdict": "SHIP",
+  "session_id": "copilot-session-xyz",
+  "timestamp": "2026-01-11T10:30:00Z"
+}
+```
+
+**Session continuity:** Receipts include `session_id` parsed from Copilot output. Re-reviews resume with `copilot --resume=<session_id>` when available.
+
 ### checkpoint
 
 Save and restore epic state (used during review-fix cycles).
@@ -725,7 +798,7 @@ What it does:
 
 ## Ralph Receipts
 
-RepoPrompt review receipts are written by the review skills (not flowctl commands). Codex review receipts are written by `flowctl codex impl-review` and `flowctl codex completion-review` when `--receipt` is provided. Ralph sets `REVIEW_RECEIPT_PATH` to coordinate both.
+RepoPrompt review receipts are written by the review skills (not flowctl commands). Codex and Copilot review receipts are written by `flowctl codex impl-review`, `flowctl codex completion-review`, `flowctl copilot impl-review`, or `flowctl copilot completion-review` when `--receipt` is provided. Ralph sets `REVIEW_RECEIPT_PATH` to coordinate both.
 
 See: [Ralph deep dive](ralph.md)
 

--- a/plugins/flow-next/docs/flowctl.md
+++ b/plugins/flow-next/docs/flowctl.md
@@ -667,17 +667,17 @@ copilot auth
 flowctl copilot check [--json]
 
 # Implementation review (reviews code changes for a task)
-flowctl copilot impl-review <task-id> --base <branch> [--receipt <path>] [--json]
-# Example: flowctl copilot impl-review fn-1.3 --base main --receipt /tmp/impl-fn-1.3.json
+flowctl copilot impl-review <task-id> --base <branch> --model <model> [--receipt <path>] [--json]
+# Example: flowctl copilot impl-review fn-1.3 --base main --model gpt-5.1 --receipt /tmp/impl-fn-1.3.json
 
 # Plan review (reviews epic spec before implementation)
-flowctl copilot plan-review <epic-id> --files <file1,file2,...> [--receipt <path>] [--json]
-# Example: flowctl copilot plan-review fn-1 --files "src/auth.ts,src/config.ts" --receipt /tmp/plan-fn-1.json
+flowctl copilot plan-review <epic-id> --files <file1,file2,...> --model <model> [--receipt <path>] [--json]
+# Example: flowctl copilot plan-review fn-1 --files "src/auth.ts,src/config.ts" --model gpt-5.1 --receipt /tmp/plan-fn-1.json
 # Note: Epic/task specs are included automatically; --files should be CODE files for repository context.
 
 # Completion review (reviews epic implementation against spec)
-flowctl copilot completion-review <epic-id> [--receipt <path>] [--json]
-# Example: flowctl copilot completion-review fn-1 --receipt /tmp/completion-fn-1.json
+flowctl copilot completion-review <epic-id> --model <model> [--receipt <path>] [--json]
+# Example: flowctl copilot completion-review fn-1 --model gpt-5.1 --receipt /tmp/completion-fn-1.json
 # Runs after all tasks done; verifies implementation matches spec requirements
 ```
 
@@ -685,7 +685,7 @@ flowctl copilot completion-review <epic-id> [--receipt <path>] [--json]
 
 1. **Gather context hints** — Analyzes changed files, extracts symbols (functions, classes), finds references in unchanged files
 2. **Build review prompt** — Uses same Carmack-level criteria as RepoPrompt (7 criteria each for plan/impl)
-3. **Run copilot** — Executes `copilot --prompt -` with the prompt on stdin
+3. **Run copilot** — Executes `copilot --model <model> --allow-all --stream --prompt -` with the prompt on stdin (model required; flowctl uses `--model` or `COPILOT_MODEL`)
 4. **Parse verdict** — Extracts `<verdict>SHIP|NEEDS_WORK|MAJOR_RETHINK</verdict>` from output
 5. **Write receipt** — If `--receipt` provided, writes JSON for Ralph gating
 

--- a/plugins/flow-next/docs/ralph.md
+++ b/plugins/flow-next/docs/ralph.md
@@ -22,6 +22,7 @@ Ralph is Flow-Next's repo-local autonomous harness. It loops over tasks, applies
 - [Review Backends](#review-backends)
   - [RepoPrompt](#repoprompt-integration)
   - [Codex CLI](#codex-integration)
+  - [Copilot CLI](#copilot-integration)
 - [Run Artifacts](#run-artifacts)
 - [Controlling Ralph](#controlling-ralph)
 - [Testing & Debugging](#testing--debugging)
@@ -60,8 +61,8 @@ Creates `scripts/ralph/` with:
 Edit `scripts/ralph/config.env`:
 
 ```bash
-PLAN_REVIEW=codex   # rp, codex, or none
-WORK_REVIEW=codex   # rp, codex, or none
+PLAN_REVIEW=codex   # rp, codex, copilot, or none
+WORK_REVIEW=codex   # rp, codex, copilot, or none
 ```
 
 ### 3. Test
@@ -183,6 +184,7 @@ A second model verifies code. Two models catch what one misses.
 |---------|----------|---------|-------------|
 | `rp` | macOS (GUI) | Full file context via Builder | Yes |
 | `codex` | Cross-platform | Heuristic context from changed files | Fallback |
+| `copilot` | Cross-platform | Heuristic context from changed files | Fallback |
 | `none` | Any | — | Not for production |
 
 Two review types:
@@ -217,7 +219,7 @@ Both settings are required for plan reviews:
 ```bash
 # config.env
 REQUIRE_PLAN_REVIEW=1   # Gate: don't start work until plans reviewed
-PLAN_REVIEW=codex       # Backend: rp, codex, or export
+PLAN_REVIEW=codex       # Backend: rp, codex, copilot, or export
 ```
 
 | `REQUIRE_PLAN_REVIEW` | `PLAN_REVIEW` | Behavior |
@@ -225,6 +227,7 @@ PLAN_REVIEW=codex       # Backend: rp, codex, or export
 | `0` | any | Plans auto-ship, work starts immediately |
 | `1` | `rp` | Plans reviewed via RepoPrompt |
 | `1` | `codex` | Plans reviewed via Codex CLI |
+| `1` | `copilot` | Plans reviewed via Copilot CLI |
 | `1` | `export` | Context exported for manual review |
 | `1` | `none` | **Blocked forever** — no backend to review |
 
@@ -248,7 +251,7 @@ When `flowctl next` returns `status=plan`:
    - Parse reviewer feedback
    - Update epic spec via `flowctl epic set-plan`
    - Sync affected task specs via `flowctl task set-spec`
-   - Re-review (same chat for RP, receipt continuity for Codex)
+    - Re-review (same chat for RP, receipt continuity for Codex)
    - Repeat until `SHIP`
 
 4. **Receipt** — Write proof-of-work
@@ -318,7 +321,7 @@ The epic-completion review gate ensures implementation matches the spec before c
 
 ```bash
 # config.env
-COMPLETION_REVIEW=codex       # Backend: rp, codex, or none
+COMPLETION_REVIEW=codex       # Backend: rp, codex, copilot, or none
 ```
 
 When `COMPLETION_REVIEW != none`, Ralph passes `--require-completion-review` to the selector. There is no separate `REQUIRE_COMPLETION_REVIEW` flag—the presence of a backend implies the gate is active.
@@ -327,6 +330,7 @@ When `COMPLETION_REVIEW != none`, Ralph passes `--require-completion-review` to 
 |---------------------|----------|
 | `rp` | Completion reviewed via RepoPrompt |
 | `codex` | Completion reviewed via Codex CLI |
+| `copilot` | Completion reviewed via Copilot CLI |
 | `none` | No completion review, epics close immediately |
 
 #### The Review Cycle
@@ -437,9 +441,9 @@ Edit `scripts/ralph/config.env`:
 
 | Variable | Values | Default | Description |
 |----------|--------|---------|-------------|
-| `PLAN_REVIEW` | `rp`, `codex`, `none` | — | Plan review backend |
-| `WORK_REVIEW` | `rp`, `codex`, `none` | — | Impl review backend |
-| `COMPLETION_REVIEW` | `rp`, `codex`, `none` | — | Completion review backend |
+| `PLAN_REVIEW` | `rp`, `codex`, `copilot`, `none` | — | Plan review backend |
+| `WORK_REVIEW` | `rp`, `codex`, `copilot`, `none` | — | Impl review backend |
+| `COMPLETION_REVIEW` | `rp`, `codex`, `copilot`, `none` | — | Completion review backend |
 | `REQUIRE_PLAN_REVIEW` | `0`, `1` | `0` | Block work until plan approved |
 
 ### Branches
@@ -530,6 +534,22 @@ npm install -g @openai/codex && codex auth
 - Terminal-based (no GUI)
 - Session continuity via `thread_id`
 
+### Copilot Integration
+
+When using `PLAN_REVIEW=copilot` or `WORK_REVIEW=copilot`:
+
+```bash
+flowctl copilot check                    # Verify available
+flowctl copilot impl-review ...          # Run impl review
+flowctl copilot plan-review <id> --files "src/auth.ts,src/config.ts"
+```
+
+**Requirements:**
+
+```bash
+copilot auth
+```
+
 ---
 
 ## Run Artifacts
@@ -616,7 +636,7 @@ scripts/ralph/ralph.sh --watch --config rp-reviews.env
 ```
 
 Use alternate config files for different platforms or review backends without editing `config.env`. Useful for:
-- Separate configs for RepoPrompt vs Codex reviews
+- Separate configs for RepoPrompt vs Codex/Copilot reviews
 - Platform-specific settings (macOS vs Linux vs Windows)
 - Testing different `MAX_ITERATIONS` or `WORKER_TIMEOUT` values
 
@@ -740,7 +760,7 @@ grep -E "REQUIRE_PLAN_REVIEW|PLAN_REVIEW" scripts/ralph/config.env
 | Config | Problem | Fix |
 |--------|---------|-----|
 | `REQUIRE_PLAN_REVIEW=0` | Plan gate disabled | Set to `1` |
-| `PLAN_REVIEW=none` + `REQUIRE_PLAN_REVIEW=1` | No backend to review | Set `PLAN_REVIEW=codex` or `rp` |
+| `PLAN_REVIEW=none` + `REQUIRE_PLAN_REVIEW=1` | No backend to review | Set `PLAN_REVIEW=codex`, `copilot`, or `rp` |
 | `PLAN_REVIEW` unset | Defaults to template placeholder | Set explicitly |
 
 **Verify selector sees plan work:**
@@ -877,6 +897,20 @@ CODEX_SANDBOX=auto
 ```
 
 The `read-only` sandbox blocks all commands on Windows.
+
+### Copilot Issues
+
+**"copilot not found":**
+
+```bash
+copilot --version
+```
+
+**Not authenticated:**
+
+```bash
+copilot auth
+```
 
 ### Run Inspection
 

--- a/plugins/flow-next/docs/ralph.md
+++ b/plugins/flow-next/docs/ralph.md
@@ -540,8 +540,8 @@ When using `PLAN_REVIEW=copilot` or `WORK_REVIEW=copilot`:
 
 ```bash
 flowctl copilot check                    # Verify available
-flowctl copilot impl-review ... --model gpt-5.1          # Run impl review
-flowctl copilot plan-review <id> --files "src/auth.ts,src/config.ts" --model gpt-5.1
+flowctl copilot impl-review ... --model gpt-5.2          # Run impl review
+flowctl copilot plan-review <id> --files "src/auth.ts,src/config.ts" --model gpt-5.2
 ```
 
 **Requirements:**
@@ -550,7 +550,7 @@ flowctl copilot plan-review <id> --files "src/auth.ts,src/config.ts" --model gpt
 copilot auth
 ```
 
-Set `COPILOT_MODEL` in `scripts/ralph/config.env` (required).
+Set `FLOW_COPILOT_MODEL` in your environment (required).
 
 ---
 

--- a/plugins/flow-next/docs/ralph.md
+++ b/plugins/flow-next/docs/ralph.md
@@ -540,8 +540,8 @@ When using `PLAN_REVIEW=copilot` or `WORK_REVIEW=copilot`:
 
 ```bash
 flowctl copilot check                    # Verify available
-flowctl copilot impl-review ...          # Run impl review
-flowctl copilot plan-review <id> --files "src/auth.ts,src/config.ts"
+flowctl copilot impl-review ... --model gpt-5.1          # Run impl review
+flowctl copilot plan-review <id> --files "src/auth.ts,src/config.ts" --model gpt-5.1
 ```
 
 **Requirements:**
@@ -549,6 +549,8 @@ flowctl copilot plan-review <id> --files "src/auth.ts,src/config.ts"
 ```bash
 copilot auth
 ```
+
+Set `COPILOT_MODEL` in `scripts/ralph/config.env` (required).
 
 ---
 

--- a/plugins/flow-next/scripts/flowctl.py
+++ b/plugins/flow-next/scripts/flowctl.py
@@ -670,7 +670,7 @@ def epic_id_from_task(task_id: str) -> str:
     return task_id.rsplit(".", 1)[0]
 
 
-# --- Context Hints (for codex reviews) ---
+# --- Context Hints (for codex/copilot reviews) ---
 
 
 def get_changed_files(base_branch: str) -> list[str]:
@@ -1162,6 +1162,36 @@ def get_codex_version() -> Optional[str]:
         return None
 
 
+# --- Copilot Backend Helpers ---
+
+
+def require_copilot() -> str:
+    """Ensure copilot CLI is available. Returns path to copilot."""
+    copilot = shutil.which("copilot")
+    if not copilot:
+        error_exit("copilot not found in PATH", use_json=False, code=2)
+    return copilot
+
+
+def get_copilot_version() -> Optional[str]:
+    """Get copilot version, or None if not available."""
+    copilot = shutil.which("copilot")
+    if not copilot:
+        return None
+    try:
+        result = subprocess.run(
+            [copilot, "--version"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        output = result.stdout.strip()
+        match = re.search(r"(\d+\.\d+\.\d+)", output)
+        return match.group(1) if match else output
+    except subprocess.CalledProcessError:
+        return None
+
+
 CODEX_SANDBOX_MODES = {"read-only", "workspace-write", "danger-full-access", "auto"}
 
 
@@ -1279,6 +1309,35 @@ def run_codex_exec(
         return "", None, 2, "codex exec timed out (600s)"
 
 
+def run_copilot_exec(
+    prompt: str,
+    session_id: Optional[str] = None,
+) -> tuple[str, Optional[str], int, str]:
+    """Run copilot CLI and return (stdout, session_id, exit_code, stderr).
+
+    Note: uses --resume=<session_id> when available to continue review sessions.
+    """
+    copilot = require_copilot()
+    cmd = [copilot]
+    if session_id:
+        cmd.append(f"--resume={session_id}")
+    cmd.extend(["--stream", "--prompt", "-"])
+    try:
+        result = subprocess.run(
+            cmd,
+            input=prompt,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=600,
+        )
+        output = result.stdout
+        new_session_id = parse_copilot_session_id(output) or session_id
+        return output, new_session_id, result.returncode, result.stderr
+    except subprocess.TimeoutExpired:
+        return "", session_id, 2, "copilot exec timed out (600s)"
+
+
 def parse_codex_thread_id(output: str) -> Optional[str]:
     """Extract thread_id from codex --json output.
 
@@ -1291,6 +1350,28 @@ def parse_codex_thread_id(output: str) -> Optional[str]:
             data = json.loads(line)
             if data.get("type") == "thread.started" and "thread_id" in data:
                 return data["thread_id"]
+        except json.JSONDecodeError:
+            continue
+    return None
+
+
+def parse_copilot_session_id(output: str) -> Optional[str]:
+    """Extract session id from copilot output if present."""
+    for line in output.split("\n"):
+        if not line.strip():
+            continue
+        try:
+            data = json.loads(line)
+            if isinstance(data, dict):
+                for key in ("session_id", "thread_id", "conversation_id", "id"):
+                    value = data.get(key)
+                    if isinstance(value, str) and value:
+                        return value
+                session = data.get("session")
+                if isinstance(session, dict):
+                    value = session.get("id")
+                    if isinstance(value, str) and value:
+                        return value
         except json.JSONDecodeError:
             continue
     return None
@@ -1372,13 +1453,13 @@ def build_review_prompt(
     diff_content: str = "",
     files_embedded: bool = False,
 ) -> str:
-    """Build XML-structured review prompt for codex.
+    """Build XML-structured review prompt for codex/copilot.
 
     review_type: 'impl' or 'plan'
     task_specs: Combined task spec content (plan reviews only)
-    embedded_files: Pre-read file contents for codex sandbox mode
+    embedded_files: Pre-read file contents for sandboxed review
     diff_content: Actual git diff output (impl reviews only)
-    files_embedded: True if files are embedded (Windows), False if Codex can read from disk (Unix)
+    files_embedded: True if files are embedded (Windows), False if CLI can read from disk (Unix)
 
     Uses same Carmack-level criteria as RepoPrompt workflow to ensure parity.
     """
@@ -2351,12 +2432,12 @@ def cmd_review_backend(args: argparse.Namespace) -> None:
     """Get review backend for skill conditionals. Returns ASK if not configured."""
     # Priority: FLOW_REVIEW_BACKEND env > config > ASK
     env_val = os.environ.get("FLOW_REVIEW_BACKEND", "").strip()
-    if env_val and env_val in ("rp", "codex", "none"):
+    if env_val and env_val in ("rp", "codex", "copilot", "none"):
         backend = env_val
         source = "env"
     elif ensure_flow_exists():
         cfg_val = get_config("review.backend")
-        if cfg_val and cfg_val in ("rp", "codex", "none"):
+        if cfg_val and cfg_val in ("rp", "codex", "copilot", "none"):
             backend = cfg_val
             source = "config"
         else:
@@ -5230,6 +5311,21 @@ def cmd_codex_check(args: argparse.Namespace) -> None:
             print("codex not available")
 
 
+def cmd_copilot_check(args: argparse.Namespace) -> None:
+    """Check if copilot CLI is available and return version."""
+    copilot = shutil.which("copilot")
+    available = copilot is not None
+    version = get_copilot_version() if available else None
+
+    if args.json:
+        json_output({"available": available, "version": version})
+    else:
+        if available:
+            print(f"copilot available: {version or 'unknown version'}")
+        else:
+            print("copilot not available")
+
+
 def build_standalone_review_prompt(
     base_branch: str, focus: Optional[str], diff_summary: str, files_embedded: bool = True
 ) -> str:
@@ -5555,6 +5651,193 @@ def cmd_codex_impl_review(args: argparse.Namespace) -> None:
         print(f"\nVERDICT={verdict or 'UNKNOWN'}")
 
 
+def cmd_copilot_impl_review(args: argparse.Namespace) -> None:
+    """Run implementation review via copilot."""
+    task_id = args.task
+    base_branch = args.base
+    focus = getattr(args, "focus", None)
+
+    standalone = task_id is None
+
+    if not standalone:
+        if not ensure_flow_exists():
+            error_exit(".flow/ does not exist", use_json=args.json)
+        if not is_task_id(task_id):
+            error_exit(f"Invalid task ID: {task_id}", use_json=args.json)
+
+        flow_dir = get_flow_dir()
+        task_spec_path = flow_dir / TASKS_DIR / f"{task_id}.md"
+        if not task_spec_path.exists():
+            error_exit(f"Task spec not found: {task_spec_path}", use_json=args.json)
+        task_spec = task_spec_path.read_text(encoding="utf-8")
+
+    diff_summary = ""
+    try:
+        diff_result = subprocess.run(
+            ["git", "diff", "--stat", f"{base_branch}..HEAD"],
+            capture_output=True,
+            text=True,
+            cwd=get_repo_root(),
+        )
+        if diff_result.returncode == 0:
+            diff_summary = diff_result.stdout.strip()
+    except (subprocess.CalledProcessError, OSError):
+        pass
+
+    diff_content = ""
+    max_diff_bytes = 50000
+    try:
+        proc = subprocess.Popen(
+            ["git", "diff", f"{base_branch}..HEAD"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            cwd=get_repo_root(),
+        )
+        diff_bytes = proc.stdout.read(max_diff_bytes + 1)
+        was_truncated = len(diff_bytes) > max_diff_bytes
+        if was_truncated:
+            diff_bytes = diff_bytes[:max_diff_bytes]
+        while proc.stdout.read(65536):
+            pass
+        stderr_bytes = proc.stderr.read()
+        proc.stdout.close()
+        proc.stderr.close()
+        returncode = proc.wait()
+
+        if returncode != 0 and stderr_bytes:
+            diff_content = f"[git diff failed: {stderr_bytes.decode('utf-8', errors='replace').strip()}]"
+        else:
+            diff_content = diff_bytes.decode("utf-8", errors="replace").strip()
+            if was_truncated:
+                diff_content += "\n\n... [diff truncated at 50KB]"
+    except (subprocess.CalledProcessError, OSError):
+        pass
+
+    if os.name == "nt":
+        changed_files = get_changed_files(base_branch)
+        embedded_content, embed_stats = get_embedded_file_contents(changed_files)
+    else:
+        embedded_content = ""
+        embed_stats = {
+            "embedded": 0,
+            "total": 0,
+            "bytes": 0,
+            "binary_skipped": [],
+            "deleted_skipped": [],
+            "outside_repo_skipped": [],
+            "budget_skipped": [],
+        }
+
+    files_embedded = os.name == "nt"
+    if standalone:
+        prompt = build_standalone_review_prompt(base_branch, focus, diff_summary, files_embedded)
+        if diff_content:
+            prompt += f"\n\n<diff_content>\n{diff_content}\n</diff_content>"
+        if embedded_content:
+            prompt += f"\n\n<embedded_files>\n{embedded_content}\n</embedded_files>"
+    else:
+        context_hints = gather_context_hints(base_branch)
+        prompt = build_review_prompt(
+            "impl",
+            task_spec,
+            context_hints,
+            diff_summary,
+            embedded_files=embedded_content,
+            diff_content=diff_content,
+            files_embedded=files_embedded,
+        )
+
+    receipt_path = args.receipt if hasattr(args, "receipt") and args.receipt else None
+    session_id = None
+    is_rereview = False
+    if receipt_path:
+        receipt_file = Path(receipt_path)
+        if receipt_file.exists():
+            try:
+                receipt_data = json.loads(receipt_file.read_text(encoding="utf-8"))
+                session_id = receipt_data.get("session_id")
+                is_rereview = session_id is not None
+            except (json.JSONDecodeError, Exception):
+                pass
+
+    if is_rereview:
+        changed_files = get_changed_files(base_branch)
+        if changed_files:
+            rereview_preamble = build_rereview_preamble(
+                changed_files, "implementation", files_embedded
+            )
+            prompt = rereview_preamble + prompt
+
+    output, new_session_id, exit_code, stderr = run_copilot_exec(
+        prompt, session_id=session_id
+    )
+
+    if exit_code != 0:
+        if receipt_path:
+            try:
+                Path(receipt_path).unlink(missing_ok=True)
+            except OSError:
+                pass
+        msg = (stderr or output or "copilot exec failed").strip()
+        error_exit(f"copilot exec failed: {msg}", use_json=args.json, code=2)
+
+    verdict = parse_codex_verdict(output)
+    if not verdict:
+        if receipt_path:
+            try:
+                Path(receipt_path).unlink(missing_ok=True)
+            except OSError:
+                pass
+        error_exit(
+            "Copilot review completed but no verdict found in output. "
+            "Expected <verdict>SHIP</verdict> or <verdict>NEEDS_WORK</verdict>",
+            use_json=args.json,
+            code=2,
+        )
+
+    review_id = task_id if task_id else "branch"
+    session_id_to_write = new_session_id or session_id
+
+    if receipt_path:
+        receipt_data = {
+            "type": "impl_review",
+            "id": review_id,
+            "mode": "copilot",
+            "base": base_branch,
+            "verdict": verdict,
+            "session_id": session_id_to_write,
+            "timestamp": now_iso(),
+            "review": output,
+        }
+        ralph_iter = os.environ.get("RALPH_ITERATION")
+        if ralph_iter:
+            try:
+                receipt_data["iteration"] = int(ralph_iter)
+            except ValueError:
+                pass
+        if focus:
+            receipt_data["focus"] = focus
+        Path(receipt_path).write_text(
+            json.dumps(receipt_data, indent=2) + "\n", encoding="utf-8"
+        )
+
+    if args.json:
+        json_output(
+            {
+                "type": "impl_review",
+                "id": review_id,
+                "verdict": verdict,
+                "session_id": session_id_to_write,
+                "mode": "copilot",
+                "standalone": standalone,
+                "review": output,
+            }
+        )
+    else:
+        print(output)
+        print(f"\nVERDICT={verdict or 'UNKNOWN'}")
+
+
 def cmd_codex_plan_review(args: argparse.Namespace) -> None:
     """Run plan review via codex exec."""
     if not ensure_flow_exists():
@@ -5769,6 +6052,185 @@ def cmd_codex_plan_review(args: argparse.Namespace) -> None:
                 "session_id": thread_id,
                 "mode": "codex",
                 "review": output,  # Full review feedback for fix loop
+            }
+        )
+    else:
+        print(output)
+        print(f"\nVERDICT={verdict or 'UNKNOWN'}")
+
+
+def cmd_copilot_plan_review(args: argparse.Namespace) -> None:
+    """Run plan review via copilot."""
+    if not ensure_flow_exists():
+        error_exit(".flow/ does not exist", use_json=args.json)
+
+    epic_id = args.epic
+    if not is_epic_id(epic_id):
+        error_exit(f"Invalid epic ID: {epic_id}", use_json=args.json)
+
+    files_arg = getattr(args, "files", None)
+    if not files_arg:
+        error_exit(
+            "plan-review requires --files argument (comma-separated CODE file paths). "
+            "On Windows: files are embedded for context. On Unix: used as relevance list. "
+            "Example: --files src/main.py,src/utils.py",
+            use_json=args.json,
+        )
+
+    repo_root = get_repo_root()
+    file_paths = []
+    invalid_paths = []
+    for f in files_arg.split(","):
+        f = f.strip()
+        if not f:
+            continue
+        full_path = (repo_root / f).resolve()
+        try:
+            full_path.relative_to(repo_root)
+            if full_path.exists():
+                file_paths.append(f)
+            else:
+                invalid_paths.append(f"{f} (not found)")
+        except ValueError:
+            invalid_paths.append(f"{f} (outside repo)")
+
+    if invalid_paths:
+        print(f"Warning: Skipping invalid paths: {', '.join(invalid_paths)}", file=sys.stderr)
+
+    if not file_paths:
+        error_exit(
+            "No valid file paths provided. Use --files with comma-separated repo-relative code paths.",
+            use_json=args.json,
+        )
+
+    flow_dir = get_flow_dir()
+    epic_spec_path = flow_dir / SPECS_DIR / f"{epic_id}.md"
+    if not epic_spec_path.exists():
+        error_exit(f"Epic spec not found: {epic_spec_path}", use_json=args.json)
+    epic_spec = epic_spec_path.read_text(encoding="utf-8")
+
+    tasks_dir = flow_dir / TASKS_DIR
+    task_specs_parts = []
+    for task_file in sorted(tasks_dir.glob(f"{epic_id}.*.md")):
+        task_id = task_file.stem
+        task_content = task_file.read_text(encoding="utf-8")
+        task_specs_parts.append(f"### {task_id}\n\n{task_content}")
+
+    task_specs = "\n\n---\n\n".join(task_specs_parts) if task_specs_parts else ""
+
+    if os.name == "nt":
+        embedded_content, embed_stats = get_embedded_file_contents(file_paths)
+    else:
+        embedded_content = ""
+        embed_stats = {
+            "embedded": 0,
+            "total": 0,
+            "bytes": 0,
+            "binary_skipped": [],
+            "deleted_skipped": [],
+            "outside_repo_skipped": [],
+            "budget_skipped": [],
+        }
+
+    base_branch = args.base if hasattr(args, "base") and args.base else "main"
+    context_hints = gather_context_hints(base_branch)
+
+    files_embedded = os.name == "nt"
+    prompt = build_review_prompt(
+        "plan",
+        epic_spec,
+        context_hints,
+        task_specs=task_specs,
+        embedded_files=embedded_content,
+        files_embedded=files_embedded,
+    )
+
+    if file_paths:
+        files_list = "\n".join(f"- {f}" for f in file_paths)
+        prompt += (
+            "\n\n<requested_files>\nThe following code files are relevant to this plan:\n"
+            f"{files_list}\n</requested_files>"
+        )
+
+    receipt_path = args.receipt if hasattr(args, "receipt") and args.receipt else None
+    session_id = None
+    is_rereview = False
+    if receipt_path:
+        receipt_file = Path(receipt_path)
+        if receipt_file.exists():
+            try:
+                receipt_data = json.loads(receipt_file.read_text(encoding="utf-8"))
+                session_id = receipt_data.get("session_id")
+                is_rereview = session_id is not None
+            except (json.JSONDecodeError, Exception):
+                pass
+
+    if is_rereview:
+        repo_root = get_repo_root()
+        spec_files = [str(epic_spec_path.relative_to(repo_root))]
+        for task_file in sorted(tasks_dir.glob(f"{epic_id}.*.md")):
+            spec_files.append(str(task_file.relative_to(repo_root)))
+        rereview_preamble = build_rereview_preamble(spec_files, "plan", files_embedded)
+        prompt = rereview_preamble + prompt
+
+    output, new_session_id, exit_code, stderr = run_copilot_exec(
+        prompt, session_id=session_id
+    )
+
+    if exit_code != 0:
+        if receipt_path:
+            try:
+                Path(receipt_path).unlink(missing_ok=True)
+            except OSError:
+                pass
+        msg = (stderr or output or "copilot exec failed").strip()
+        error_exit(f"copilot exec failed: {msg}", use_json=args.json, code=2)
+
+    verdict = parse_codex_verdict(output)
+    if not verdict:
+        if receipt_path:
+            try:
+                Path(receipt_path).unlink(missing_ok=True)
+            except OSError:
+                pass
+        error_exit(
+            "Copilot review completed but no verdict found in output. "
+            "Expected <verdict>SHIP</verdict> or <verdict>NEEDS_WORK</verdict>",
+            use_json=args.json,
+            code=2,
+        )
+
+    session_id_to_write = new_session_id or session_id
+
+    if receipt_path:
+        receipt_data = {
+            "type": "plan_review",
+            "id": epic_id,
+            "mode": "copilot",
+            "verdict": verdict,
+            "session_id": session_id_to_write,
+            "timestamp": now_iso(),
+            "review": output,
+        }
+        ralph_iter = os.environ.get("RALPH_ITERATION")
+        if ralph_iter:
+            try:
+                receipt_data["iteration"] = int(ralph_iter)
+            except ValueError:
+                pass
+        Path(receipt_path).write_text(
+            json.dumps(receipt_data, indent=2) + "\n", encoding="utf-8"
+        )
+
+    if args.json:
+        json_output(
+            {
+                "type": "plan_review",
+                "id": epic_id,
+                "verdict": verdict,
+                "session_id": session_id_to_write,
+                "mode": "copilot",
+                "review": output,
             }
         )
     else:
@@ -6126,6 +6588,182 @@ def cmd_codex_completion_review(args: argparse.Namespace) -> None:
                 "verdict": verdict,
                 "session_id": session_id_to_write,
                 "mode": "codex",
+                "review": output,
+            }
+        )
+    else:
+        print(output)
+        print(f"\nVERDICT={verdict or 'UNKNOWN'}")
+
+
+def cmd_copilot_completion_review(args: argparse.Namespace) -> None:
+    """Run epic completion review via copilot.
+
+    Verifies that all epic requirements are implemented before closing.
+    Two-phase approach: extract requirements, then verify coverage.
+    """
+    if not ensure_flow_exists():
+        error_exit(".flow/ does not exist", use_json=args.json)
+
+    epic_id = args.epic
+    if not is_epic_id(epic_id):
+        error_exit(f"Invalid epic ID: {epic_id}", use_json=args.json)
+
+    flow_dir = get_flow_dir()
+
+    epic_spec_path = flow_dir / SPECS_DIR / f"{epic_id}.md"
+    if not epic_spec_path.exists():
+        error_exit(f"Epic spec not found: {epic_spec_path}", use_json=args.json)
+    epic_spec = epic_spec_path.read_text(encoding="utf-8")
+
+    tasks_dir = flow_dir / TASKS_DIR
+    task_specs_parts = []
+    for task_file in sorted(tasks_dir.glob(f"{epic_id}.*.md")):
+        task_id = task_file.stem
+        task_content = task_file.read_text(encoding="utf-8")
+        task_specs_parts.append(f"### {task_id}\n\n{task_content}")
+    task_specs = "\n\n---\n\n".join(task_specs_parts) if task_specs_parts else ""
+
+    base_branch = args.base if hasattr(args, "base") and args.base else "main"
+
+    diff_summary = ""
+    try:
+        diff_result = subprocess.run(
+            ["git", "diff", "--stat", f"{base_branch}..HEAD"],
+            capture_output=True,
+            text=True,
+            cwd=get_repo_root(),
+        )
+        if diff_result.returncode == 0:
+            diff_summary = diff_result.stdout.strip()
+    except (subprocess.CalledProcessError, OSError):
+        pass
+
+    diff_content = ""
+    max_diff_bytes = 50000
+    try:
+        proc = subprocess.Popen(
+            ["git", "diff", f"{base_branch}..HEAD"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            cwd=get_repo_root(),
+        )
+        diff_bytes = proc.stdout.read(max_diff_bytes + 1)
+        was_truncated = len(diff_bytes) > max_diff_bytes
+        if was_truncated:
+            diff_bytes = diff_bytes[:max_diff_bytes]
+        while proc.stdout.read(65536):
+            pass
+        stderr_bytes = proc.stderr.read()
+        proc.stdout.close()
+        proc.stderr.close()
+        returncode = proc.wait()
+
+        if returncode != 0 and stderr_bytes:
+            diff_content = f"[git diff failed: {stderr_bytes.decode('utf-8', errors='replace').strip()}]"
+        else:
+            diff_content = diff_bytes.decode("utf-8", errors="replace").strip()
+            if was_truncated:
+                diff_content += "\n\n... [diff truncated at 50KB]"
+    except (subprocess.CalledProcessError, OSError):
+        pass
+
+    if os.name == "nt":
+        changed_files = get_changed_files(base_branch)
+        embedded_content, _ = get_embedded_file_contents(changed_files)
+    else:
+        embedded_content = ""
+
+    files_embedded = os.name == "nt"
+    prompt = build_completion_review_prompt(
+        epic_spec,
+        task_specs,
+        diff_summary,
+        diff_content,
+        embedded_files=embedded_content,
+        files_embedded=files_embedded,
+    )
+
+    receipt_path = args.receipt if hasattr(args, "receipt") and args.receipt else None
+    session_id = None
+    is_rereview = False
+    if receipt_path:
+        receipt_file = Path(receipt_path)
+        if receipt_file.exists():
+            try:
+                receipt_data = json.loads(receipt_file.read_text(encoding="utf-8"))
+                session_id = receipt_data.get("session_id")
+                is_rereview = session_id is not None
+            except (json.JSONDecodeError, Exception):
+                pass
+
+    if is_rereview:
+        changed_files = get_changed_files(base_branch)
+        if changed_files:
+            rereview_preamble = build_rereview_preamble(
+                changed_files, "completion", files_embedded
+            )
+            prompt = rereview_preamble + prompt
+
+    output, new_session_id, exit_code, stderr = run_copilot_exec(
+        prompt, session_id=session_id
+    )
+
+    if exit_code != 0:
+        if receipt_path:
+            try:
+                Path(receipt_path).unlink(missing_ok=True)
+            except OSError:
+                pass
+        msg = (stderr or output or "copilot exec failed").strip()
+        error_exit(f"copilot exec failed: {msg}", use_json=args.json, code=2)
+
+    verdict = parse_codex_verdict(output)
+    if not verdict:
+        if receipt_path:
+            try:
+                Path(receipt_path).unlink(missing_ok=True)
+            except OSError:
+                pass
+        error_exit(
+            "Copilot review completed but no verdict found in output. "
+            "Expected <verdict>SHIP</verdict> or <verdict>NEEDS_WORK</verdict>",
+            use_json=args.json,
+            code=2,
+        )
+
+    session_id_to_write = new_session_id or session_id
+
+    if receipt_path:
+        receipt_data = {
+            "type": "completion_review",
+            "id": epic_id,
+            "mode": "copilot",
+            "base": base_branch,
+            "verdict": verdict,
+            "session_id": session_id_to_write,
+            "timestamp": now_iso(),
+            "review": output,
+        }
+        ralph_iter = os.environ.get("RALPH_ITERATION")
+        if ralph_iter:
+            try:
+                receipt_data["iteration"] = int(ralph_iter)
+            except ValueError:
+                pass
+        Path(receipt_path).write_text(
+            json.dumps(receipt_data, indent=2) + "\n", encoding="utf-8"
+        )
+
+    if args.json:
+        json_output(
+            {
+                "type": "completion_review",
+                "id": epic_id,
+                "base": base_branch,
+                "verdict": verdict,
+                "session_id": session_id_to_write,
+                "mode": "copilot",
                 "review": output,
             }
         )
@@ -7074,6 +7712,58 @@ def main() -> None:
         help="Sandbox mode (auto: danger-full-access on Windows, read-only on Unix)",
     )
     p_codex_completion.set_defaults(func=cmd_codex_completion_review)
+
+    # copilot (Copilot CLI wrappers)
+    p_copilot = subparsers.add_parser("copilot", help="Copilot CLI helpers")
+    copilot_sub = p_copilot.add_subparsers(dest="copilot_cmd", required=True)
+
+    p_copilot_check = copilot_sub.add_parser("check", help="Check copilot availability")
+    p_copilot_check.add_argument("--json", action="store_true", help="JSON output")
+    p_copilot_check.set_defaults(func=cmd_copilot_check)
+
+    p_copilot_impl = copilot_sub.add_parser("impl-review", help="Implementation review")
+    p_copilot_impl.add_argument(
+        "task",
+        nargs="?",
+        default=None,
+        help="Task ID (fn-N.M), optional for standalone",
+    )
+    p_copilot_impl.add_argument("--base", required=True, help="Base branch for diff")
+    p_copilot_impl.add_argument(
+        "--focus", help="Focus areas for standalone review (comma-separated)"
+    )
+    p_copilot_impl.add_argument(
+        "--receipt", help="Receipt file path for session continuity"
+    )
+    p_copilot_impl.add_argument("--json", action="store_true", help="JSON output")
+    p_copilot_impl.set_defaults(func=cmd_copilot_impl_review)
+
+    p_copilot_plan = copilot_sub.add_parser("plan-review", help="Plan review")
+    p_copilot_plan.add_argument("epic", help="Epic ID (fn-N)")
+    p_copilot_plan.add_argument(
+        "--files",
+        required=True,
+        help="Comma-separated file paths to embed for context (required)",
+    )
+    p_copilot_plan.add_argument("--base", default="main", help="Base branch for context")
+    p_copilot_plan.add_argument(
+        "--receipt", help="Receipt file path for session continuity"
+    )
+    p_copilot_plan.add_argument("--json", action="store_true", help="JSON output")
+    p_copilot_plan.set_defaults(func=cmd_copilot_plan_review)
+
+    p_copilot_completion = copilot_sub.add_parser(
+        "completion-review", help="Epic completion review"
+    )
+    p_copilot_completion.add_argument("epic", help="Epic ID (fn-N)")
+    p_copilot_completion.add_argument(
+        "--base", default="main", help="Base branch for diff"
+    )
+    p_copilot_completion.add_argument(
+        "--receipt", help="Receipt file path for session continuity"
+    )
+    p_copilot_completion.add_argument("--json", action="store_true", help="JSON output")
+    p_copilot_completion.set_defaults(func=cmd_copilot_completion_review)
 
     args = parser.parse_args()
     args.func(args)

--- a/plugins/flow-next/scripts/flowctl.py
+++ b/plugins/flow-next/scripts/flowctl.py
@@ -1319,9 +1319,11 @@ def run_copilot_exec(
     Note: uses --resume=<session_id> when available to continue review sessions.
     """
     copilot = require_copilot()
-    if not model:
-        error_exit("Copilot model is required (use --model or COPILOT_MODEL)", use_json=False, code=2)
-    cmd = [copilot, "--model", model]
+    # Model priority: env > parameter (required, no default).
+    effective_model = os.environ.get("FLOW_COPILOT_MODEL") or model
+    if not effective_model:
+        error_exit("Copilot model is required (set FLOW_COPILOT_MODEL or pass --model)", use_json=False, code=2)
+    cmd = [copilot, "--model", effective_model]
     if session_id:
         cmd.append(f"--resume={session_id}")
     cmd.extend(["--allow-all", "--stream", "--prompt", "-"])
@@ -5659,7 +5661,7 @@ def cmd_copilot_impl_review(args: argparse.Namespace) -> None:
     task_id = args.task
     base_branch = args.base
     focus = getattr(args, "focus", None)
-    model = getattr(args, "model", None) or os.environ.get("COPILOT_MODEL")
+    model = getattr(args, "model", None)
 
     standalone = task_id is None
 
@@ -6177,7 +6179,7 @@ def cmd_copilot_plan_review(args: argparse.Namespace) -> None:
         rereview_preamble = build_rereview_preamble(spec_files, "plan", files_embedded)
         prompt = rereview_preamble + prompt
 
-    model = getattr(args, "model", None) or os.environ.get("COPILOT_MODEL")
+    model = getattr(args, "model", None)
     output, new_session_id, exit_code, stderr = run_copilot_exec(
         prompt, session_id=session_id, model=model
     )
@@ -6710,7 +6712,7 @@ def cmd_copilot_completion_review(args: argparse.Namespace) -> None:
             )
             prompt = rereview_preamble + prompt
 
-    model = getattr(args, "model", None) or os.environ.get("COPILOT_MODEL")
+    model = getattr(args, "model", None)
     output, new_session_id, exit_code, stderr = run_copilot_exec(
         prompt, session_id=session_id, model=model
     )
@@ -7735,7 +7737,7 @@ def main() -> None:
         help="Task ID (fn-N.M), optional for standalone",
     )
     p_copilot_impl.add_argument("--base", required=True, help="Base branch for diff")
-    p_copilot_impl.add_argument("--model", required=True, help="Copilot model name")
+    p_copilot_impl.add_argument("--model", help="Copilot model name")
     p_copilot_impl.add_argument(
         "--focus", help="Focus areas for standalone review (comma-separated)"
     )
@@ -7753,7 +7755,7 @@ def main() -> None:
         help="Comma-separated file paths to embed for context (required)",
     )
     p_copilot_plan.add_argument("--base", default="main", help="Base branch for context")
-    p_copilot_plan.add_argument("--model", required=True, help="Copilot model name")
+    p_copilot_plan.add_argument("--model", help="Copilot model name")
     p_copilot_plan.add_argument(
         "--receipt", help="Receipt file path for session continuity"
     )
@@ -7767,7 +7769,7 @@ def main() -> None:
     p_copilot_completion.add_argument(
         "--base", default="main", help="Base branch for diff"
     )
-    p_copilot_completion.add_argument("--model", required=True, help="Copilot model name")
+    p_copilot_completion.add_argument("--model", help="Copilot model name")
     p_copilot_completion.add_argument(
         "--receipt", help="Receipt file path for session continuity"
     )

--- a/plugins/flow-next/scripts/flowctl.py
+++ b/plugins/flow-next/scripts/flowctl.py
@@ -1312,16 +1312,19 @@ def run_codex_exec(
 def run_copilot_exec(
     prompt: str,
     session_id: Optional[str] = None,
+    model: Optional[str] = None,
 ) -> tuple[str, Optional[str], int, str]:
     """Run copilot CLI and return (stdout, session_id, exit_code, stderr).
 
     Note: uses --resume=<session_id> when available to continue review sessions.
     """
     copilot = require_copilot()
-    cmd = [copilot]
+    if not model:
+        error_exit("Copilot model is required (use --model or COPILOT_MODEL)", use_json=False, code=2)
+    cmd = [copilot, "--model", model]
     if session_id:
         cmd.append(f"--resume={session_id}")
-    cmd.extend(["--stream", "--prompt", "-"])
+    cmd.extend(["--allow-all", "--stream", "--prompt", "-"])
     try:
         result = subprocess.run(
             cmd,
@@ -5656,6 +5659,7 @@ def cmd_copilot_impl_review(args: argparse.Namespace) -> None:
     task_id = args.task
     base_branch = args.base
     focus = getattr(args, "focus", None)
+    model = getattr(args, "model", None) or os.environ.get("COPILOT_MODEL")
 
     standalone = task_id is None
 
@@ -5769,7 +5773,7 @@ def cmd_copilot_impl_review(args: argparse.Namespace) -> None:
             prompt = rereview_preamble + prompt
 
     output, new_session_id, exit_code, stderr = run_copilot_exec(
-        prompt, session_id=session_id
+        prompt, session_id=session_id, model=model
     )
 
     if exit_code != 0:
@@ -6173,8 +6177,9 @@ def cmd_copilot_plan_review(args: argparse.Namespace) -> None:
         rereview_preamble = build_rereview_preamble(spec_files, "plan", files_embedded)
         prompt = rereview_preamble + prompt
 
+    model = getattr(args, "model", None) or os.environ.get("COPILOT_MODEL")
     output, new_session_id, exit_code, stderr = run_copilot_exec(
-        prompt, session_id=session_id
+        prompt, session_id=session_id, model=model
     )
 
     if exit_code != 0:
@@ -6705,8 +6710,9 @@ def cmd_copilot_completion_review(args: argparse.Namespace) -> None:
             )
             prompt = rereview_preamble + prompt
 
+    model = getattr(args, "model", None) or os.environ.get("COPILOT_MODEL")
     output, new_session_id, exit_code, stderr = run_copilot_exec(
-        prompt, session_id=session_id
+        prompt, session_id=session_id, model=model
     )
 
     if exit_code != 0:
@@ -7729,6 +7735,7 @@ def main() -> None:
         help="Task ID (fn-N.M), optional for standalone",
     )
     p_copilot_impl.add_argument("--base", required=True, help="Base branch for diff")
+    p_copilot_impl.add_argument("--model", required=True, help="Copilot model name")
     p_copilot_impl.add_argument(
         "--focus", help="Focus areas for standalone review (comma-separated)"
     )
@@ -7746,6 +7753,7 @@ def main() -> None:
         help="Comma-separated file paths to embed for context (required)",
     )
     p_copilot_plan.add_argument("--base", default="main", help="Base branch for context")
+    p_copilot_plan.add_argument("--model", required=True, help="Copilot model name")
     p_copilot_plan.add_argument(
         "--receipt", help="Receipt file path for session continuity"
     )
@@ -7759,6 +7767,7 @@ def main() -> None:
     p_copilot_completion.add_argument(
         "--base", default="main", help="Base branch for diff"
     )
+    p_copilot_completion.add_argument("--model", required=True, help="Copilot model name")
     p_copilot_completion.add_argument(
         "--receipt", help="Receipt file path for session continuity"
     )

--- a/plugins/flow-next/scripts/hooks/ralph-guard.py
+++ b/plugins/flow-next/scripts/hooks/ralph-guard.py
@@ -11,13 +11,14 @@ Enforces:
 - Receipt must be written after SHIP verdict
 - Validates flowctl command patterns
 
-Supports both review backends:
-- rp (RepoPrompt): tracks chat-send calls and receipt writes
-- codex: tracks flowctl codex impl-review/plan-review and verdict output
+    Supports both review backends:
+    - rp (RepoPrompt): tracks chat-send calls and receipt writes
+    - codex: tracks flowctl codex impl-review/plan-review and verdict output
+    - copilot: tracks flowctl copilot impl-review/plan-review and verdict output
 """
 
 # Version for drift detection (bump when making changes)
-RALPH_GUARD_VERSION = "0.12.0"
+RALPH_GUARD_VERSION = "0.12.1"
 
 import json
 import os
@@ -46,6 +47,7 @@ def load_state(session_id: str) -> dict:
             state.setdefault("chat_send_succeeded", False)
             state.setdefault("flowctl_done_called", set())
             state.setdefault("codex_review_succeeded", False)
+            state.setdefault("copilot_review_succeeded", False)
             return state
         except (json.JSONDecodeError, KeyError, TypeError):
             pass
@@ -57,6 +59,7 @@ def load_state(session_id: str) -> dict:
         "chat_send_succeeded": False,  # Track if chat-send actually returned review text
         "flowctl_done_called": set(),  # Track tasks that had flowctl done called
         "codex_review_succeeded": False,  # Track if codex review returned verdict
+        "copilot_review_succeeded": False,  # Track if copilot review returned verdict
     }
 
 
@@ -170,6 +173,17 @@ def handle_pre_tool_use(data: dict) -> None:
                 "Session continuity is managed via session_id in receipts."
             )
 
+    # Block direct copilot calls (must use flowctl copilot wrappers)
+    if re.search(r"\bcopilot\b", command):
+        is_wrapper = re.search(r"flowctl\s+copilot|FLOWCTL.*copilot", command)
+        if not is_wrapper:
+            if re.search(r"\bcopilot\s+exec\b", command):
+                output_block(
+                    "BLOCKED: Do not call 'copilot exec' directly. "
+                    "Use 'flowctl copilot impl-review' or 'flowctl copilot plan-review' "
+                    "to ensure proper receipt handling and session continuity."
+                )
+
     # Validate setup-review usage
     if "setup-review" in command:
         if not re.search(r"--repo-root", command):
@@ -220,13 +234,16 @@ def handle_pre_tool_use(data: dict) -> None:
         )
         if is_receipt_write:
             state = load_state(session_id)
-            if not state.get("chat_send_succeeded") and not state.get(
-                "codex_review_succeeded"
+            if (
+                not state.get("chat_send_succeeded")
+                and not state.get("codex_review_succeeded")
+                and not state.get("copilot_review_succeeded")
             ):
                 output_block(
                     "BLOCKED: Cannot write receipt before review completes. "
                     "You must run 'flowctl rp chat-send' or 'flowctl codex impl-review/plan-review' "
-                    "and receive a review response before writing the receipt."
+                    "or 'flowctl copilot impl-review/plan-review' and receive a review response "
+                    "before writing the receipt."
                 )
             # Validate receipt has required 'id' field
             if '"id"' not in command and "'id'" not in command:
@@ -331,6 +348,20 @@ def handle_post_tool_use(data: dict) -> None:
             state["last_verdict"] = verdict_in_output.group(1)
             save_state(session_id, state)
 
+    # Track copilot review calls - check for verdict in output
+    if (
+        "flowctl" in command
+        and "copilot" in command
+        and ("impl-review" in command or "plan-review" in command or "completion-review" in command)
+    ):
+        verdict_in_output = re.search(
+            r"<verdict>(SHIP|NEEDS_WORK|MAJOR_RETHINK)</verdict>", response_text
+        )
+        if verdict_in_output:
+            state["copilot_review_succeeded"] = True
+            state["last_verdict"] = verdict_in_output.group(1)
+            save_state(session_id, state)
+
     # Track flowctl done calls - match various invocation patterns:
     # - flowctl done <task>
     # - flowctl.py done <task>
@@ -377,6 +408,7 @@ def handle_post_tool_use(data: dict) -> None:
     if receipt_path and receipt_path in command and ">" in command:
         state["chat_send_succeeded"] = False  # Reset for next review
         state["codex_review_succeeded"] = False  # Reset codex state too
+        state["copilot_review_succeeded"] = False  # Reset copilot state too
         save_state(session_id, state)
 
     # Track setup-review output (W= T=)

--- a/plugins/flow-next/scripts/ralph_smoke_test.sh
+++ b/plugins/flow-next/scripts/ralph_smoke_test.sh
@@ -43,6 +43,7 @@ cd "$TEST_DIR/repo"
 git init -q
 git config user.email "ralph-smoke@example.com"
 git config user.name "Ralph Smoke"
+git config commit.gpgsign false
 git checkout -b main >/dev/null 2>&1 || true
 
 cat > README.md <<'EOF'
@@ -67,17 +68,20 @@ write_config() {
   local max_iter="$5"
   local max_turns="$6"
   local max_attempts="$7"
-  "$PYTHON_BIN" - <<'PY' "$plan" "$work" "$require" "$branch" "$max_iter" "$max_turns" "$max_attempts"
+  local completion="${8:-none}"
+  "$PYTHON_BIN" - <<'PY' "$plan" "$work" "$require" "$branch" "$max_iter" "$max_turns" "$max_attempts" "$completion"
 from pathlib import Path
 import re, sys
-plan, work, require, branch, max_iter, max_turns, max_attempts = sys.argv[1:8]
+plan, work, require, branch, max_iter, max_turns, max_attempts, completion = sys.argv[1:9]
 cfg = Path("scripts/ralph/config.env")
 text = cfg.read_text()
 # Replace template placeholders first (for initial setup)
 text = text.replace("{{PLAN_REVIEW}}", plan).replace("{{WORK_REVIEW}}", work)
+text = text.replace("{{COMPLETION_REVIEW}}", completion)
 # Then use re.sub for subsequent calls (when values are already set)
 text = re.sub(r"^PLAN_REVIEW=.*$", f"PLAN_REVIEW={plan}", text, flags=re.M)
 text = re.sub(r"^WORK_REVIEW=.*$", f"WORK_REVIEW={work}", text, flags=re.M)
+text = re.sub(r"^COMPLETION_REVIEW=.*$", f"COMPLETION_REVIEW={completion}", text, flags=re.M)
 text = re.sub(r"^REQUIRE_PLAN_REVIEW=.*$", f"REQUIRE_PLAN_REVIEW={require}", text, flags=re.M)
 text = re.sub(r"^BRANCH_MODE=.*$", f"BRANCH_MODE={branch}", text, flags=re.M)
 text = re.sub(r"^MAX_ITERATIONS=.*$", f"MAX_ITERATIONS={max_iter}", text, flags=re.M)

--- a/plugins/flow-next/scripts/smoke_test.sh
+++ b/plugins/flow-next/scripts/smoke_test.sh
@@ -42,6 +42,10 @@ echo -e "${YELLOW}=== flowctl smoke tests ===${NC}"
 mkdir -p "$TEST_DIR/repo/scripts"
 cd "$TEST_DIR/repo"
 git init -q
+git config user.name "flowctl-smoke"
+git config user.email "flowctl-smoke@example.com"
+git config commit.gpgsign false
+git config gpg.format openpgp
 
 cp "$PLUGIN_ROOT/scripts/flowctl.py" scripts/flowctl.py
 cp "$PLUGIN_ROOT/scripts/flowctl" scripts/flowctl

--- a/plugins/flow-next/skills/flow-next-epic-review/SKILL.md
+++ b/plugins/flow-next/skills/flow-next-epic-review/SKILL.md
@@ -10,7 +10,7 @@ description: Epic completion review - verifies all epic tasks implement spec req
 Verify that the combined implementation of all epic tasks satisfies the spec requirements. This is NOT a code quality review (that's impl-review's job) — this confirms spec compliance only.
 
 **Role**: Epic Review Coordinator (NOT the reviewer)
-**Backends**: RepoPrompt (rp) or Codex CLI (codex)
+**Backends**: RepoPrompt (rp) or Codex CLI (codex) or Copilot CLI (copilot)
 
 **CRITICAL: flowctl is BUNDLED — NOT installed globally.** `which flowctl` will fail (expected). Always use:
 ```bash
@@ -20,8 +20,8 @@ FLOWCTL="${CLAUDE_PLUGIN_ROOT}/scripts/flowctl"
 ## Backend Selection
 
 **Priority** (first match wins):
-1. `--review=rp|codex|none` argument
-2. `FLOW_REVIEW_BACKEND` env var (`rp`, `codex`, `none`)
+1. `--review=rp|codex|copilot|none` argument
+2. `FLOW_REVIEW_BACKEND` env var (`rp`, `codex`, `copilot`, `none`)
 3. `.flow/config.json` → `review.backend`
 4. **Error** - no auto-detection
 
@@ -30,6 +30,7 @@ FLOWCTL="${CLAUDE_PLUGIN_ROOT}/scripts/flowctl"
 Check $ARGUMENTS for:
 - `--review=rp` or `--review rp` → use rp
 - `--review=codex` or `--review codex` → use codex
+- `--review=copilot` or `--review copilot` → use copilot
 - `--review=none` or `--review none` → skip review
 
 If found, use that backend and skip all other detection.
@@ -41,11 +42,11 @@ BACKEND=$($FLOWCTL review-backend)
 
 if [[ "$BACKEND" == "ASK" ]]; then
   echo "Error: No review backend configured."
-  echo "Run /flow-next:setup to configure, or pass --review=rp|codex|none"
+echo "Run /flow-next:setup to configure, or pass --review=rp|codex|copilot|none"
   exit 1
 fi
 
-echo "Review backend: $BACKEND (override: --review=rp|codex|none)"
+echo "Review backend: $BACKEND (override: --review=rp|codex|copilot|none)"
 ```
 
 ## Critical Rules
@@ -62,6 +63,11 @@ echo "Review backend: $BACKEND (override: --review=rp|codex|none)"
 2. Pass `--receipt` for session continuity on re-reviews
 3. Parse verdict from command output
 
+**For copilot backend:**
+1. Use `$FLOWCTL copilot completion-review` exclusively
+2. Pass `--receipt` for session continuity on re-reviews
+3. Parse verdict from command output
+
 **For all backends:**
 - If `REVIEW_RECEIPT_PATH` set: write receipt after SHIP verdict (RP writes manually after fix loop; codex writes automatically via `--receipt`)
 - Any failure → output `<promise>RETRY</promise>` and stop
@@ -74,7 +80,7 @@ echo "Review backend: $BACKEND (override: --review=rp|codex|none)"
 ## Input
 
 Arguments: $ARGUMENTS
-Format: `<epic-id> [--review=rp|codex|none]`
+Format: `<epic-id> [--review=rp|codex|copilot|none]`
 
 - Epic ID - Required, e.g. `fn-1` or `fn-22-53k`
 - `--review` - Optional backend override
@@ -105,6 +111,17 @@ Run backend detection from SKILL.md above. Then branch:
 RECEIPT_PATH="${REVIEW_RECEIPT_PATH:-/tmp/completion-review-receipt.json}"
 
 $FLOWCTL codex completion-review "$EPIC_ID" --receipt "$RECEIPT_PATH"
+# Output includes VERDICT=SHIP|NEEDS_WORK
+```
+
+On NEEDS_WORK: fix code, commit, re-run (receipt enables session continuity).
+
+### Copilot Backend
+
+```bash
+RECEIPT_PATH="${REVIEW_RECEIPT_PATH:-/tmp/completion-review-receipt.json}"
+
+$FLOWCTL copilot completion-review "$EPIC_ID" --receipt "$RECEIPT_PATH"
 # Output includes VERDICT=SHIP|NEEDS_WORK
 ```
 

--- a/plugins/flow-next/skills/flow-next-epic-review/workflow.md
+++ b/plugins/flow-next/skills/flow-next-epic-review/workflow.md
@@ -26,7 +26,7 @@ BACKEND=$($FLOWCTL review-backend)
 
 if [[ "$BACKEND" == "ASK" ]]; then
   echo "Error: No review backend configured."
-  echo "Run /flow-next:setup to configure, or pass --review=rp|codex|none"
+  echo "Run /flow-next:setup to configure, or pass --review=rp|codex|copilot|none"
   exit 1
 fi
 
@@ -73,6 +73,43 @@ If `VERDICT=NEEDS_WORK`:
 
 Receipt is written automatically by `flowctl codex completion-review` when `--receipt` provided.
 Format: `{"type":"completion_review","id":"<epic-id>","mode":"codex","verdict":"<verdict>","session_id":"<thread_id>","timestamp":"..."}`
+
+---
+
+## Copilot Backend Workflow
+
+Use when `BACKEND="copilot"`.
+
+### Step 1: Identify Epic
+
+```bash
+# EPIC_ID from arguments (e.g., fn-1, fn-22-53k)
+$FLOWCTL show "$EPIC_ID" --json
+```
+
+### Step 2: Execute Review
+
+```bash
+RECEIPT_PATH="${REVIEW_RECEIPT_PATH:-/tmp/completion-review-receipt.json}"
+
+$FLOWCTL copilot completion-review "$EPIC_ID" --receipt "$RECEIPT_PATH"
+```
+
+**Output includes `VERDICT=SHIP|NEEDS_WORK`.**
+
+### Step 3: Handle Verdict
+
+If `VERDICT=NEEDS_WORK`:
+1. Parse issues from output
+2. Fix code and run tests
+3. Commit fixes
+4. Re-run step 2 (receipt enables session continuity)
+5. Repeat until SHIP
+
+### Step 4: Receipt
+
+Receipt is written automatically by `flowctl copilot completion-review` when `--receipt` provided.
+Format: `{"type":"completion_review","id":"<epic-id>","mode":"copilot","verdict":"<verdict>","session_id":"<session_id>","timestamp":"..."}`
 
 ---
 

--- a/plugins/flow-next/skills/flow-next-impl-review/SKILL.md
+++ b/plugins/flow-next/skills/flow-next-impl-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: flow-next-impl-review
-description: John Carmack-level implementation review via RepoPrompt or Codex. Use when reviewing code changes, PRs, or implementations. Triggers on /flow-next:impl-review.
+description: John Carmack-level implementation review via RepoPrompt, Codex, or Copilot. Use when reviewing code changes, PRs, or implementations. Triggers on /flow-next:impl-review.
 ---
 
 # Implementation Review Mode
@@ -10,7 +10,7 @@ description: John Carmack-level implementation review via RepoPrompt or Codex. U
 Conduct a John Carmack-level review of implementation changes on the current branch.
 
 **Role**: Code Review Coordinator (NOT the reviewer)
-**Backends**: RepoPrompt (rp) or Codex CLI (codex)
+**Backends**: RepoPrompt (rp) or Codex CLI (codex) or Copilot CLI (copilot)
 
 **CRITICAL: flowctl is BUNDLED — NOT installed globally.** `which flowctl` will fail (expected). Always use:
 ```bash
@@ -20,8 +20,8 @@ FLOWCTL="${CLAUDE_PLUGIN_ROOT}/scripts/flowctl"
 ## Backend Selection
 
 **Priority** (first match wins):
-1. `--review=rp|codex|export|none` argument
-2. `FLOW_REVIEW_BACKEND` env var (`rp`, `codex`, `none`)
+1. `--review=rp|codex|copilot|export|none` argument
+2. `FLOW_REVIEW_BACKEND` env var (`rp`, `codex`, `copilot`, `none`)
 3. `.flow/config.json` → `review.backend`
 4. **Error** - no auto-detection
 
@@ -30,6 +30,7 @@ FLOWCTL="${CLAUDE_PLUGIN_ROOT}/scripts/flowctl"
 Check $ARGUMENTS for:
 - `--review=rp` or `--review rp` → use rp
 - `--review=codex` or `--review codex` → use codex
+- `--review=copilot` or `--review copilot` → use copilot
 - `--review=export` or `--review export` → use export
 - `--review=none` or `--review none` → skip review
 
@@ -42,11 +43,11 @@ BACKEND=$($FLOWCTL review-backend)
 
 if [[ "$BACKEND" == "ASK" ]]; then
   echo "Error: No review backend configured."
-  echo "Run /flow-next:setup to configure, or pass --review=rp|codex|none"
+echo "Run /flow-next:setup to configure, or pass --review=rp|codex|copilot|none"
   exit 1
 fi
 
-echo "Review backend: $BACKEND (override: --review=rp|codex|none)"
+echo "Review backend: $BACKEND (override: --review=rp|codex|copilot|none)"
 ```
 
 ## Critical Rules
@@ -60,6 +61,11 @@ echo "Review backend: $BACKEND (override: --review=rp|codex|none)"
 
 **For codex backend:**
 1. Use `$FLOWCTL codex impl-review` exclusively
+2. Pass `--receipt` for session continuity on re-reviews
+3. Parse verdict from command output
+
+**For copilot backend:**
+1. Use `$FLOWCTL copilot impl-review` exclusively
 2. Pass `--receipt` for session continuity on re-reviews
 3. Parse verdict from command output
 
@@ -117,6 +123,22 @@ if [[ -n "$BASE_COMMIT" ]]; then
   $FLOWCTL codex impl-review "$TASK_ID" --base "$BASE_COMMIT" --receipt "$RECEIPT_PATH"
 else
   $FLOWCTL codex impl-review "$TASK_ID" --base main --receipt "$RECEIPT_PATH"
+fi
+# Output includes VERDICT=SHIP|NEEDS_WORK|MAJOR_RETHINK
+```
+
+On NEEDS_WORK: fix code, commit, re-run (receipt enables session continuity).
+
+### Copilot Backend
+
+```bash
+RECEIPT_PATH="${REVIEW_RECEIPT_PATH:-/tmp/impl-review-receipt.json}"
+
+# Use BASE_COMMIT if provided, else fall back to main
+if [[ -n "$BASE_COMMIT" ]]; then
+  $FLOWCTL copilot impl-review "$TASK_ID" --base "$BASE_COMMIT" --receipt "$RECEIPT_PATH"
+else
+  $FLOWCTL copilot impl-review "$TASK_ID" --base main --receipt "$RECEIPT_PATH"
 fi
 # Output includes VERDICT=SHIP|NEEDS_WORK|MAJOR_RETHINK
 ```

--- a/plugins/flow-next/skills/flow-next-impl-review/workflow.md
+++ b/plugins/flow-next/skills/flow-next-impl-review/workflow.md
@@ -2,7 +2,7 @@
 
 ## Philosophy
 
-The reviewer model only sees selected files. RepoPrompt's Builder discovers context you'd miss (rp backend). Codex uses context hints from flowctl (codex backend).
+The reviewer model only sees selected files. RepoPrompt's Builder discovers context you'd miss (rp backend). Codex/Copilot use context hints from flowctl (codex/cp backends).
 
 ---
 
@@ -22,11 +22,11 @@ BACKEND=$($FLOWCTL review-backend)
 
 if [[ "$BACKEND" == "ASK" ]]; then
   echo "Error: No review backend configured."
-  echo "Run /flow-next:setup to configure, or pass --review=rp|codex|none"
+  echo "Run /flow-next:setup to configure, or pass --review=rp|codex|copilot|none"
   exit 1
 fi
 
-echo "Review backend: $BACKEND (override: --review=rp|codex|none)"
+echo "Review backend: $BACKEND (override: --review=rp|codex|copilot|none)"
 ```
 
 **If backend is "none"**: Skip review, inform user, and exit cleanly (no error).
@@ -79,6 +79,53 @@ If `VERDICT=NEEDS_WORK`:
 
 Receipt is written automatically by `flowctl codex impl-review` when `--receipt` provided.
 Format: `{"mode":"codex","task":"<id>","verdict":"<verdict>","session_id":"<thread_id>","timestamp":"..."}`
+
+---
+
+## Copilot Backend Workflow
+
+Use when `BACKEND="copilot"`.
+
+### Step 1: Identify Task and Diff Base
+
+```bash
+BRANCH="$(git branch --show-current)"
+
+# Use BASE_COMMIT from arguments if provided (task-scoped review)
+# Otherwise fall back to main/master (full branch review)
+if [[ -z "$BASE_COMMIT" ]]; then
+  DIFF_BASE="main"
+  git rev-parse main >/dev/null 2>&1 || DIFF_BASE="master"
+else
+  DIFF_BASE="$BASE_COMMIT"
+fi
+
+git log ${DIFF_BASE}..HEAD --oneline
+```
+
+### Step 2: Execute Review
+
+```bash
+RECEIPT_PATH="${REVIEW_RECEIPT_PATH:-/tmp/impl-review-receipt.json}"
+
+$FLOWCTL copilot impl-review "$TASK_ID" --base "$DIFF_BASE" --receipt "$RECEIPT_PATH"
+```
+
+**Output includes `VERDICT=SHIP|NEEDS_WORK|MAJOR_RETHINK`.**
+
+### Step 3: Handle Verdict
+
+If `VERDICT=NEEDS_WORK`:
+1. Parse issues from output
+2. Fix code and run tests
+3. Commit fixes
+4. Re-run step 2 (receipt enables session continuity)
+5. Repeat until SHIP
+
+### Step 4: Receipt
+
+Receipt is written automatically by `flowctl copilot impl-review` when `--receipt` provided.
+Format: `{"mode":"copilot","task":"<id>","verdict":"<verdict>","session_id":"<session_id>","timestamp":"..."}`
 
 ---
 

--- a/plugins/flow-next/skills/flow-next-plan-review/SKILL.md
+++ b/plugins/flow-next/skills/flow-next-plan-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: flow-next-plan-review
-description: Carmack-level plan review via RepoPrompt or Codex. Use when reviewing Flow epic specs or design docs. Triggers on /flow-next:plan-review.
+description: Carmack-level plan review via RepoPrompt, Codex, or Copilot. Use when reviewing Flow epic specs or design docs. Triggers on /flow-next:plan-review.
 ---
 
 # Plan Review Mode
@@ -10,7 +10,7 @@ description: Carmack-level plan review via RepoPrompt or Codex. Use when reviewi
 Conduct a John Carmack-level review of epic plans.
 
 **Role**: Code Review Coordinator (NOT the reviewer)
-**Backends**: RepoPrompt (rp) or Codex CLI (codex)
+**Backends**: RepoPrompt (rp) or Codex CLI (codex) or Copilot CLI (copilot)
 
 **CRITICAL: flowctl is BUNDLED — NOT installed globally.** `which flowctl` will fail (expected). Always use:
 ```bash
@@ -20,8 +20,8 @@ FLOWCTL="${CLAUDE_PLUGIN_ROOT}/scripts/flowctl"
 ## Backend Selection
 
 **Priority** (first match wins):
-1. `--review=rp|codex|export|none` argument
-2. `FLOW_REVIEW_BACKEND` env var (`rp`, `codex`, `none`)
+1. `--review=rp|codex|copilot|export|none` argument
+2. `FLOW_REVIEW_BACKEND` env var (`rp`, `codex`, `copilot`, `none`)
 3. `.flow/config.json` → `review.backend`
 4. **Error** - no auto-detection
 
@@ -30,6 +30,7 @@ FLOWCTL="${CLAUDE_PLUGIN_ROOT}/scripts/flowctl"
 Check $ARGUMENTS for:
 - `--review=rp` or `--review rp` → use rp
 - `--review=codex` or `--review codex` → use codex
+- `--review=copilot` or `--review copilot` → use copilot
 - `--review=export` or `--review export` → use export
 - `--review=none` or `--review none` → skip review
 
@@ -43,11 +44,11 @@ BACKEND=$($FLOWCTL review-backend)
 
 if [[ "$BACKEND" == "ASK" ]]; then
   echo "Error: No review backend configured."
-  echo "Run /flow-next:setup to configure, or pass --review=rp|codex|none"
+echo "Run /flow-next:setup to configure, or pass --review=rp|codex|copilot|none"
   exit 1
 fi
 
-echo "Review backend: $BACKEND (override: --review=rp|codex|none)"
+echo "Review backend: $BACKEND (override: --review=rp|codex|copilot|none)"
 ```
 
 ## Critical Rules
@@ -61,6 +62,11 @@ echo "Review backend: $BACKEND (override: --review=rp|codex|none)"
 
 **For codex backend:**
 1. Use `$FLOWCTL codex plan-review` exclusively
+2. Pass `--receipt` for session continuity on re-reviews
+3. Parse verdict from command output
+
+**For copilot backend:**
+1. Use `$FLOWCTL copilot plan-review` exclusively
 2. Pass `--receipt` for session continuity on re-reviews
 3. Parse verdict from command output
 
@@ -117,6 +123,26 @@ $FLOWCTL codex plan-review "$EPIC_ID" --files "$CODE_FILES" --receipt "$RECEIPT_
 On NEEDS_WORK: fix plan via `$FLOWCTL epic set-plan` AND sync affected task specs via `$FLOWCTL task set-spec`, then re-run (receipt enables session continuity).
 
 **Note**: `codex plan-review` automatically includes task specs in the review prompt.
+
+### Copilot Backend
+
+```bash
+EPIC_ID="${1:-}"
+RECEIPT_PATH="${REVIEW_RECEIPT_PATH:-/tmp/plan-review-receipt.json}"
+
+# Save checkpoint before review (recovery point if context compacts)
+$FLOWCTL checkpoint save --epic "$EPIC_ID" --json
+
+# --files: comma-separated CODE files for reviewer context
+CODE_FILES="src/main.py,src/config.py"
+
+$FLOWCTL copilot plan-review "$EPIC_ID" --files "$CODE_FILES" --receipt "$RECEIPT_PATH"
+# Output includes VERDICT=SHIP|NEEDS_WORK|MAJOR_RETHINK
+```
+
+On NEEDS_WORK: fix plan via `$FLOWCTL epic set-plan` AND sync affected task specs via `$FLOWCTL task set-spec`, then re-run (receipt enables session continuity).
+
+**Note**: `copilot plan-review` automatically includes task specs in the review prompt.
 
 ### RepoPrompt Backend
 

--- a/plugins/flow-next/skills/flow-next-plan-review/workflow.md
+++ b/plugins/flow-next/skills/flow-next-plan-review/workflow.md
@@ -2,7 +2,7 @@
 
 ## Philosophy
 
-The reviewer model only sees selected files. RepoPrompt's Builder discovers context you'd miss (rp backend). Codex uses context hints from flowctl (codex backend).
+The reviewer model only sees selected files. RepoPrompt's Builder discovers context you'd miss (rp backend). Codex/Copilot use context hints from flowctl (codex/cp backends).
 
 ---
 
@@ -22,11 +22,11 @@ BACKEND=$($FLOWCTL review-backend)
 
 if [[ "$BACKEND" == "ASK" ]]; then
   echo "Error: No review backend configured."
-  echo "Run /flow-next:setup to configure, or pass --review=rp|codex|none"
+  echo "Run /flow-next:setup to configure, or pass --review=rp|codex|copilot|none"
   exit 1
 fi
 
-echo "Review backend: $BACKEND (override: --review=rp|codex|none)"
+echo "Review backend: $BACKEND (override: --review=rp|codex|copilot|none)"
 ```
 
 **If backend is "none"**: Skip review, inform user, and exit cleanly (no error).
@@ -83,6 +83,56 @@ If `VERDICT=NEEDS_WORK`:
 
 Receipt is written automatically by `flowctl codex plan-review` when `--receipt` provided.
 Format: `{"mode":"codex","epic":"<id>","verdict":"<verdict>","session_id":"<thread_id>","timestamp":"..."}`
+
+---
+
+## Copilot Backend Workflow
+
+Use when `BACKEND="copilot"`.
+
+### Step 0: Save Checkpoint
+
+**Before review** (protects against context compaction):
+```bash
+EPIC_ID="${1:-}"
+$FLOWCTL checkpoint save --epic "$EPIC_ID" --json
+```
+
+### Step 1: Execute Review
+
+```bash
+RECEIPT_PATH="${REVIEW_RECEIPT_PATH:-/tmp/plan-review-receipt.json}"
+
+# --files: comma-separated CODE files for reviewer context
+# Epic/task specs are auto-included; pass files the plan will CREATE or MODIFY
+CODE_FILES="src/main.py,src/config.py"  # Customize per epic
+
+$FLOWCTL copilot plan-review "$EPIC_ID" --files "$CODE_FILES" --receipt "$RECEIPT_PATH"
+```
+
+**Output includes `VERDICT=SHIP|NEEDS_WORK|MAJOR_RETHINK`.**
+
+### Step 2: Update Status
+
+```bash
+# Based on verdict
+$FLOWCTL epic set-plan-review-status "$EPIC_ID" --status ship --json
+# OR
+$FLOWCTL epic set-plan-review-status "$EPIC_ID" --status needs_work --json
+```
+
+### Step 3: Handle Verdict
+
+If `VERDICT=NEEDS_WORK`:
+1. Parse issues from output
+2. Fix plan via `$FLOWCTL epic set-plan`
+3. Re-run step 1 (receipt enables session continuity)
+4. Repeat until SHIP
+
+### Step 4: Receipt
+
+Receipt is written automatically by `flowctl copilot plan-review` when `--receipt` provided.
+Format: `{"mode":"copilot","epic":"<id>","verdict":"<verdict>","session_id":"<session_id>","timestamp":"..."}`
 
 ---
 

--- a/plugins/flow-next/skills/flow-next-plan/SKILL.md
+++ b/plugins/flow-next/skills/flow-next-plan/SKILL.md
@@ -75,7 +75,7 @@ Check configured backend:
 ```bash
 REVIEW_BACKEND=$($FLOWCTL review-backend)
 ```
-Returns: `ASK` (not configured), or `rp`/`codex`/`none` (configured).
+Returns: `ASK` (not configured), or `rp`/`codex`/`copilot`/`none` (configured).
 
 ### Option Parsing (skip questions if found in arguments)
 
@@ -86,6 +86,7 @@ Parse the arguments for these patterns. If found, use them and skip questions:
 - `--research=grep` or `--research grep` or "use grep" or "repo-scout" or "fast" → repo-scout
 
 **Review mode**:
+- `--review=copilot` or "review with copilot" or "copilot review" or "use copilot" → Copilot CLI
 - `--review=codex` or "review with codex" or "codex review" or "use codex" → Codex CLI (GPT 5.2 High)
 - `--review=rp` or "review with rp" or "rp chat" or "repoprompt review" → RepoPrompt chat (via `flowctl rp chat-send`)
 - `--review=export` or "export review" or "external llm" → export for external LLM
@@ -99,7 +100,7 @@ Parse the arguments for these patterns. If found, use them and skip questions:
 - `--depth=deep` or "comprehensive" or "detailed" → DEEP
 - Default: SHORT (simpler is better)
 
-**If REVIEW_BACKEND is rp, codex, or none** (already configured): Only ask research question. Show override hint:
+**If REVIEW_BACKEND is rp, codex, copilot, or none** (already configured): Only ask research question. Show override hint:
 
 ```
 Quick setup: Use RepoPrompt for deeper context?
@@ -107,7 +108,7 @@ a) Yes, context-scout (slower, thorough)
 b) No, repo-scout (faster)
 
 (Reply: "a", "b", or just tell me)
-(Tip: --depth=short|standard|deep, --review=rp|codex|none)
+(Tip: --depth=short|standard|deep, --review=rp|codex|copilot|none)
 ```
 
 **If REVIEW_BACKEND is ASK** (not configured): Ask all questions (do NOT use AskUserQuestion tool):
@@ -125,10 +126,11 @@ Quick setup before planning:
    b) No, repo-scout (faster)
 
 3. **Review** — Run Carmack-level review after?
-   a) Codex CLI
-   b) RepoPrompt
-   c) Export for external LLM
-   d) None (configure later)
+   a) Copilot CLI
+   b) Codex CLI
+   c) RepoPrompt
+   d) Export for external LLM
+   e) None (configure later)
 
 (Reply: "1a 2b 3d", or just tell me naturally)
 ```

--- a/plugins/flow-next/skills/flow-next-ralph-init/SKILL.md
+++ b/plugins/flow-next/skills/flow-next-ralph-init/SKILL.md
@@ -29,21 +29,24 @@ Scaffold or update repo-local Ralph harness. Opt-in only.
    ```bash
    HAVE_RP=$(which rp-cli >/dev/null 2>&1 && echo 1 || echo 0)
    HAVE_CODEX=$(which codex >/dev/null 2>&1 && echo 1 || echo 0)
+   HAVE_COPILOT=$(which copilot >/dev/null 2>&1 && echo 1 || echo 0)
    ```
 
 4. Determine review backend (skip if UPDATE_MODE=1):
    - If BOTH available, ask user (do NOT use AskUserQuestion tool):
      ```
-     Both RepoPrompt and Codex available. Which review backend?
-     a) RepoPrompt (macOS, visual builder)
-     b) Codex CLI (cross-platform, GPT 5.2 High)
+    Review backends available. Which review backend?
+    a) RepoPrompt (macOS, visual builder)
+    b) Codex CLI (cross-platform, GPT 5.2 High)
+    c) Copilot CLI (cross-platform)
 
-     (Reply: "a", "rp", "b", "codex", or just tell me)
+    (Reply: "a", "rp", "b", "codex", "c", "copilot", or just tell me)
      ```
      Wait for response. Default if empty/ambiguous: `rp`
-   - If only rp-cli available: use `rp`
-   - If only codex available: use `codex`
-   - If neither available: use `none`
+    - If only rp-cli available: use `rp`
+    - If only codex available: use `codex`
+    - If only copilot available: use `copilot`
+    - If neither available: use `none`
 
 5. Copy files using bash (MUST use cp, NOT Write tool):
 

--- a/plugins/flow-next/skills/flow-next-ralph-init/templates/config.env
+++ b/plugins/flow-next/skills/flow-next-ralph-init/templates/config.env
@@ -25,6 +25,9 @@ CODEX_SANDBOX=auto
 # 500KB default (~70% of Codex 200k token context). Set to 0 for unlimited.
 FLOW_CODEX_EMBED_MAX_BYTES=500000
 
+# Copilot model (required for copilot reviews)
+COPILOT_MODEL=gpt-5.1
+
 # Work settings
 BRANCH_MODE=new
 MAX_ITERATIONS=25

--- a/plugins/flow-next/skills/flow-next-ralph-init/templates/config.env
+++ b/plugins/flow-next/skills/flow-next-ralph-init/templates/config.env
@@ -25,8 +25,9 @@ CODEX_SANDBOX=auto
 # 500KB default (~70% of Codex 200k token context). Set to 0 for unlimited.
 FLOW_CODEX_EMBED_MAX_BYTES=500000
 
-# Copilot model (required for copilot reviews)
-COPILOT_MODEL=gpt-5.1
+# Copilot model (only used when PLAN_REVIEW or WORK_REVIEW is copilot)
+FLOW_COPILOT_MODEL=gpt-5.2
+
 
 # Work settings
 BRANCH_MODE=new

--- a/plugins/flow-next/skills/flow-next-ralph-init/templates/config.env
+++ b/plugins/flow-next/skills/flow-next-ralph-init/templates/config.env
@@ -5,15 +5,15 @@ EPICS=
 
 # Plan gate
 REQUIRE_PLAN_REVIEW=0
-# PLAN_REVIEW options: rp (RepoPrompt, macOS), codex (cross-platform), none
+# PLAN_REVIEW options: rp (RepoPrompt, macOS), codex (cross-platform), copilot (cross-platform), none
 PLAN_REVIEW={{PLAN_REVIEW}}
 
 # Work gate
-# WORK_REVIEW options: rp (RepoPrompt, macOS), codex (cross-platform), none
+# WORK_REVIEW options: rp (RepoPrompt, macOS), codex (cross-platform), copilot (cross-platform), none
 WORK_REVIEW={{WORK_REVIEW}}
 
 # Epic completion gate (runs when all tasks done, before epic closes)
-# COMPLETION_REVIEW options: rp (RepoPrompt, macOS), codex (cross-platform), none
+# COMPLETION_REVIEW options: rp (RepoPrompt, macOS), codex (cross-platform), copilot (cross-platform), none
 COMPLETION_REVIEW={{COMPLETION_REVIEW}}
 
 # Codex sandbox mode (only used when PLAN_REVIEW or WORK_REVIEW is codex)

--- a/plugins/flow-next/skills/flow-next-ralph-init/templates/prompt_completion.md
+++ b/plugins/flow-next/skills/flow-next-ralph-init/templates/prompt_completion.md
@@ -19,25 +19,25 @@ Steps:
 Ralph mode rules (must follow):
 - If COMPLETION_REVIEW=rp: use `flowctl rp` wrappers (setup-review, select-add, prompt-get, chat-send).
 - If COMPLETION_REVIEW=codex: use `flowctl codex` wrappers (completion-review with --receipt).
-- If COMPLETION_REVIEW=copilot: use `flowctl copilot` wrappers (completion-review with --receipt and `--model "$FLOW_COPILOT_MODEL"`).
+- If COMPLETION_REVIEW=copilot: use `flowctl copilot` wrappers (completion-review with --receipt).
 - Write receipt via bash heredoc (no Write tool) if `REVIEW_RECEIPT_PATH` set.
 - If any rule is violated, output `<promise>RETRY</promise>` and stop.
 
-3) Completion review gate:
+1) Completion review gate:
    - If COMPLETION_REVIEW=rp: run `/flow-next:epic-review {{EPIC_ID}} --review=rp`
    - If COMPLETION_REVIEW=codex: run `/flow-next:epic-review {{EPIC_ID}} --review=codex`
-  - If COMPLETION_REVIEW=copilot: run `/flow-next:epic-review {{EPIC_ID}} --review=copilot` (flowctl will use `--model "$FLOW_COPILOT_MODEL"`).
+   - If COMPLETION_REVIEW=copilot: run `/flow-next:epic-review {{EPIC_ID}} --review=copilot`
    - If COMPLETION_REVIEW=none: set ship and stop:
      `scripts/ralph/flowctl epic set-completion-review-status {{EPIC_ID}} --status ship --json`
 
-4) The skill will loop internally until `<verdict>SHIP</verdict>`:
+2) The skill will loop internally until `<verdict>SHIP</verdict>`:
    - First review uses `--new-chat`
    - If NEEDS_WORK: skill fixes gaps (creates tasks or implements inline), re-reviews in SAME chat
    - Repeats until SHIP
    - Only returns to Ralph after SHIP or MAJOR_RETHINK
    - If context compacts mid-review: `scripts/ralph/flowctl checkpoint restore --epic {{EPIC_ID}} --json`
 
-5) IMMEDIATELY after SHIP verdict, write receipt (for rp mode):
+3) IMMEDIATELY after SHIP verdict, write receipt (for rp mode):
    ```bash
    mkdir -p "$(dirname '{{REVIEW_RECEIPT_PATH}}')"
    ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
@@ -49,15 +49,15 @@ Ralph mode rules (must follow):
    **CRITICAL: Copy EXACTLY. The `"id":"{{EPIC_ID}}"` field is REQUIRED.**
    Missing id = verification fails = forced retry.
 
-6) After SHIP:
+4) After SHIP:
    - `scripts/ralph/flowctl epic set-completion-review-status {{EPIC_ID}} --status ship --json`
    - stop (do NOT output promise tag)
 
-7) If MAJOR_RETHINK (rare):
+5) If MAJOR_RETHINK (rare):
    - `scripts/ralph/flowctl epic set-completion-review-status {{EPIC_ID}} --status needs_work --json`
    - output `<promise>FAIL</promise>` and stop
 
-8) On hard failure, output `<promise>FAIL</promise>` and stop.
+6) On hard failure, output `<promise>FAIL</promise>` and stop.
 
 ## FORBIDDEN OUTPUT
 **NEVER output `<promise>COMPLETE</promise>`** - this prompt handles ONE epic only.

--- a/plugins/flow-next/skills/flow-next-ralph-init/templates/prompt_completion.md
+++ b/plugins/flow-next/skills/flow-next-ralph-init/templates/prompt_completion.md
@@ -19,14 +19,14 @@ Steps:
 Ralph mode rules (must follow):
 - If COMPLETION_REVIEW=rp: use `flowctl rp` wrappers (setup-review, select-add, prompt-get, chat-send).
 - If COMPLETION_REVIEW=codex: use `flowctl codex` wrappers (completion-review with --receipt).
-- If COMPLETION_REVIEW=copilot: use `flowctl copilot` wrappers (completion-review with --receipt).
+- If COMPLETION_REVIEW=copilot: use `flowctl copilot` wrappers (completion-review with --receipt and `--model "$COPILOT_MODEL"`).
 - Write receipt via bash heredoc (no Write tool) if `REVIEW_RECEIPT_PATH` set.
 - If any rule is violated, output `<promise>RETRY</promise>` and stop.
 
 3) Completion review gate:
    - If COMPLETION_REVIEW=rp: run `/flow-next:epic-review {{EPIC_ID}} --review=rp`
    - If COMPLETION_REVIEW=codex: run `/flow-next:epic-review {{EPIC_ID}} --review=codex`
-   - If COMPLETION_REVIEW=copilot: run `/flow-next:epic-review {{EPIC_ID}} --review=copilot`
+  - If COMPLETION_REVIEW=copilot: run `/flow-next:epic-review {{EPIC_ID}} --review=copilot` (flowctl will use `--model "$COPILOT_MODEL"`).
    - If COMPLETION_REVIEW=none: set ship and stop:
      `scripts/ralph/flowctl epic set-completion-review-status {{EPIC_ID}} --status ship --json`
 

--- a/plugins/flow-next/skills/flow-next-ralph-init/templates/prompt_completion.md
+++ b/plugins/flow-next/skills/flow-next-ralph-init/templates/prompt_completion.md
@@ -19,12 +19,14 @@ Steps:
 Ralph mode rules (must follow):
 - If COMPLETION_REVIEW=rp: use `flowctl rp` wrappers (setup-review, select-add, prompt-get, chat-send).
 - If COMPLETION_REVIEW=codex: use `flowctl codex` wrappers (completion-review with --receipt).
+- If COMPLETION_REVIEW=copilot: use `flowctl copilot` wrappers (completion-review with --receipt).
 - Write receipt via bash heredoc (no Write tool) if `REVIEW_RECEIPT_PATH` set.
 - If any rule is violated, output `<promise>RETRY</promise>` and stop.
 
 3) Completion review gate:
    - If COMPLETION_REVIEW=rp: run `/flow-next:epic-review {{EPIC_ID}} --review=rp`
    - If COMPLETION_REVIEW=codex: run `/flow-next:epic-review {{EPIC_ID}} --review=codex`
+   - If COMPLETION_REVIEW=copilot: run `/flow-next:epic-review {{EPIC_ID}} --review=copilot`
    - If COMPLETION_REVIEW=none: set ship and stop:
      `scripts/ralph/flowctl epic set-completion-review-status {{EPIC_ID}} --status ship --json`
 

--- a/plugins/flow-next/skills/flow-next-ralph-init/templates/prompt_completion.md
+++ b/plugins/flow-next/skills/flow-next-ralph-init/templates/prompt_completion.md
@@ -19,14 +19,14 @@ Steps:
 Ralph mode rules (must follow):
 - If COMPLETION_REVIEW=rp: use `flowctl rp` wrappers (setup-review, select-add, prompt-get, chat-send).
 - If COMPLETION_REVIEW=codex: use `flowctl codex` wrappers (completion-review with --receipt).
-- If COMPLETION_REVIEW=copilot: use `flowctl copilot` wrappers (completion-review with --receipt and `--model "$COPILOT_MODEL"`).
+- If COMPLETION_REVIEW=copilot: use `flowctl copilot` wrappers (completion-review with --receipt and `--model "$FLOW_COPILOT_MODEL"`).
 - Write receipt via bash heredoc (no Write tool) if `REVIEW_RECEIPT_PATH` set.
 - If any rule is violated, output `<promise>RETRY</promise>` and stop.
 
 3) Completion review gate:
    - If COMPLETION_REVIEW=rp: run `/flow-next:epic-review {{EPIC_ID}} --review=rp`
    - If COMPLETION_REVIEW=codex: run `/flow-next:epic-review {{EPIC_ID}} --review=codex`
-  - If COMPLETION_REVIEW=copilot: run `/flow-next:epic-review {{EPIC_ID}} --review=copilot` (flowctl will use `--model "$COPILOT_MODEL"`).
+  - If COMPLETION_REVIEW=copilot: run `/flow-next:epic-review {{EPIC_ID}} --review=copilot` (flowctl will use `--model "$FLOW_COPILOT_MODEL"`).
    - If COMPLETION_REVIEW=none: set ship and stop:
      `scripts/ralph/flowctl epic set-completion-review-status {{EPIC_ID}} --status ship --json`
 

--- a/plugins/flow-next/skills/flow-next-ralph-init/templates/prompt_plan.md
+++ b/plugins/flow-next/skills/flow-next-ralph-init/templates/prompt_plan.md
@@ -20,28 +20,28 @@ Steps:
 Ralph mode rules (must follow):
 - If PLAN_REVIEW=rp: use `flowctl rp` wrappers (setup-review, select-add, prompt-get, chat-send).
 - If PLAN_REVIEW=codex: use `flowctl codex` wrappers (plan-review with --receipt).
-- If PLAN_REVIEW=copilot: use `flowctl copilot` wrappers (plan-review with --receipt and `--model "$FLOW_COPILOT_MODEL"`).
+- If PLAN_REVIEW=copilot: use `flowctl copilot` wrappers (plan-review with --receipt).
 - Write receipt via bash heredoc (no Write tool) if `REVIEW_RECEIPT_PATH` set.
 - If any rule is violated, output `<promise>RETRY</promise>` and stop.
 
-3) Plan review gate:
+1) Plan review gate:
    - If PLAN_REVIEW=rp: run `/flow-next:plan-review {{EPIC_ID}} --review=rp`
    - If PLAN_REVIEW=codex: run `/flow-next:plan-review {{EPIC_ID}} --review=codex`
-  - If PLAN_REVIEW=copilot: run `/flow-next:plan-review {{EPIC_ID}} --review=copilot` (flowctl will use `--model "$FLOW_COPILOT_MODEL"`).
+   - If PLAN_REVIEW=copilot: run `/flow-next:plan-review {{EPIC_ID}} --review=copilot` 
    - If PLAN_REVIEW=export: run `/flow-next:plan-review {{EPIC_ID}} --review=export`
    - If PLAN_REVIEW=none:
      - If REQUIRE_PLAN_REVIEW=1: output `<promise>RETRY</promise>` and stop.
      - Else: set ship and stop:
        `scripts/ralph/flowctl epic set-plan-review-status {{EPIC_ID}} --status ship --json`
 
-4) The skill will loop internally until `<verdict>SHIP</verdict>`:
+2) The skill will loop internally until `<verdict>SHIP</verdict>`:
    - First review uses `--new-chat`
    - If NEEDS_WORK: skill fixes plan AND syncs affected task specs, re-reviews in SAME chat (no --new-chat)
    - Repeats until SHIP
    - Only returns to Ralph after SHIP or MAJOR_RETHINK
    - If context compacts mid-review: `scripts/ralph/flowctl checkpoint restore --epic {{EPIC_ID}} --json`
 
-5) IMMEDIATELY after SHIP verdict, write receipt (for rp mode):
+3) IMMEDIATELY after SHIP verdict, write receipt (for rp mode):
    ```bash
    mkdir -p "$(dirname '{{REVIEW_RECEIPT_PATH}}')"
    ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
@@ -53,15 +53,15 @@ Ralph mode rules (must follow):
    **CRITICAL: Copy EXACTLY. The `"id":"{{EPIC_ID}}"` field is REQUIRED.**
    Missing id = verification fails = forced retry.
 
-6) After SHIP:
+4) After SHIP:
    - `scripts/ralph/flowctl epic set-plan-review-status {{EPIC_ID}} --status ship --json`
    - stop (do NOT output promise tag)
 
-7) If MAJOR_RETHINK (rare):
+5) If MAJOR_RETHINK (rare):
    - `scripts/ralph/flowctl epic set-plan-review-status {{EPIC_ID}} --status needs_work --json`
    - output `<promise>FAIL</promise>` and stop
 
-8) On hard failure, output `<promise>FAIL</promise>` and stop.
+6) On hard failure, output `<promise>FAIL</promise>` and stop.
 
 ## ⛔ FORBIDDEN OUTPUT
 **NEVER output `<promise>COMPLETE</promise>`** — this prompt handles ONE epic only.

--- a/plugins/flow-next/skills/flow-next-ralph-init/templates/prompt_plan.md
+++ b/plugins/flow-next/skills/flow-next-ralph-init/templates/prompt_plan.md
@@ -20,14 +20,14 @@ Steps:
 Ralph mode rules (must follow):
 - If PLAN_REVIEW=rp: use `flowctl rp` wrappers (setup-review, select-add, prompt-get, chat-send).
 - If PLAN_REVIEW=codex: use `flowctl codex` wrappers (plan-review with --receipt).
-- If PLAN_REVIEW=copilot: use `flowctl copilot` wrappers (plan-review with --receipt).
+- If PLAN_REVIEW=copilot: use `flowctl copilot` wrappers (plan-review with --receipt and `--model "$COPILOT_MODEL"`).
 - Write receipt via bash heredoc (no Write tool) if `REVIEW_RECEIPT_PATH` set.
 - If any rule is violated, output `<promise>RETRY</promise>` and stop.
 
 3) Plan review gate:
    - If PLAN_REVIEW=rp: run `/flow-next:plan-review {{EPIC_ID}} --review=rp`
    - If PLAN_REVIEW=codex: run `/flow-next:plan-review {{EPIC_ID}} --review=codex`
-   - If PLAN_REVIEW=copilot: run `/flow-next:plan-review {{EPIC_ID}} --review=copilot`
+  - If PLAN_REVIEW=copilot: run `/flow-next:plan-review {{EPIC_ID}} --review=copilot` (flowctl will use `--model "$COPILOT_MODEL"`).
    - If PLAN_REVIEW=export: run `/flow-next:plan-review {{EPIC_ID}} --review=export`
    - If PLAN_REVIEW=none:
      - If REQUIRE_PLAN_REVIEW=1: output `<promise>RETRY</promise>` and stop.

--- a/plugins/flow-next/skills/flow-next-ralph-init/templates/prompt_plan.md
+++ b/plugins/flow-next/skills/flow-next-ralph-init/templates/prompt_plan.md
@@ -20,12 +20,14 @@ Steps:
 Ralph mode rules (must follow):
 - If PLAN_REVIEW=rp: use `flowctl rp` wrappers (setup-review, select-add, prompt-get, chat-send).
 - If PLAN_REVIEW=codex: use `flowctl codex` wrappers (plan-review with --receipt).
+- If PLAN_REVIEW=copilot: use `flowctl copilot` wrappers (plan-review with --receipt).
 - Write receipt via bash heredoc (no Write tool) if `REVIEW_RECEIPT_PATH` set.
 - If any rule is violated, output `<promise>RETRY</promise>` and stop.
 
 3) Plan review gate:
    - If PLAN_REVIEW=rp: run `/flow-next:plan-review {{EPIC_ID}} --review=rp`
    - If PLAN_REVIEW=codex: run `/flow-next:plan-review {{EPIC_ID}} --review=codex`
+   - If PLAN_REVIEW=copilot: run `/flow-next:plan-review {{EPIC_ID}} --review=copilot`
    - If PLAN_REVIEW=export: run `/flow-next:plan-review {{EPIC_ID}} --review=export`
    - If PLAN_REVIEW=none:
      - If REQUIRE_PLAN_REVIEW=1: output `<promise>RETRY</promise>` and stop.

--- a/plugins/flow-next/skills/flow-next-ralph-init/templates/prompt_plan.md
+++ b/plugins/flow-next/skills/flow-next-ralph-init/templates/prompt_plan.md
@@ -20,14 +20,14 @@ Steps:
 Ralph mode rules (must follow):
 - If PLAN_REVIEW=rp: use `flowctl rp` wrappers (setup-review, select-add, prompt-get, chat-send).
 - If PLAN_REVIEW=codex: use `flowctl codex` wrappers (plan-review with --receipt).
-- If PLAN_REVIEW=copilot: use `flowctl copilot` wrappers (plan-review with --receipt and `--model "$COPILOT_MODEL"`).
+- If PLAN_REVIEW=copilot: use `flowctl copilot` wrappers (plan-review with --receipt and `--model "$FLOW_COPILOT_MODEL"`).
 - Write receipt via bash heredoc (no Write tool) if `REVIEW_RECEIPT_PATH` set.
 - If any rule is violated, output `<promise>RETRY</promise>` and stop.
 
 3) Plan review gate:
    - If PLAN_REVIEW=rp: run `/flow-next:plan-review {{EPIC_ID}} --review=rp`
    - If PLAN_REVIEW=codex: run `/flow-next:plan-review {{EPIC_ID}} --review=codex`
-  - If PLAN_REVIEW=copilot: run `/flow-next:plan-review {{EPIC_ID}} --review=copilot` (flowctl will use `--model "$COPILOT_MODEL"`).
+  - If PLAN_REVIEW=copilot: run `/flow-next:plan-review {{EPIC_ID}} --review=copilot` (flowctl will use `--model "$FLOW_COPILOT_MODEL"`).
    - If PLAN_REVIEW=export: run `/flow-next:plan-review {{EPIC_ID}} --review=export`
    - If PLAN_REVIEW=none:
      - If REQUIRE_PLAN_REVIEW=1: output `<promise>RETRY</promise>` and stop.

--- a/plugins/flow-next/skills/flow-next-ralph-init/templates/prompt_work.md
+++ b/plugins/flow-next/skills/flow-next-ralph-init/templates/prompt_work.md
@@ -13,7 +13,7 @@ Inputs:
 ```
 When `--review=rp`, the worker subagent invokes `/flow-next:impl-review` internally.
 When `--review=codex`, the worker uses `flowctl codex impl-review` for review.
-When `--review=copilot`, the worker uses `flowctl copilot impl-review` for review.
+When `--review=copilot`, the worker uses `flowctl copilot impl-review` with `--model "$COPILOT_MODEL"` for review.
 The impl-review skill handles review coordination and requires `<verdict>SHIP|NEEDS_WORK|MAJOR_RETHINK</verdict>` from reviewer.
 Do NOT improvise review prompts - the skill has the correct format.
 

--- a/plugins/flow-next/skills/flow-next-ralph-init/templates/prompt_work.md
+++ b/plugins/flow-next/skills/flow-next-ralph-init/templates/prompt_work.md
@@ -13,6 +13,7 @@ Inputs:
 ```
 When `--review=rp`, the worker subagent invokes `/flow-next:impl-review` internally.
 When `--review=codex`, the worker uses `flowctl codex impl-review` for review.
+When `--review=copilot`, the worker uses `flowctl copilot impl-review` for review.
 The impl-review skill handles review coordination and requires `<verdict>SHIP|NEEDS_WORK|MAJOR_RETHINK</verdict>` from reviewer.
 Do NOT improvise review prompts - the skill has the correct format.
 

--- a/plugins/flow-next/skills/flow-next-ralph-init/templates/prompt_work.md
+++ b/plugins/flow-next/skills/flow-next-ralph-init/templates/prompt_work.md
@@ -13,7 +13,7 @@ Inputs:
 ```
 When `--review=rp`, the worker subagent invokes `/flow-next:impl-review` internally.
 When `--review=codex`, the worker uses `flowctl codex impl-review` for review.
-When `--review=copilot`, the worker uses `flowctl copilot impl-review` with `--model "$FLOW_COPILOT_MODEL"` for review.
+When `--review=copilot`, the worker uses `flowctl copilot impl-review` for review.
 The impl-review skill handles review coordination and requires `<verdict>SHIP|NEEDS_WORK|MAJOR_RETHINK</verdict>` from reviewer.
 Do NOT improvise review prompts - the skill has the correct format.
 

--- a/plugins/flow-next/skills/flow-next-ralph-init/templates/prompt_work.md
+++ b/plugins/flow-next/skills/flow-next-ralph-init/templates/prompt_work.md
@@ -13,7 +13,7 @@ Inputs:
 ```
 When `--review=rp`, the worker subagent invokes `/flow-next:impl-review` internally.
 When `--review=codex`, the worker uses `flowctl codex impl-review` for review.
-When `--review=copilot`, the worker uses `flowctl copilot impl-review` with `--model "$COPILOT_MODEL"` for review.
+When `--review=copilot`, the worker uses `flowctl copilot impl-review` with `--model "$FLOW_COPILOT_MODEL"` for review.
 The impl-review skill handles review coordination and requires `<verdict>SHIP|NEEDS_WORK|MAJOR_RETHINK</verdict>` from reviewer.
 Do NOT improvise review prompts - the skill has the correct format.
 

--- a/plugins/flow-next/skills/flow-next-ralph-init/templates/ralph.sh
+++ b/plugins/flow-next/skills/flow-next-ralph-init/templates/ralph.sh
@@ -227,10 +227,13 @@ ui_config() {
   local plan_display="$PLAN_REVIEW" work_display="$WORK_REVIEW" completion_display="$COMPLETION_REVIEW"
   [[ "$PLAN_REVIEW" == "rp" ]] && plan_display="RepoPrompt"
   [[ "$PLAN_REVIEW" == "codex" ]] && plan_display="Codex"
+  [[ "$PLAN_REVIEW" == "copilot" ]] && plan_display="Copilot"
   [[ "$WORK_REVIEW" == "rp" ]] && work_display="RepoPrompt"
   [[ "$WORK_REVIEW" == "codex" ]] && work_display="Codex"
+  [[ "$WORK_REVIEW" == "copilot" ]] && work_display="Copilot"
   [[ "$COMPLETION_REVIEW" == "rp" ]] && completion_display="RepoPrompt"
   [[ "$COMPLETION_REVIEW" == "codex" ]] && completion_display="Codex"
+  [[ "$COMPLETION_REVIEW" == "copilot" ]] && completion_display="Copilot"
   ui "${C_DIM}   Reviews:${C_RESET} Plan=$plan_display ${C_DIM}•${C_RESET} Work=$work_display ${C_DIM}•${C_RESET} Completion=$completion_display"
   [[ -n "${EPICS:-}" ]] && ui "${C_DIM}   Scope:${C_RESET} $EPICS"
   ui ""
@@ -1047,7 +1050,7 @@ Violations break automation and leave the user with incomplete work. Be precise,
   plan_review_status=""
   task_status=""
   impl_receipt_ok="1"
-  if [[ "$status" == "plan" && ( "$PLAN_REVIEW" == "rp" || "$PLAN_REVIEW" == "codex" ) ]]; then
+  if [[ "$status" == "plan" && ( "$PLAN_REVIEW" == "rp" || "$PLAN_REVIEW" == "codex" || "$PLAN_REVIEW" == "copilot" ) ]]; then
     if ! verify_receipt "$REVIEW_RECEIPT_PATH" "plan_review" "$epic_id"; then
       echo "ralph: missing plan review receipt; forcing retry" >> "$iter_log"
       log "missing plan receipt; forcing retry"
@@ -1061,7 +1064,7 @@ Violations break automation and leave the user with incomplete work. Be precise,
   fi
   completion_review_status=""
   completion_receipt_ok="1"
-  if [[ "$status" == "completion_review" && ( "$COMPLETION_REVIEW" == "rp" || "$COMPLETION_REVIEW" == "codex" ) ]]; then
+  if [[ "$status" == "completion_review" && ( "$COMPLETION_REVIEW" == "rp" || "$COMPLETION_REVIEW" == "codex" || "$COMPLETION_REVIEW" == "copilot" ) ]]; then
     if ! verify_receipt "$REVIEW_RECEIPT_PATH" "completion_review" "$epic_id"; then
       echo "ralph: missing completion review receipt; forcing retry" >> "$iter_log"
       log "missing completion receipt; forcing retry"
@@ -1084,7 +1087,7 @@ Violations break automation and leave the user with incomplete work. Be precise,
     fi
   fi
   receipt_verdict=""
-  if [[ "$status" == "work" && ( "$WORK_REVIEW" == "rp" || "$WORK_REVIEW" == "codex" ) ]]; then
+  if [[ "$status" == "work" && ( "$WORK_REVIEW" == "rp" || "$WORK_REVIEW" == "codex" || "$WORK_REVIEW" == "copilot" ) ]]; then
     if ! verify_receipt "$REVIEW_RECEIPT_PATH" "impl_review" "$task_id"; then
       echo "ralph: missing impl review receipt; forcing retry" >> "$iter_log"
       log "missing impl receipt; forcing retry"

--- a/plugins/flow-next/skills/flow-next-ralph-init/templates/ralph.sh
+++ b/plugins/flow-next/skills/flow-next-ralph-init/templates/ralph.sh
@@ -387,12 +387,12 @@ PLAN_REVIEW="${PLAN_REVIEW:-none}"
 WORK_REVIEW="${WORK_REVIEW:-none}"
 COMPLETION_REVIEW="${COMPLETION_REVIEW:-none}"
 CODEX_SANDBOX="${CODEX_SANDBOX:-auto}"  # Codex sandbox mode; flowctl reads this env var
-COPILOT_MODEL="${COPILOT_MODEL:-gpt-5.1}"
+FLOW_COPILOT_MODEL="${FLOW_COPILOT_MODEL:-gpt-5.2}"
 REQUIRE_PLAN_REVIEW="${REQUIRE_PLAN_REVIEW:-0}"
 YOLO="${YOLO:-0}"
 EPICS="${EPICS:-}"
 export CODEX_SANDBOX  # Ensure available to Claude worker for flowctl codex commands
-export COPILOT_MODEL
+export FLOW_COPILOT_MODEL
 
 # Parse command line arguments
 while [[ $# -gt 0 ]]; do

--- a/plugins/flow-next/skills/flow-next-ralph-init/templates/ralph.sh
+++ b/plugins/flow-next/skills/flow-next-ralph-init/templates/ralph.sh
@@ -387,10 +387,12 @@ PLAN_REVIEW="${PLAN_REVIEW:-none}"
 WORK_REVIEW="${WORK_REVIEW:-none}"
 COMPLETION_REVIEW="${COMPLETION_REVIEW:-none}"
 CODEX_SANDBOX="${CODEX_SANDBOX:-auto}"  # Codex sandbox mode; flowctl reads this env var
+COPILOT_MODEL="${COPILOT_MODEL:-gpt-5.1}"
 REQUIRE_PLAN_REVIEW="${REQUIRE_PLAN_REVIEW:-0}"
 YOLO="${YOLO:-0}"
 EPICS="${EPICS:-}"
 export CODEX_SANDBOX  # Ensure available to Claude worker for flowctl codex commands
+export COPILOT_MODEL
 
 # Parse command line arguments
 while [[ $# -gt 0 ]]; do

--- a/plugins/flow-next/skills/flow-next-setup/workflow.md
+++ b/plugins/flow-next/skills/flow-next-setup/workflow.md
@@ -78,6 +78,8 @@ Before asking questions, detect available tools and read current config:
 # Detect available review backends
 HAVE_RP=$(which rp-cli >/dev/null 2>&1 && echo 1 || echo 0)
 HAVE_CODEX=$(which codex >/dev/null 2>&1 && echo 1 || echo 0)
+HAVE_COPILOT=$(which copilot >/dev/null 2>&1 && echo 1 || echo 0)
+HAVE_COPILOT=$(which copilot >/dev/null 2>&1 && echo 1 || echo 0)
 
 # Read current config values if they exist
 CURRENT_BACKEND=$("${PLUGIN_ROOT}/scripts/flowctl" config get review.backend --json 2>/dev/null | jq -r '.value // empty')
@@ -111,7 +113,7 @@ Current configuration:
 - Memory: <enabled|disabled> (change with: flowctl config set memory.enabled <true|false>)
 - Plan-Sync: <enabled|disabled> (change with: flowctl config set planSync.enabled <true|false>)
 - Plan-Sync cross-epic: <enabled|disabled> (change with: flowctl config set planSync.crossEpic <true|false>)
-- Review backend: <codex|rp|none> (change with: flowctl config set review.backend <codex|rp|none>)
+- Review backend: <copilot|codex|rp|none> (change with: flowctl config set review.backend <copilot|codex|rp|none>)
 ```
 
 Only include lines for config values that are set. If no config is set, skip this notice.
@@ -167,6 +169,7 @@ Available questions (include only if corresponding config is unset):
   "header": "Review",
   "question": "Which review backend for Carmack-level reviews?",
   "options": [
+    {"label": "Copilot CLI", "description": "Cross-platform, uses GitHub Copilot CLI for reviews. <detected if HAVE_COPILOT=1, (not detected) if HAVE_COPILOT=0>"},
     {"label": "Codex CLI", "description": "Cross-platform, uses GPT 5.2 High for reviews. Simple setup, works everywhere. <detected if HAVE_CODEX=1, (not detected) if HAVE_CODEX=0>"},
     {"label": "RepoPrompt", "description": "macOS only. Auto-discovers git diffs + context, reviews scoped to actual changes, ~65% fewer tokens than traditional approaches. <detected if HAVE_RP=1, (not detected) if HAVE_RP=0>"},
     {"label": "None", "description": "Skip reviews, can configure later with --review flag"}
@@ -207,7 +210,7 @@ Use `AskUserQuestion` with the built questions array.
 
 **Note:** If docs are already current, adjust the Docs question description to mention "(already up to date)" or skip that question entirely.
 
-**Note:** If neither rp-cli nor codex is detected, add note to the Review question: "Neither rp-cli nor codex detected. Install one for review support."
+**Note:** If none of rp-cli, codex, or copilot is detected, add note to the Review question: "No review backends detected. Install one for review support."
 
 ## Step 7: Process Answers
 
@@ -231,6 +234,7 @@ Map user's answer to config value and persist:
 ```bash
 # Determine backend from answer
 case "$review_answer" in
+  "Copilot"*) REVIEW_BACKEND="copilot" ;;
   "Codex"*) REVIEW_BACKEND="codex" ;;
   "RepoPrompt"*) REVIEW_BACKEND="rp" ;;
   *) REVIEW_BACKEND="none" ;;
@@ -269,7 +273,7 @@ Configuration (use flowctl config set to change):
 - Memory: <enabled|disabled>
 - Plan-Sync: <enabled|disabled>
 - Plan-Sync cross-epic: <enabled|disabled>
-- Review backend: <codex|rp|none>
+- Review backend: <copilot|codex|rp|none>
 
 Documentation updated:
 - <files updated or "none">

--- a/plugins/flow-next/skills/flow-next-work/SKILL.md
+++ b/plugins/flow-next/skills/flow-next-work/SKILL.md
@@ -60,7 +60,7 @@ Check configured backend:
 ```bash
 REVIEW_BACKEND=$($FLOWCTL review-backend)
 ```
-Returns: `ASK` (not configured), or `rp`/`codex`/`none` (configured).
+Returns: `ASK` (not configured), or `rp`/`codex`/`copilot`/`none` (configured).
 
 ### Option Parsing (skip questions if found in arguments)
 
@@ -72,6 +72,7 @@ Parse the arguments for these patterns. If found, use them and skip correspondin
 - `--branch=worktree` or `--worktree` or "isolated worktree" or "worktree" → isolated worktree
 
 **Review mode**:
+- `--review=copilot` or "review with copilot" or "copilot review" or "use copilot" → Copilot CLI
 - `--review=codex` or "review with codex" or "codex review" or "use codex" → Codex CLI (GPT 5.2 High)
 - `--review=rp` or "review with rp" or "rp chat" or "repoprompt review" → RepoPrompt chat (via `flowctl rp chat-send`)
 - `--review=export` or "export review" or "external llm" → export for external LLM
@@ -79,14 +80,14 @@ Parse the arguments for these patterns. If found, use them and skip correspondin
 
 ### If options NOT found in arguments
 
-**If REVIEW_BACKEND is rp, codex, or none** (already configured): Only ask branch question. Show override hint:
+**If REVIEW_BACKEND is rp, codex, copilot, or none** (already configured): Only ask branch question. Show override hint:
 
 ```
 Quick setup: Where to work?
 a) Current branch  b) New branch  c) Isolated worktree
 
 (Reply: "a", "current", or just tell me)
-(Tip: --review=rp|codex|export|none overrides configured backend)
+(Tip: --review=rp|codex|copilot|export|none overrides configured backend)
 ```
 
 **If REVIEW_BACKEND is ASK** (not configured): Ask both branch AND review questions:
@@ -100,10 +101,11 @@ Quick setup before starting:
    c) Isolated worktree
 
 2. **Review** — Run Carmack-level review after?
-   a) Codex CLI
-   b) RepoPrompt
-   c) Export for external LLM
-   d) None (configure later with --review flag)
+   a) Copilot CLI
+   b) Codex CLI
+   c) RepoPrompt
+   d) Export for external LLM
+   e) None (configure later with --review flag)
 
 (Reply: "1a 2a", "current branch, codex", or just tell me naturally)
 ```


### PR DESCRIPTION
This pull request adds support for using the GitHub Copilot CLI as a cross-platform review backend alongside RepoPrompt and Codex. The documentation, configuration options, and command hints have all been updated to include Copilot, making multi-model reviews available on any OS. The changelog and version numbers have also been updated accordingly.

**Copilot review backend support:**

* Added GitHub Copilot CLI as a supported review backend for cross-model reviews, including setup instructions, usage examples, and trade-offs in `plugins/flow-next/README.md`. [[1]](diffhunk://#diff-b2656936ccb42eda216d6fd049179e7b30e06c362b2ef9780fe8198f1a38cca7R843-R879) [[2]](diffhunk://#diff-b2656936ccb42eda216d6fd049179e7b30e06c362b2ef9780fe8198f1a38cca7L554-R554) [[3]](diffhunk://#diff-b2656936ccb42eda216d6fd049179e7b30e06c362b2ef9780fe8198f1a38cca7L769-R769) [[4]](diffhunk://#diff-b2656936ccb42eda216d6fd049179e7b30e06c362b2ef9780fe8198f1a38cca7L863-R895) [[5]](diffhunk://#diff-b2656936ccb42eda216d6fd049179e7b30e06c362b2ef9780fe8198f1a38cca7L994-R1028) [[6]](diffhunk://#diff-b2656936ccb42eda216d6fd049179e7b30e06c362b2ef9780fe8198f1a38cca7L1008-R1039) [[7]](diffhunk://#diff-b2656936ccb42eda216d6fd049179e7b30e06c362b2ef9780fe8198f1a38cca7L1017-R1054) [[8]](diffhunk://#diff-b2656936ccb42eda216d6fd049179e7b30e06c362b2ef9780fe8198f1a38cca7L1034-R1065) [[9]](diffhunk://#diff-b2656936ccb42eda216d6fd049179e7b30e06c362b2ef9780fe8198f1a38cca7L1055-R1094) [[10]](diffhunk://#diff-b2656936ccb42eda216d6fd049179e7b30e06c362b2ef9780fe8198f1a38cca7L1071-R1110) [[11]](diffhunk://#diff-b2656936ccb42eda216d6fd049179e7b30e06c362b2ef9780fe8198f1a38cca7L1086-R1127) [[12]](diffhunk://#diff-b2656936ccb42eda216d6fd049179e7b30e06c362b2ef9780fe8198f1a38cca7L1142-R1176) [[13]](diffhunk://#diff-b2656936ccb42eda216d6fd049179e7b30e06c362b2ef9780fe8198f1a38cca7L1420-R1456)
* Updated command argument hints and descriptions in review-related markdown files to include Copilot as an option (`plan-review`, `impl-review`, `epic-review`). [[1]](diffhunk://#diff-ea5776da8e0e02cbe224c824c67d9d04b3d99d552f6274730792c386d6917127L3-R4) [[2]](diffhunk://#diff-19e1d031fe0cc8d613632db415a6ac1538f035ddc10e339258c9f4054b3b22d1L3-R4) [[3]](diffhunk://#diff-b1c18de69c2c1cde0c1e4a898e83990c8dd4f6f32343df4fece786f2bc5b9941L4-R4)

**Documentation and configuration updates:**

* Updated the main `README.md` and `plugins/flow-next/docs/flowctl.md` to reflect Copilot as a review backend option, including configuration instructions and command lists. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L28-R28) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L70-R70) [[3]](diffhunk://#diff-7955d335d0a9724e2a2b7aa6bd01e88a7c37dc60fbde423fd1adba06b7a8c3b3L10-R10) [[4]](diffhunk://#diff-7955d335d0a9724e2a2b7aa6bd01e88a7c37dc60fbde423fd1adba06b7a8c3b3L449-R449) [[5]](diffhunk://#diff-7955d335d0a9724e2a2b7aa6bd01e88a7c37dc60fbde423fd1adba06b7a8c3b3L461-R461)
* Updated changelog to mention the addition of the Copilot review backend.

**Version bump:**

* Bumped version numbers for `flow-next` in both `.claude-plugin/marketplace.json` and `plugins/flow-next/.claude-plugin/plugin.json` from `0.20.1` to `0.20.2`. [[1]](diffhunk://#diff-5352ee4067f17e7948e1425843f0a454e045bc8edf338f0bcf75c6804ddabd9aL34-R34) [[2]](diffhunk://#diff-365874deee2bbdc014d5c1fdac3cc094b93da9c3670a0702fe4025f59f38ae4aL3-R3)