### PR TITLE
fix: always embed file contents in codex reviews on all platforms

### DIFF
--- a/plugins/flow-next/scripts/flowctl.py
+++ b/plugins/flow-next/scripts/flowctl.py
@@ -5710,8 +5710,10 @@ def cmd_codex_impl_review(args: argparse.Namespace) -> None:
     changed_files = get_changed_files(base_branch)
     embedded_content, embed_stats = get_embedded_file_contents(changed_files)
 
-    # Build prompt
-    files_embedded = True
+    # Only forbid disk reads when ALL files were fully embedded. If the budget
+    # was exhausted or files were truncated, allow Codex to read the remainder
+    # from disk so it doesn't review with incomplete context.
+    files_embedded = not embed_stats.get("budget_skipped") and not embed_stats.get("truncated")
     if standalone:
         prompt = build_standalone_review_prompt(base_branch, focus, diff_summary, files_embedded)
         # Append embedded files and diff content to standalone prompt
@@ -5928,8 +5930,8 @@ def cmd_codex_plan_review(args: argparse.Namespace) -> None:
     base_branch = args.base if hasattr(args, "base") and args.base else "main"
     context_hints = gather_context_hints(base_branch)
 
-    # Build prompt
-    files_embedded = True
+    # Only forbid disk reads when ALL files were fully embedded.
+    files_embedded = not embed_stats.get("budget_skipped") and not embed_stats.get("truncated")
     prompt = build_review_prompt(
         "plan", epic_spec, context_hints, task_specs=task_specs, embedded_files=embedded_content,
         files_embedded=files_embedded
@@ -6285,10 +6287,10 @@ def cmd_codex_completion_review(args: argparse.Namespace) -> None:
     # Always embed changed file contents. See cmd_codex_impl_review comment
     # for rationale.
     changed_files = get_changed_files(base_branch)
-    embedded_content, _ = get_embedded_file_contents(changed_files)
+    embedded_content, embed_stats = get_embedded_file_contents(changed_files)
 
-    # Build prompt
-    files_embedded = True
+    # Only forbid disk reads when ALL files were fully embedded.
+    files_embedded = not embed_stats.get("budget_skipped") and not embed_stats.get("truncated")
     prompt = build_completion_review_prompt(
         epic_spec,
         task_specs,

--- a/plugins/flow-next/scripts/flowctl.py
+++ b/plugins/flow-next/scripts/flowctl.py
@@ -745,16 +745,17 @@ def get_embedded_file_contents(file_paths: list[str]) -> tuple[str, dict]:
 
     Environment:
         FLOW_CODEX_EMBED_MAX_BYTES: Total byte budget for embedded files.
-            Default 102400 (100KB). Set to 0 for unlimited.
+            Default 512000 (500KB). Set to 0 for unlimited.
     """
     repo_root = get_repo_root()
 
-    # Get budget from env (default 100KB to prevent oversized prompts)
-    max_bytes_str = os.environ.get("FLOW_CODEX_EMBED_MAX_BYTES", "102400")
+    # Get budget from env (default 500KB — large enough for complex epics with
+    # many source files while still preventing excessively large prompts)
+    max_bytes_str = os.environ.get("FLOW_CODEX_EMBED_MAX_BYTES", "512000")
     try:
         max_total_bytes = int(max_bytes_str)
     except ValueError:
-        max_total_bytes = 102400  # Invalid value uses default
+        max_total_bytes = 512000  # Invalid value uses default
 
     stats = {
         "embedded": 0,
@@ -5701,25 +5702,16 @@ def cmd_codex_impl_review(args: argparse.Namespace) -> None:
     except (subprocess.CalledProcessError, OSError):
         pass
 
-    # Embed changed file contents for codex only on Windows (sandbox is broken there)
-    # Unix sandbox works correctly, so no embedding needed
-    if os.name == "nt":
-        changed_files = get_changed_files(base_branch)
-        embedded_content, embed_stats = get_embedded_file_contents(changed_files)
-    else:
-        embedded_content = ""
-        embed_stats = {
-            "embedded": 0,
-            "total": 0,
-            "bytes": 0,
-            "binary_skipped": [],
-            "deleted_skipped": [],
-            "outside_repo_skipped": [],
-            "budget_skipped": [],
-        }
+    # Always embed changed file contents so Codex doesn't waste turns reading
+    # files from disk. Without embedding, Codex exhausts its turn budget on
+    # sed/rg commands before producing a verdict (observed 114 turns with no
+    # verdict on complex epics). The FLOW_CODEX_EMBED_MAX_BYTES budget cap
+    # prevents oversized prompts.
+    changed_files = get_changed_files(base_branch)
+    embedded_content, embed_stats = get_embedded_file_contents(changed_files)
 
     # Build prompt
-    files_embedded = os.name == "nt"
+    files_embedded = True
     if standalone:
         prompt = build_standalone_review_prompt(base_branch, focus, diff_summary, files_embedded)
         # Append embedded files and diff content to standalone prompt
@@ -5928,28 +5920,16 @@ def cmd_codex_plan_review(args: argparse.Namespace) -> None:
 
     task_specs = "\n\n---\n\n".join(task_specs_parts) if task_specs_parts else ""
 
-    # Embed specified file contents for codex only on Windows (sandbox is broken there)
-    # Unix sandbox works correctly, so no embedding needed
-    if os.name == "nt":
-        embedded_content, embed_stats = get_embedded_file_contents(file_paths)
-    else:
-        embedded_content = ""
-        embed_stats = {
-            "embedded": 0,
-            "total": 0,
-            "bytes": 0,
-            "binary_skipped": [],
-            "deleted_skipped": [],
-            "outside_repo_skipped": [],
-            "budget_skipped": [],
-        }
+    # Always embed file contents so Codex doesn't waste turns reading files
+    # from disk. See cmd_codex_impl_review comment for rationale.
+    embedded_content, embed_stats = get_embedded_file_contents(file_paths)
 
     # Get context hints (from main branch for plans)
     base_branch = args.base if hasattr(args, "base") and args.base else "main"
     context_hints = gather_context_hints(base_branch)
 
     # Build prompt
-    files_embedded = os.name == "nt"
+    files_embedded = True
     prompt = build_review_prompt(
         "plan", epic_spec, context_hints, task_specs=task_specs, embedded_files=embedded_content,
         files_embedded=files_embedded
@@ -6302,15 +6282,13 @@ def cmd_codex_completion_review(args: argparse.Namespace) -> None:
     except (subprocess.CalledProcessError, OSError):
         pass
 
-    # Embed changed file contents for codex only on Windows
-    if os.name == "nt":
-        changed_files = get_changed_files(base_branch)
-        embedded_content, _ = get_embedded_file_contents(changed_files)
-    else:
-        embedded_content = ""
+    # Always embed changed file contents. See cmd_codex_impl_review comment
+    # for rationale.
+    changed_files = get_changed_files(base_branch)
+    embedded_content, _ = get_embedded_file_contents(changed_files)
 
     # Build prompt
-    files_embedded = os.name == "nt"
+    files_embedded = True
     prompt = build_completion_review_prompt(
         epic_spec,
         task_specs,


### PR DESCRIPTION
## Summary

On Unix/macOS, codex reviews (`plan-review`, `impl-review`, `completion-review`) did not embed file contents in the prompt — only Windows did. This caused Codex to spend its entire turn budget reading source files via `sed`/`rg` commands, exhausting turns before producing a verdict.

**Observed failure on a complex epic** (290-line spec + 5 task specs):
- 114 shell command executions just reading source files
- 3.68M input tokens consumed exploring the codebase
- All 4 review todo items still uncompleted when `turn.completed` fired
- **No verdict produced** — the review silently failed

## Changes

- Remove `os.name == "nt"` gate from all three codex review commands (`cmd_codex_impl_review`, `cmd_codex_plan_review`, `cmd_codex_completion_review`)
- Always call `get_embedded_file_contents()` regardless of platform
- Set `files_embedded = True` so the prompt instructs Codex to use embedded content instead of exploring the filesystem
- Increase default `FLOW_CODEX_EMBED_MAX_BYTES` from 100KB to 500KB to accommodate larger codebases

## Why this works

When `files_embedded = True`, `build_review_prompt()` generates a context preamble that says _"Do NOT attempt to read files from disk — use only the embedded content"_. This eliminates the file-reading turns entirely, letting Codex focus on the actual review and verdict.

The existing `FLOW_CODEX_EMBED_MAX_BYTES` env var still allows users to tune the budget. The sandbox `read-only` mode on Unix remains unchanged as a defense-in-depth measure.

## Test plan

- [x] Verified `plan-review` produces verdict on first attempt (previously failed 2/3 times)
- [x] Verified `impl-review` produces verdict with significantly fewer Codex turns
- [x] Confirmed `os.name == "nt"` only remains in `resolve_codex_sandbox()` (correct — Windows sandbox is broken)
- [ ] Verify Windows behavior unchanged (embedding was already enabled there)