### PR TITLE
fix(flow-next): check depends_on_epics in cmd_ready

### DIFF
--- a/plugins/flow-next/scripts/flowctl.py
+++ b/plugins/flow-next/scripts/flowctl.py
@@ -4256,6 +4256,41 @@ def cmd_ready(args: argparse.Namespace) -> None:
     # MU-2: Get current actor for display (marks your tasks)
     current_actor = get_actor()
 
+    # Check epic-level dependencies before inspecting tasks
+    epic_data = normalize_epic(
+        load_json_or_exit(epic_path, f"Epic {args.epic}", use_json=args.json)
+    )
+    epic_blocked_by: list[str] = []
+    for dep in epic_data.get("depends_on_epics", []) or []:
+        if dep == args.epic:
+            continue
+        dep_path = flow_dir / EPICS_DIR / f"{dep}.json"
+        if not dep_path.exists():
+            epic_blocked_by.append(dep)
+            continue
+        dep_data = normalize_epic(
+            load_json_or_exit(dep_path, f"Epic {dep}", use_json=args.json)
+        )
+        if dep_data.get("status") != "done":
+            epic_blocked_by.append(dep)
+    if epic_blocked_by:
+        if args.json:
+            json_output(
+                {
+                    "epic": args.epic,
+                    "actor": current_actor,
+                    "ready": [],
+                    "in_progress": [],
+                    "blocked": [],
+                    "epic_blocked_by": epic_blocked_by,
+                }
+            )
+        else:
+            print(
+                f"Epic {args.epic} is blocked by: {', '.join(epic_blocked_by)}"
+            )
+        return
+
     # Get all tasks for epic (with merged runtime state)
     tasks_dir = flow_dir / TASKS_DIR
     if not tasks_dir.exists():


### PR DESCRIPTION
Hello, really enjoying this project, thanks for making it and making it public (also huge compliments on your website!). If you're interested I made this patch for an issue I ran into.

I use flowctl's CLI commands directly rather than through Ralph/flow-next-work. The `ready` command doesn't check `depends_on_epics`, so blocked epics report their tasks as ready. `next` already has this check — this patch adds the same gate to `ready`.

With epics fn-1 → fn-2 (`depends_on_epics`), fn-1 not done:
- **Before:** `flowctl ready --epic fn-2` returns root tasks as ready
- **After:** returns empty with `epic_blocked_by: [fn-1]`

Anyway, thanks for everything. This is what the robots are saying about it:

> cmd_ready only checked task-level depends_on when determining which tasks are ready. It ignored the epic's own depends_on_epics field, so tasks in blocked epics were reported as ready to work on.
> 
> cmd_next already handles this correctly (lines 4425-4441) by filtering out epics whose depends_on_epics aren't all done. This adds the same gate to cmd_ready: if the epic is blocked by unfinished prerequisite epics, return empty ready/in_progress/blocked lists with a new epic_blocked_by field in JSON output.
> 
> The bug is latent in flow-next's default workflow because Ralph uses next exclusively and flow-next-work only calls ready on pre-validated epics. External consumers that call ready per-epic independently hit it immediately.