### PR TITLE
fix(flowctl): patch_task_section creates duplicate headings on re-patch

### DIFF
--- a/plugins/flow-next/scripts/flowctl.py
+++ b/plugins/flow-next/scripts/flowctl.py
@@ -1873,6 +1873,10 @@ TBD
 def patch_task_section(content: str, section: str, new_content: str) -> str:
     """Patch a specific section in task spec. Preserves other sections.
 
+    When new_content introduces additional ## headings (e.g., replacing
+    ## Description with content that also contains ## Approach), any OLD
+    sections with those same headings are removed to prevent duplicates.
+
     Raises ValueError on invalid content (duplicate/missing headings).
     """
     # Check for duplicate headings first (defensive)
@@ -1889,15 +1893,24 @@ def patch_task_section(content: str, section: str, new_content: str) -> str:
     if new_lines and new_lines[0].strip() == section:
         new_content = "\n".join(new_lines[1:]).lstrip()
 
+    # Collect ## headings introduced by the new content so we can remove
+    # old sections with the same headings (prevents duplicates).
+    new_headings: set[str] = set()
+    for nl in new_content.split("\n"):
+        if nl.startswith("## "):
+            new_headings.add(nl.strip())
+
     lines = content.split("\n")
     result = []
     in_target_section = False
+    in_superseded_section = False
     section_found = False
 
     for i, line in enumerate(lines):
         if line.startswith("## "):
             if line.strip() == section:
                 in_target_section = True
+                in_superseded_section = False
                 section_found = True
                 result.append(line)
                 # Add new content
@@ -1905,8 +1918,14 @@ def patch_task_section(content: str, section: str, new_content: str) -> str:
                 continue
             else:
                 in_target_section = False
+                # Skip old sections whose headings are now part of new content
+                if line.strip() in new_headings:
+                    in_superseded_section = True
+                    continue
+                else:
+                    in_superseded_section = False
 
-        if not in_target_section:
+        if not in_target_section and not in_superseded_section:
             result.append(line)
 
     if not section_found:

--- a/plugins/flow-next/scripts/smoke_test.sh
+++ b/plugins/flow-next/scripts/smoke_test.sh
@@ -875,6 +875,55 @@ echo "$stdin_spec" | grep -q "spec was written via stdin" || { echo "set-spec --
 echo -e "${GREEN}✓${NC} task set-spec --file stdin"
 PASS=$((PASS + 1))
 
+echo -e "${YELLOW}--- task set-spec with extra headings (no duplicates) ---${NC}"
+scripts/flowctl task create --epic "$STDIN_EPIC" --title "Heading dedup test" --json >/dev/null
+DEDUP_TASK="${STDIN_EPIC}.4"
+# First set-spec: description includes ## Approach and ## Key context
+cat > "$TEST_DIR/desc_with_headings.md" << 'DESCEOF'
+Initial description.
+
+## Approach
+Initial approach content.
+
+## Key context
+Initial key context.
+DESCEOF
+echo '- [ ] Initial check' > "$TEST_DIR/acc_initial.md"
+scripts/flowctl task set-spec "$DEDUP_TASK" --description "$TEST_DIR/desc_with_headings.md" --acceptance "$TEST_DIR/acc_initial.md" --json >/dev/null
+# Second set-spec: updated description also includes ## Approach (should replace, not duplicate)
+cat > "$TEST_DIR/desc_updated.md" << 'DESCEOF2'
+Updated description.
+
+## Approach
+Updated approach content.
+
+## Key context
+Updated key context.
+DESCEOF2
+scripts/flowctl task set-spec "$DEDUP_TASK" --description "$TEST_DIR/desc_updated.md" --json >/dev/null
+dedup_spec="$(scripts/flowctl cat "$DEDUP_TASK")"
+# Should contain updated content
+echo "$dedup_spec" | grep -q "Updated description" || { echo "set-spec dedup: missing updated description"; FAIL=$((FAIL + 1)); }
+echo "$dedup_spec" | grep -q "Updated approach content" || { echo "set-spec dedup: missing updated approach"; FAIL=$((FAIL + 1)); }
+echo "$dedup_spec" | grep -q "Updated key context" || { echo "set-spec dedup: missing updated key context"; FAIL=$((FAIL + 1)); }
+# Should NOT contain old content (the bug: old sections were preserved)
+if echo "$dedup_spec" | grep -q "Initial approach content"; then
+  echo "set-spec dedup: OLD approach still present (duplicate heading bug)"
+  FAIL=$((FAIL + 1))
+else
+  true  # old content correctly removed
+fi
+if echo "$dedup_spec" | grep -q "Initial key context"; then
+  echo "set-spec dedup: OLD key context still present (duplicate heading bug)"
+  FAIL=$((FAIL + 1))
+else
+  true  # old content correctly removed
+fi
+# Acceptance should still be present (not touched by description update)
+echo "$dedup_spec" | grep -q "Initial check" || { echo "set-spec dedup: acceptance lost"; FAIL=$((FAIL + 1)); }
+echo -e "${GREEN}✓${NC} task set-spec heading dedup"
+PASS=$((PASS + 1))
+
 echo -e "${YELLOW}--- checkpoint save/restore ---${NC}"
 # Save checkpoint
 scripts/flowctl checkpoint save --epic "$STDIN_EPIC" --json >/dev/null


### PR DESCRIPTION
## Summary

- `patch_task_section` now removes old sections whose `##` headings are superseded by the new content, preventing duplicate/contradictory sections when `task set-spec --description` is called multiple times
- Adds smoke test covering the re-patch deduplication scenario

## Problem

When `task set-spec --description` is called with content that includes additional `## ` headings (e.g., `## Approach`, `## Key context`), and the task spec already contains those sections from a previous `set-spec` call, the old sections are preserved alongside the new ones.

This creates duplicate `## Approach` / `## Key context` sections with contradictory content — the first from the new patch, the second from the original file.

### Root cause

`patch_task_section` replaces content between the target `## ` heading and the next `## ` heading, then preserves everything else. But it doesn't account for the **new content** introducing `## ` headings that already exist later in the original file.

### Example

Given a task spec with `## Description`, `## Approach`, `## Acceptance`, calling:
```bash
flowctl task set-spec fn-1.1 --description desc.md
```
Where `desc.md` contains:
```markdown
Updated description.

## Approach
Updated approach.
```

**Before fix:** Result has TWO `## Approach` sections (updated + old).
**After fix:** Old `## Approach` is superseded by the one in the new content.

## Fix

Collect `## ` headings introduced by the new content. During the patch loop, skip (supersede) any old sections whose headings match. This preserves backward compatibility — when new content has no extra headings, behavior is identical to before.

## Test plan

- [x] Added smoke test: `task set-spec with extra headings (no duplicates)`
- [x] Verified simple replacement (no extra headings) still works
- [x] Verified new headings not in original are added cleanly
- [x] Verified replacing acceptance preserves unrelated description+approach
- [x] Existing smoke tests unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)