### PR TITLE
Fix RepoPrompt RP 2.x reviews and Ralph receipt gate

### DIFF
--- a/.flow/bin/flowctl.py
+++ b/.flow/bin/flowctl.py
@@ -417,6 +417,55 @@ def run_rp_cli(
         error_exit(f"rp-cli failed: {msg}", use_json=False, code=2)
 
 
+def run_rp_cli_unchecked(
+    args: list[str], timeout: Optional[int] = None
+) -> subprocess.CompletedProcess:
+    """Run rp-cli without collapsing command failures.
+
+    Used when a caller needs to inspect stderr/stdout before deciding whether a
+    failure is a capability mismatch or a real RepoPrompt error.
+    """
+    if timeout is None:
+        timeout = int(os.environ.get("FLOW_RP_TIMEOUT", "1200"))
+    rp = require_rp_cli()
+    cmd = [rp] + args
+    try:
+        return subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+    except subprocess.TimeoutExpired:
+        error_exit(f"rp-cli timed out after {timeout}s", use_json=False, code=3)
+
+
+def try_run_rp_cli(
+    args: list[str], timeout: Optional[int] = None
+) -> Optional[subprocess.CompletedProcess]:
+    """Run rp-cli and return None on failure.
+
+    Used for optional capability probing where newer RepoPrompt features may not
+    exist yet and flowctl should fall back gracefully.
+    """
+    if timeout is None:
+        timeout = int(os.environ.get("FLOW_RP_TIMEOUT", "1200"))
+    rp = require_rp_cli()
+    cmd = [rp] + args
+    try:
+        return subprocess.run(
+            cmd, capture_output=True, text=True, check=True, timeout=timeout
+        )
+    except (subprocess.TimeoutExpired, subprocess.CalledProcessError):
+        return None
+
+
+def is_rp_tool_missing_error(output: str, tool_name: str) -> bool:
+    """Return true only for clear RepoPrompt missing-tool capability errors."""
+    patterns = [
+        rf"\bTool not found:\s*{re.escape(tool_name)}\b",
+        rf"\bUnknown tool:\s*{re.escape(tool_name)}\b",
+        rf"\bUnknown function:\s*{re.escape(tool_name)}\b",
+        rf"\bNo such tool:\s*{re.escape(tool_name)}\b",
+    ]
+    return any(re.search(pattern, output, re.I) for pattern in patterns)
+
+
 def normalize_repo_root(path: str) -> list[str]:
     """Normalize repo root for window matching."""
     root = os.path.realpath(path)
@@ -448,7 +497,7 @@ def parse_windows(raw: str) -> list[dict[str, Any]]:
 
 
 def extract_window_id(win: dict[str, Any]) -> Optional[int]:
-    for key in ("windowID", "windowId", "id"):
+    for key in ("windowID", "windowId", "window_id", "id"):
         if key in win:
             try:
                 return int(win[key])
@@ -468,11 +517,234 @@ def extract_root_paths(win: dict[str, Any]) -> list[str]:
     return []
 
 
+def parse_manage_workspaces(raw: str) -> list[dict[str, Any]]:
+    """Parse manage_workspaces list JSON, tolerating nested wrappers."""
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as e:
+        error_exit(
+            f"manage_workspaces list JSON parse failed: {e}",
+            use_json=False,
+            code=2,
+        )
+
+    for _ in range(4):
+        if isinstance(data, list):
+            break
+        if isinstance(data, dict):
+            for key in ("workspaces", "result", "data"):
+                if key in data:
+                    data = data[key]
+                    break
+            else:
+                break
+        else:
+            break
+
+    if isinstance(data, list):
+        workspaces: list[dict[str, Any]] = []
+        for item in data:
+            if isinstance(item, dict):
+                workspaces.append(item)
+            elif isinstance(item, str):
+                workspaces.append({"name": item})
+        return workspaces
+
+    error_exit("manage_workspaces list JSON has unexpected shape", use_json=False, code=2)
+
+
+def extract_workspace_id(workspace: dict[str, Any]) -> Optional[str]:
+    for key in ("id", "workspace_id", "workspaceId", "uuid"):
+        val = workspace.get(key)
+        if val is not None:
+            return str(val)
+    return None
+
+
+def extract_workspace_name(workspace: dict[str, Any]) -> Optional[str]:
+    for key in ("name", "workspace", "title"):
+        val = workspace.get(key)
+        if val is not None:
+            return str(val)
+    return None
+
+
+def extract_workspace_paths(workspace: dict[str, Any]) -> list[str]:
+    for key in (
+        "repoPaths",
+        "repo_paths",
+        "rootFolderPaths",
+        "rootFolders",
+        "folderPaths",
+        "folder_paths",
+        "paths",
+    ):
+        if key in workspace:
+            val = workspace[key]
+            if isinstance(val, list):
+                return [str(v) for v in val]
+            if isinstance(val, str):
+                return [val]
+
+    for key in ("folder_path", "repoPath", "repo_path", "path"):
+        val = workspace.get(key)
+        if isinstance(val, str):
+            return [val]
+
+    return []
+
+
+def extract_workspace_window_ids(workspace: dict[str, Any]) -> list[int]:
+    for key in (
+        "showingInWindows",
+        "showing_in_windows",
+        "showingWindows",
+        "window_ids",
+        "windowIds",
+        "windows",
+    ):
+        if key not in workspace:
+            continue
+
+        val = workspace[key]
+        items = val if isinstance(val, list) else [val]
+        window_ids: list[int] = []
+
+        for item in items:
+            if isinstance(item, dict):
+                win_id = extract_window_id(item)
+                if win_id is not None:
+                    window_ids.append(win_id)
+                continue
+
+            try:
+                window_ids.append(int(item))
+            except Exception:
+                continue
+
+        return list(dict.fromkeys(window_ids))
+
+    return []
+
+
+def workspace_matches_roots(workspace: dict[str, Any], roots: list[str]) -> bool:
+    for path in extract_workspace_paths(workspace):
+        real_path = os.path.realpath(path)
+        if real_path in roots or path in roots:
+            return True
+    return False
+
+
+def find_workspace_for_repo(
+    workspaces: list[dict[str, Any]], roots: list[str], preferred_window: Optional[int] = None
+) -> Optional[dict[str, Any]]:
+    matches = [ws for ws in workspaces if workspace_matches_roots(ws, roots)]
+    if not matches:
+        return None
+
+    if preferred_window is not None:
+        for workspace in matches:
+            if preferred_window in extract_workspace_window_ids(workspace):
+                return workspace
+
+    visible = [ws for ws in matches if extract_workspace_window_ids(ws)]
+    if visible:
+        return sorted(
+            visible,
+            key=lambda ws: (
+                min(extract_workspace_window_ids(ws)),
+                extract_workspace_name(ws) or "",
+            ),
+        )[0]
+
+    return matches[0]
+
+
+def extract_response_window_id(data: Any) -> Optional[int]:
+    if isinstance(data, dict):
+        win_id = extract_window_id(data)
+        if win_id is not None:
+            return win_id
+        for key in ("result", "data"):
+            if key in data:
+                win_id = extract_response_window_id(data[key])
+                if win_id is not None:
+                    return win_id
+        return None
+
+    if isinstance(data, list):
+        for item in data:
+            win_id = extract_response_window_id(item)
+            if win_id is not None:
+                return win_id
+
+    return None
+
+
+def extract_builder_tab_from_payload(data: Any) -> Optional[str]:
+    if isinstance(data, dict):
+        for key in ("tab_id", "tab", "tabId", "context_id", "context", "contextId"):
+            val = data.get(key)
+            if isinstance(val, str) and val:
+                return val
+        for key in ("result", "review", "data"):
+            if key in data:
+                tab = extract_builder_tab_from_payload(data[key])
+                if tab:
+                    return tab
+        return None
+
+    if isinstance(data, list):
+        for item in data:
+            tab = extract_builder_tab_from_payload(item)
+            if tab:
+                return tab
+
+    return None
+
+
+def bind_context_window(repo_root: str) -> Optional[int]:
+    """Prefer RepoPrompt's bind_context repo-path matching when available."""
+    payload = {"op": "bind", "working_dirs": normalize_repo_root(repo_root)}
+    result = try_run_rp_cli(
+        ["--raw-json", "-e", f"call bind_context {json.dumps(payload)}"]
+    )
+    if result is None:
+        return None
+
+    try:
+        data = json.loads(result.stdout or "{}")
+    except json.JSONDecodeError:
+        return None
+
+    return extract_response_window_id(data)
+
+
 def parse_builder_tab(output: str) -> str:
-    match = re.search(r"Tab:\s*([A-Za-z0-9-]+)", output)
-    if not match:
-        error_exit("builder output missing Tab id", use_json=False, code=2)
-    return match.group(1)
+    for pattern in (
+        r"Tab:\s*([A-Za-z0-9-]+)",
+        r"Context:\s*([A-Za-z0-9-]+)",
+        r"\bT=([A-Za-z0-9-]+)\b",
+        r'"tab_id"\s*:\s*"([^\"]+)"',
+        r'"tab"\s*:\s*"([^\"]+)"',
+        r'"context_id"\s*:\s*"([^\"]+)"',
+        r'"context"\s*:\s*"([^\"]+)"',
+    ):
+        match = re.search(pattern, output)
+        if match:
+            return match.group(1)
+
+    try:
+        data = json.loads(output)
+    except json.JSONDecodeError:
+        data = None
+
+    if data is not None:
+        tab = extract_builder_tab_from_payload(data)
+        if tab:
+            return tab
+
+    error_exit("builder output missing tab/context id", use_json=False, code=2)
 
 
 def parse_chat_id(output: str) -> Optional[str]:
@@ -492,6 +764,7 @@ def build_chat_payload(
     chat_name: Optional[str] = None,
     chat_id: Optional[str] = None,
     selected_paths: Optional[list[str]] = None,
+    include_legacy_fields: bool = True,
 ) -> str:
     payload: dict[str, Any] = {
         "message": message,
@@ -499,12 +772,13 @@ def build_chat_payload(
     }
     if new_chat:
         payload["new_chat"] = True
-    if chat_name:
-        payload["chat_name"] = chat_name
     if chat_id:
         payload["chat_id"] = chat_id
-    if selected_paths:
-        payload["selected_paths"] = selected_paths
+    if include_legacy_fields:
+        if chat_name:
+            payload["chat_name"] = chat_name
+        if selected_paths:
+            payload["selected_paths"] = selected_paths
     return json.dumps(payload, ensure_ascii=False, separators=(",", ":"))
 
 
@@ -745,16 +1019,17 @@ def get_embedded_file_contents(file_paths: list[str]) -> tuple[str, dict]:
 
     Environment:
         FLOW_CODEX_EMBED_MAX_BYTES: Total byte budget for embedded files.
-            Default 102400 (100KB). Set to 0 for unlimited.
+            Default 512000 (500KB). Set to 0 for unlimited.
     """
     repo_root = get_repo_root()
 
-    # Get budget from env (default 100KB to prevent oversized prompts)
-    max_bytes_str = os.environ.get("FLOW_CODEX_EMBED_MAX_BYTES", "102400")
+    # Get budget from env (default 500KB — large enough for complex epics with
+    # many source files while still preventing excessively large prompts)
+    max_bytes_str = os.environ.get("FLOW_CODEX_EMBED_MAX_BYTES", "512000")
     try:
         max_total_bytes = int(max_bytes_str)
     except ValueError:
-        max_total_bytes = 102400  # Invalid value uses default
+        max_total_bytes = 512000  # Invalid value uses default
 
     stats = {
         "embedded": 0,
@@ -5172,6 +5447,15 @@ def cmd_rp_windows(args: argparse.Namespace) -> None:
 def cmd_rp_pick_window(args: argparse.Namespace) -> None:
     repo_root = args.repo_root
     roots = normalize_repo_root(repo_root)
+
+    win_id = bind_context_window(repo_root)
+    if win_id is not None:
+        if args.json:
+            print(json.dumps({"window": win_id}))
+        else:
+            print(win_id)
+        return
+
     result = run_rp_cli(["--raw-json", "-e", "windows"])
     windows = parse_windows(result.stdout or "")
     if len(windows) == 1 and not extract_root_paths(windows[0]):
@@ -5194,6 +5478,25 @@ def cmd_rp_pick_window(args: argparse.Namespace) -> None:
                 else:
                     print(win_id)
                 return
+
+    workspaces_res = run_rp_cli(
+        [
+            "--raw-json",
+            "-e",
+            f"call manage_workspaces {json.dumps({'action': 'list'})}",
+        ]
+    )
+    workspace = find_workspace_for_repo(parse_manage_workspaces(workspaces_res.stdout or ""), roots)
+    if workspace:
+        window_ids = extract_workspace_window_ids(workspace)
+        if window_ids:
+            win_id = sorted(window_ids)[0]
+            if args.json:
+                print(json.dumps({"window": win_id}))
+            else:
+                print(win_id)
+            return
+
     error_exit("No window matches repo root", use_json=False, code=2)
 
 
@@ -5210,31 +5513,11 @@ def cmd_rp_ensure_workspace(args: argparse.Namespace) -> None:
         f"call manage_workspaces {json.dumps({'action': 'list'})}",
     ]
     list_res = run_rp_cli(list_cmd)
-    try:
-        data = json.loads(list_res.stdout)
-    except json.JSONDecodeError as e:
-        error_exit(f"workspace list JSON parse failed: {e}", use_json=False, code=2)
+    workspaces = parse_manage_workspaces(list_res.stdout or "")
+    roots = normalize_repo_root(repo_root)
+    workspace = find_workspace_for_repo(workspaces, roots, preferred_window=window)
 
-    def extract_names(obj: Any) -> set[str]:
-        names: set[str] = set()
-        if isinstance(obj, dict):
-            if "workspaces" in obj:
-                obj = obj["workspaces"]
-            elif "result" in obj:
-                obj = obj["result"]
-        if isinstance(obj, list):
-            for item in obj:
-                if isinstance(item, str):
-                    names.add(item)
-                elif isinstance(item, dict):
-                    for key in ("name", "workspace", "title"):
-                        if key in item:
-                            names.add(str(item[key]))
-        return names
-
-    names = extract_names(data)
-
-    if ws_name not in names:
+    if workspace is None:
         create_cmd = [
             "-w",
             str(window),
@@ -5242,12 +5525,21 @@ def cmd_rp_ensure_workspace(args: argparse.Namespace) -> None:
             f"call manage_workspaces {json.dumps({'action': 'create', 'name': ws_name, 'folder_path': repo_root})}",
         ]
         run_rp_cli(create_cmd)
+        list_res = run_rp_cli(list_cmd)
+        workspaces = parse_manage_workspaces(list_res.stdout or "")
+        workspace = find_workspace_for_repo(workspaces, roots, preferred_window=window)
+
+    workspace_ref = None
+    if workspace is not None:
+        workspace_ref = extract_workspace_id(workspace) or extract_workspace_name(workspace)
+    if workspace_ref is None:
+        workspace_ref = ws_name
 
     switch_cmd = [
         "-w",
         str(window),
         "-e",
-        f"call manage_workspaces {json.dumps({'action': 'switch', 'workspace': ws_name, 'window_id': window})}",
+        f"call manage_workspaces {json.dumps({'action': 'switch', 'workspace': workspace_ref, 'window_id': window})}",
     ]
     run_rp_cli(switch_cmd)
 
@@ -5257,7 +5549,6 @@ def cmd_rp_builder(args: argparse.Namespace) -> None:
     summary = args.summary
     response_type = getattr(args, "response_type", None)
 
-    # Build builder command with optional --type flag (shorthand for response_type)
     builder_expr = f"builder {json.dumps(summary)}"
     if response_type:
         builder_expr += f" --type {response_type}"
@@ -5269,15 +5560,14 @@ def cmd_rp_builder(args: argparse.Namespace) -> None:
         "-e",
         builder_expr,
     ]
-    cmd = [c for c in cmd if c]  # Remove empty strings
+    cmd = [c for c in cmd if c]
     res = run_rp_cli(cmd)
     output = (res.stdout or "") + ("\n" + res.stderr if res.stderr else "")
 
-    # For review response-type, parse the full JSON response
     if response_type == "review":
         try:
             data = json.loads(res.stdout or "{}")
-            tab = data.get("tab_id", "")
+            tab = extract_builder_tab_from_payload(data) or ""
             chat_id = data.get("review", {}).get("chat_id", "")
             review_response = data.get("review", {}).get("response", "")
             if args.json:
@@ -5351,7 +5641,14 @@ def cmd_rp_chat_send(args: argparse.Namespace) -> None:
     message = read_text_or_exit(Path(args.message_file), "Message file", use_json=False)
     chat_id_arg = getattr(args, "chat_id", None)
     mode = getattr(args, "mode", "chat") or "chat"
-    payload = build_chat_payload(
+    oracle_payload = build_chat_payload(
+        message=message,
+        mode=mode,
+        new_chat=args.new_chat,
+        chat_id=chat_id_arg,
+        include_legacy_fields=False,
+    )
+    legacy_payload = build_chat_payload(
         message=message,
         mode=mode,
         new_chat=args.new_chat,
@@ -5359,15 +5656,28 @@ def cmd_rp_chat_send(args: argparse.Namespace) -> None:
         chat_id=chat_id_arg,
         selected_paths=args.selected_paths,
     )
-    cmd = [
+    oracle_cmd = [
         "-w",
         str(args.window),
         "-t",
         args.tab,
         "-e",
-        f"call chat_send {payload}",
+        f"call oracle_send {oracle_payload}",
     ]
-    res = run_rp_cli(cmd)
+    legacy_cmd = [
+        "-w",
+        str(args.window),
+        "-t",
+        args.tab,
+        "-e",
+        f"call chat_send {legacy_payload}",
+    ]
+    res = run_rp_cli_unchecked(oracle_cmd)
+    if res.returncode != 0:
+        oracle_error = (res.stderr or res.stdout or "").strip()
+        if not is_rp_tool_missing_error(oracle_error, "oracle_send"):
+            error_exit(f"rp-cli failed: {oracle_error}", use_json=False, code=2)
+        res = run_rp_cli(legacy_cmd)
     output = (res.stdout or "") + ("\n" + res.stderr if res.stderr else "")
     chat_id = parse_chat_id(output)
     if args.json:
@@ -5409,16 +5719,17 @@ def cmd_rp_setup_review(args: argparse.Namespace) -> None:
 
     # Step 1: pick-window
     roots = normalize_repo_root(repo_root)
-    result = run_rp_cli(["--raw-json", "-e", "windows"])
-    windows = parse_windows(result.stdout or "")
-
-    win_id: Optional[int] = None
+    win_id = bind_context_window(repo_root)
+    windows: list[dict[str, Any]] = []
+    if win_id is None:
+        result = run_rp_cli(["--raw-json", "-e", "windows"])
+        windows = parse_windows(result.stdout or "")
 
     # Single window with no root paths - use it
-    if len(windows) == 1 and not extract_root_paths(windows[0]):
+    if win_id is None and len(windows) == 1 and not extract_root_paths(windows[0]):
         win_id = extract_window_id(windows[0])
 
-    # Otherwise match by root
+    # Otherwise match by root.
     if win_id is None:
         for win in windows:
             wid = extract_window_id(win)
@@ -5431,15 +5742,59 @@ def cmd_rp_setup_review(args: argparse.Namespace) -> None:
             if win_id is not None:
                 break
 
+    # Fall back to workspace inventory when window root metadata is missing.
+    if win_id is None:
+        workspaces_res = run_rp_cli(
+            [
+                "--raw-json",
+                "-e",
+                f"call manage_workspaces {json.dumps({'action': 'list'})}",
+            ]
+        )
+        workspace = find_workspace_for_repo(
+            parse_manage_workspaces(workspaces_res.stdout or ""),
+            roots,
+        )
+
+        if workspace:
+            window_ids = extract_workspace_window_ids(workspace)
+            if window_ids:
+                win_id = sorted(window_ids)[0]
+            elif getattr(args, "create", False):
+                workspace_ref = extract_workspace_id(workspace) or extract_workspace_name(workspace)
+                if workspace_ref is not None:
+                    switch_cmd = {
+                        "action": "switch",
+                        "workspace": workspace_ref,
+                        "open_in_new_window": True,
+                    }
+                    switch_res = run_rp_cli(
+                        [
+                            "--raw-json",
+                            "-e",
+                            f"call manage_workspaces {json.dumps(switch_cmd)}",
+                        ]
+                    )
+                    try:
+                        switch_data = json.loads(switch_res.stdout or "{}")
+                    except json.JSONDecodeError as e:
+                        error_exit(
+                            f"workspace switch JSON parse failed: {e}",
+                            use_json=False,
+                            code=2,
+                        )
+                    win_id = extract_response_window_id(switch_data)
+
     if win_id is None:
         if getattr(args, "create", False):
-            # Auto-create window via workspace create --new-window (RP 1.5.68+)
             ws_name = os.path.basename(repo_root)
-            create_cmd = f"workspace create {shlex.quote(ws_name)} --new-window --folder-path {shlex.quote(repo_root)}"
+            create_cmd = (
+                f"workspace create {shlex.quote(ws_name)} --new-window --folder-path {shlex.quote(repo_root)}"
+            )
             create_res = run_rp_cli(["--raw-json", "-e", create_cmd])
             try:
                 data = json.loads(create_res.stdout or "{}")
-                win_id = data.get("window_id")
+                win_id = extract_response_window_id(data)
             except json.JSONDecodeError:
                 pass
             if not win_id:
@@ -5453,7 +5808,7 @@ def cmd_rp_setup_review(args: argparse.Namespace) -> None:
 
     # Write state file for ralph-guard verification
     repo_hash = hashlib.sha256(repo_root.encode()).hexdigest()[:16]
-    state_file = Path(f"/tmp/.ralph-pick-window-{repo_hash}")
+    state_file = Path(tempfile.gettempdir()) / f".ralph-pick-window-{repo_hash}"
     state_file.write_text(f"{win_id}\n{repo_root}\n")
 
     # Step 2: builder (with optional --type flag for RP 1.6.0+)
@@ -5478,12 +5833,12 @@ def cmd_rp_setup_review(args: argparse.Namespace) -> None:
     if response_type == "review":
         try:
             data = json.loads(builder_res.stdout or "{}")
-            tab = data.get("tab_id", "")
+            tab = extract_builder_tab_from_payload(data) or ""
             chat_id = data.get("review", {}).get("chat_id", "")
             review_response = data.get("review", {}).get("response", "")
 
             if not tab:
-                error_exit("Builder did not return a tab id", use_json=False, code=2)
+                error_exit("Builder did not return a tab/context id", use_json=False, code=2)
 
             if args.json:
                 print(
@@ -5508,7 +5863,7 @@ def cmd_rp_setup_review(args: argparse.Namespace) -> None:
     else:
         tab = parse_builder_tab(output)
         if not tab:
-            error_exit("Builder did not return a tab id", use_json=False, code=2)
+            error_exit("Builder did not return a tab/context id", use_json=False, code=2)
 
         if args.json:
             print(json.dumps({"window": win_id, "tab": tab, "repo_root": repo_root}))
@@ -5701,25 +6056,18 @@ def cmd_codex_impl_review(args: argparse.Namespace) -> None:
     except (subprocess.CalledProcessError, OSError):
         pass
 
-    # Embed changed file contents for codex only on Windows (sandbox is broken there)
-    # Unix sandbox works correctly, so no embedding needed
-    if os.name == "nt":
-        changed_files = get_changed_files(base_branch)
-        embedded_content, embed_stats = get_embedded_file_contents(changed_files)
-    else:
-        embedded_content = ""
-        embed_stats = {
-            "embedded": 0,
-            "total": 0,
-            "bytes": 0,
-            "binary_skipped": [],
-            "deleted_skipped": [],
-            "outside_repo_skipped": [],
-            "budget_skipped": [],
-        }
+    # Always embed changed file contents so Codex doesn't waste turns reading
+    # files from disk. Without embedding, Codex exhausts its turn budget on
+    # sed/rg commands before producing a verdict (observed 114 turns with no
+    # verdict on complex epics). The FLOW_CODEX_EMBED_MAX_BYTES budget cap
+    # prevents oversized prompts.
+    changed_files = get_changed_files(base_branch)
+    embedded_content, embed_stats = get_embedded_file_contents(changed_files)
 
-    # Build prompt
-    files_embedded = os.name == "nt"
+    # Only forbid disk reads when ALL files were fully embedded. If the budget
+    # was exhausted or files were truncated, allow Codex to read the remainder
+    # from disk so it doesn't review with incomplete context.
+    files_embedded = not embed_stats.get("budget_skipped") and not embed_stats.get("truncated")
     if standalone:
         prompt = build_standalone_review_prompt(base_branch, focus, diff_summary, files_embedded)
         # Append embedded files and diff content to standalone prompt
@@ -5928,28 +6276,16 @@ def cmd_codex_plan_review(args: argparse.Namespace) -> None:
 
     task_specs = "\n\n---\n\n".join(task_specs_parts) if task_specs_parts else ""
 
-    # Embed specified file contents for codex only on Windows (sandbox is broken there)
-    # Unix sandbox works correctly, so no embedding needed
-    if os.name == "nt":
-        embedded_content, embed_stats = get_embedded_file_contents(file_paths)
-    else:
-        embedded_content = ""
-        embed_stats = {
-            "embedded": 0,
-            "total": 0,
-            "bytes": 0,
-            "binary_skipped": [],
-            "deleted_skipped": [],
-            "outside_repo_skipped": [],
-            "budget_skipped": [],
-        }
+    # Always embed file contents so Codex doesn't waste turns reading files
+    # from disk. See cmd_codex_impl_review comment for rationale.
+    embedded_content, embed_stats = get_embedded_file_contents(file_paths)
 
     # Get context hints (from main branch for plans)
     base_branch = args.base if hasattr(args, "base") and args.base else "main"
     context_hints = gather_context_hints(base_branch)
 
-    # Build prompt
-    files_embedded = os.name == "nt"
+    # Only forbid disk reads when ALL files were fully embedded.
+    files_embedded = not embed_stats.get("budget_skipped") and not embed_stats.get("truncated")
     prompt = build_review_prompt(
         "plan", epic_spec, context_hints, task_specs=task_specs, embedded_files=embedded_content,
         files_embedded=files_embedded
@@ -6302,15 +6638,13 @@ def cmd_codex_completion_review(args: argparse.Namespace) -> None:
     except (subprocess.CalledProcessError, OSError):
         pass
 
-    # Embed changed file contents for codex only on Windows
-    if os.name == "nt":
-        changed_files = get_changed_files(base_branch)
-        embedded_content, _ = get_embedded_file_contents(changed_files)
-    else:
-        embedded_content = ""
+    # Always embed changed file contents. See cmd_codex_impl_review comment
+    # for rationale.
+    changed_files = get_changed_files(base_branch)
+    embedded_content, embed_stats = get_embedded_file_contents(changed_files)
 
-    # Build prompt
-    files_embedded = os.name == "nt"
+    # Only forbid disk reads when ALL files were fully embedded.
+    files_embedded = not embed_stats.get("budget_skipped") and not embed_stats.get("truncated")
     prompt = build_completion_review_prompt(
         epic_spec,
         task_specs,

--- a/plugins/flow-next/codex/skills/flow-next-impl-review/workflow.md
+++ b/plugins/flow-next/codex/skills/flow-next-impl-review/workflow.md
@@ -270,7 +270,20 @@ EOF
 ### Send to RepoPrompt
 
 ```bash
-$FLOWCTL rp chat-send --window "$W" --tab "$T" --message-file /tmp/review-prompt.md --new-chat --chat-name "Impl Review: $BRANCH"
+REVIEW_RESPONSE="$($FLOWCTL rp chat-send --window "$W" --tab "$T" --message-file /tmp/review-prompt.md --new-chat --chat-name "Impl Review: $BRANCH")"
+echo "$REVIEW_RESPONSE"
+
+VERDICT="$(echo "$REVIEW_RESPONSE" \
+  | tr -d '\r' \
+  | grep -oE '<verdict>(SHIP|NEEDS_WORK|MAJOR_RETHINK)</verdict>' \
+  | tail -n 1 \
+  | sed -E 's#</?verdict>##g')"
+
+if [[ -z "$VERDICT" ]]; then
+  echo "No verdict tag found in response"
+  echo "<promise>RETRY</promise>"
+  exit 0
+fi
 ```
 
 **WAIT** for response. Takes 1-5+ minutes.
@@ -286,7 +299,7 @@ if [[ -n "${REVIEW_RECEIPT_PATH:-}" ]]; then
   ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
   mkdir -p "$(dirname "$REVIEW_RECEIPT_PATH")"
   cat > "$REVIEW_RECEIPT_PATH" <<EOF
-{"type":"impl_review","id":"<TASK_ID>","mode":"rp","timestamp":"$ts"}
+{"type":"impl_review","id":"<TASK_ID>","mode":"rp","verdict":"$VERDICT","timestamp":"$ts"}
 EOF
   echo "REVIEW_RECEIPT_WRITTEN: $REVIEW_RECEIPT_PATH"
 fi

--- a/plugins/flow-next/codex/skills/flow-next-plan-review/workflow.md
+++ b/plugins/flow-next/codex/skills/flow-next-plan-review/workflow.md
@@ -260,7 +260,20 @@ EOF
 ### Send to RepoPrompt
 
 ```bash
-$FLOWCTL rp chat-send --window "$W" --tab "$T" --message-file /tmp/review-prompt.md --new-chat --chat-name "Plan Review: <EPIC_ID>"
+REVIEW_RESPONSE="$($FLOWCTL rp chat-send --window "$W" --tab "$T" --message-file /tmp/review-prompt.md --new-chat --chat-name "Plan Review: <EPIC_ID>")"
+echo "$REVIEW_RESPONSE"
+
+VERDICT="$(echo "$REVIEW_RESPONSE" \
+  | tr -d '\r' \
+  | grep -oE '<verdict>(SHIP|NEEDS_WORK|MAJOR_RETHINK)</verdict>' \
+  | tail -n 1 \
+  | sed -E 's#</?verdict>##g')"
+
+if [[ -z "$VERDICT" ]]; then
+  echo "No verdict tag found in response"
+  echo "<promise>RETRY</promise>"
+  exit 0
+fi
 ```
 
 **WAIT** for response. Takes 1-5+ minutes.
@@ -276,7 +289,7 @@ if [[ -n "${REVIEW_RECEIPT_PATH:-}" ]]; then
   ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
   mkdir -p "$(dirname "$REVIEW_RECEIPT_PATH")"
   cat > "$REVIEW_RECEIPT_PATH" <<EOF
-{"type":"plan_review","id":"<EPIC_ID>","mode":"rp","timestamp":"$ts"}
+{"type":"plan_review","id":"<EPIC_ID>","mode":"rp","verdict":"$VERDICT","timestamp":"$ts"}
 EOF
   echo "REVIEW_RECEIPT_WRITTEN: $REVIEW_RECEIPT_PATH"
 fi
@@ -284,7 +297,6 @@ fi
 
 ### Update status
 
-Extract verdict from response, then:
 ```bash
 # If SHIP
 $FLOWCTL epic set-plan-review-status <EPIC_ID> --status ship --json

--- a/plugins/flow-next/codex/skills/flow-next-ralph-init/templates/prompt_completion.md
+++ b/plugins/flow-next/codex/skills/flow-next-ralph-init/templates/prompt_completion.md
@@ -40,12 +40,12 @@ Ralph mode rules (must follow):
    mkdir -p "$(dirname '{{REVIEW_RECEIPT_PATH}}')"
    ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
    cat > '{{REVIEW_RECEIPT_PATH}}' <<EOF
-   {"type":"completion_review","id":"{{EPIC_ID}}","mode":"rp","timestamp":"$ts","iteration":{{RALPH_ITERATION}}}
+   {"type":"completion_review","id":"{{EPIC_ID}}","mode":"rp","verdict":"SHIP","timestamp":"$ts","iteration":{{RALPH_ITERATION}}}
    EOF
    ```
    For codex mode, receipt is written automatically by `flowctl codex completion-review --receipt`.
-   **CRITICAL: Copy EXACTLY. The `"id":"{{EPIC_ID}}"` field is REQUIRED.**
-   Missing id = verification fails = forced retry.
+   **CRITICAL: Copy EXACTLY. The `"id":"{{EPIC_ID}}"` and `"verdict":"SHIP"` fields are REQUIRED.**
+   Missing id/verdict = verification fails = forced retry.
 
 6) After SHIP:
    - `scripts/ralph/flowctl epic set-completion-review-status {{EPIC_ID}} --status ship --json`

--- a/plugins/flow-next/codex/skills/flow-next-ralph-init/templates/prompt_plan.md
+++ b/plugins/flow-next/codex/skills/flow-next-ralph-init/templates/prompt_plan.md
@@ -44,12 +44,12 @@ Ralph mode rules (must follow):
    mkdir -p "$(dirname '{{REVIEW_RECEIPT_PATH}}')"
    ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
    cat > '{{REVIEW_RECEIPT_PATH}}' <<EOF
-   {"type":"plan_review","id":"{{EPIC_ID}}","mode":"rp","timestamp":"$ts","iteration":{{RALPH_ITERATION}}}
+   {"type":"plan_review","id":"{{EPIC_ID}}","mode":"rp","verdict":"SHIP","timestamp":"$ts","iteration":{{RALPH_ITERATION}}}
    EOF
    ```
    For codex mode, receipt is written automatically by `flowctl codex plan-review --receipt`.
-   **CRITICAL: Copy EXACTLY. The `"id":"{{EPIC_ID}}"` field is REQUIRED.**
-   Missing id = verification fails = forced retry.
+   **CRITICAL: Copy EXACTLY. The `"id":"{{EPIC_ID}}"` and `"verdict":"SHIP"` fields are REQUIRED.**
+   Missing id/verdict = verification fails = forced retry.
 
 6) After SHIP:
    - `scripts/ralph/flowctl epic set-plan-review-status {{EPIC_ID}} --status ship --json`

--- a/plugins/flow-next/codex/skills/flow-next-ralph-init/templates/prompt_work.md
+++ b/plugins/flow-next/codex/skills/flow-next-ralph-init/templates/prompt_work.md
@@ -28,13 +28,13 @@ For rp mode:
 mkdir -p "$(dirname '{{REVIEW_RECEIPT_PATH}}')"
 ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 cat > '{{REVIEW_RECEIPT_PATH}}' <<EOF
-{"type":"impl_review","id":"{{TASK_ID}}","mode":"rp","timestamp":"$ts","iteration":{{RALPH_ITERATION}}}
+{"type":"impl_review","id":"{{TASK_ID}}","mode":"rp","verdict":"SHIP","timestamp":"$ts","iteration":{{RALPH_ITERATION}}}
 EOF
 echo "Receipt written: {{REVIEW_RECEIPT_PATH}}"
 ```
 For codex mode, receipt is written automatically by `flowctl codex impl-review --receipt`.
-**CRITICAL: Copy the command EXACTLY. The `"id":"{{TASK_ID}}"` field is REQUIRED.**
-Ralph verifies receipts match this exact schema. Missing id = verification fails = forced retry.
+**CRITICAL: Copy the command EXACTLY. The `"id":"{{TASK_ID}}"` and `"verdict":"SHIP"` fields are REQUIRED.**
+Ralph verifies receipts match this exact schema. Missing id/verdict = verification fails = forced retry.
 
 **Step 4: Validate epic**
 ```bash

--- a/plugins/flow-next/codex/skills/flow-next-ralph-init/templates/ralph.sh
+++ b/plugins/flow-next/codex/skills/flow-next-ralph-init/templates/ralph.sh
@@ -830,6 +830,8 @@ if data.get("type") != kind:
     sys.exit(1)
 if data.get("id") != rid:
     sys.exit(1)
+if data.get("verdict") not in ("SHIP", "NEEDS_WORK", "MAJOR_RETHINK"):
+    sys.exit(1)
 sys.exit(0)
 PY
 }

--- a/plugins/flow-next/scripts/ci_test.sh
+++ b/plugins/flow-next/scripts/ci_test.sh
@@ -536,6 +536,154 @@ PYTEST
 [[ $? -eq 0 ]] && pass "RepoPrompt setup-review regression" || fail "RepoPrompt setup-review regression"
 
 # ─────────────────────────────────────────────────────────────────────────────
+# 6c. RepoPrompt Chat Send Compatibility
+# ─────────────────────────────────────────────────────────────────────────────
+echo -e "\n${YELLOW}--- RepoPrompt Chat Send Compatibility ---${NC}"
+
+"$PYTHON_BIN" - "$TEST_DIR" << 'PYTEST'
+import importlib.util
+import io
+import json
+import sys
+from argparse import Namespace
+from contextlib import redirect_stdout
+from pathlib import Path
+from types import SimpleNamespace
+
+test_dir = Path(sys.argv[1])
+spec = importlib.util.spec_from_file_location("flowctl", test_dir / "scripts/flowctl.py")
+flowctl = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(flowctl)
+
+errors = []
+
+
+def make_result(stdout="", stderr=""):
+    return SimpleNamespace(stdout=stdout, stderr=stderr)
+
+
+msg_file = test_dir / "chat-send.md"
+msg_file.write_text("Review this change.\n", encoding="utf-8")
+
+# Modern RepoPrompt: prefer oracle_send and strip legacy-only fields.
+oracle_calls = []
+legacy_calls = []
+
+
+def modern_try(args, timeout=None):
+    oracle_calls.append(args)
+    return make_result("## Chat Send ✅\n- **Chat**: `modern-chat`\n")
+
+
+def modern_run(args, timeout=None):
+    legacy_calls.append(args)
+    raise AssertionError(f"Legacy fallback should not run: {args}")
+
+
+flowctl.try_run_rp_cli = modern_try
+flowctl.run_rp_cli = modern_run
+modern_output = io.StringIO()
+with redirect_stdout(modern_output):
+    flowctl.cmd_rp_chat_send(
+        Namespace(
+            window=7,
+            tab="tab-modern",
+            message_file=str(msg_file),
+            new_chat=True,
+            chat_name="Smoke Preflight",
+            chat_id=None,
+            mode="review",
+            selected_paths=["src/a.cs", "src/b.cs"],
+            json=False,
+        )
+    )
+
+expected_modern = [
+    "-w",
+    "7",
+    "-t",
+    "tab-modern",
+    "-e",
+    'call oracle_send {"message":"Review this change.\\n","mode":"review","new_chat":true}',
+]
+if oracle_calls != [expected_modern]:
+    errors.append(f"modern chat-send should call oracle_send without legacy fields, got {oracle_calls!r}")
+if legacy_calls:
+    errors.append(f"modern chat-send unexpectedly used legacy fallback: {legacy_calls!r}")
+if "modern-chat" not in modern_output.getvalue():
+    errors.append(f"modern chat-send should print RepoPrompt response, got {modern_output.getvalue()!r}")
+
+# Legacy RepoPrompt: fall back to chat_send and preserve old payload fields.
+oracle_calls = []
+legacy_calls = []
+
+
+def legacy_try(args, timeout=None):
+    oracle_calls.append(args)
+    return None
+
+
+def legacy_run(args, timeout=None):
+    legacy_calls.append(args)
+    return make_result('{"chat_id":"legacy-chat"}')
+
+
+flowctl.try_run_rp_cli = legacy_try
+flowctl.run_rp_cli = legacy_run
+legacy_output = io.StringIO()
+with redirect_stdout(legacy_output):
+    flowctl.cmd_rp_chat_send(
+        Namespace(
+            window=9,
+            tab="tab-legacy",
+            message_file=str(msg_file),
+            new_chat=True,
+            chat_name="Legacy Chat",
+            chat_id="chat-123",
+            mode="chat",
+            selected_paths=["spec.md"],
+            json=True,
+        )
+    )
+
+expected_legacy = [
+    "-w",
+    "9",
+    "-t",
+    "tab-legacy",
+    "-e",
+    'call chat_send {"message":"Review this change.\\n","mode":"chat","new_chat":true,"chat_id":"chat-123","chat_name":"Legacy Chat","selected_paths":["spec.md"]}',
+]
+if oracle_calls != [[
+    "-w",
+    "9",
+    "-t",
+    "tab-legacy",
+    "-e",
+    'call oracle_send {"message":"Review this change.\\n","mode":"chat","new_chat":true,"chat_id":"chat-123"}',
+]]:
+    errors.append(f"legacy fallback should probe oracle_send first, got {oracle_calls!r}")
+if legacy_calls != [expected_legacy]:
+    errors.append(f"legacy fallback should preserve chat_send payload, got {legacy_calls!r}")
+try:
+    parsed = json.loads(legacy_output.getvalue())
+except json.JSONDecodeError as exc:
+    errors.append(f"legacy chat-send should emit JSON output: {exc}")
+else:
+    if parsed.get("chat") != "legacy-chat":
+        errors.append(f"legacy chat-send should parse chat id from fallback output, got {parsed!r}")
+
+if errors:
+    print("RepoPrompt chat-send compatibility errors:")
+    for error in errors:
+        print(f"  - {error}")
+    sys.exit(1)
+
+print("RepoPrompt chat-send compatibility passed")
+PYTEST
+[[ $? -eq 0 ]] && pass "RepoPrompt chat-send compatibility" || fail "RepoPrompt chat-send compatibility"
+
+# ─────────────────────────────────────────────────────────────────────────────
 # 7. ralph.sh Helper Functions
 # ─────────────────────────────────────────────────────────────────────────────
 echo -e "\n${YELLOW}--- ralph.sh Helpers ---${NC}"

--- a/plugins/flow-next/scripts/ci_test.sh
+++ b/plugins/flow-next/scripts/ci_test.sh
@@ -374,7 +374,7 @@ import json
 import sys
 import tempfile
 from argparse import Namespace
-from contextlib import redirect_stdout
+from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -546,7 +546,7 @@ import io
 import json
 import sys
 from argparse import Namespace
-from contextlib import redirect_stdout
+from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -562,6 +562,10 @@ def make_result(stdout="", stderr=""):
     return SimpleNamespace(stdout=stdout, stderr=stderr)
 
 
+def make_completed(stdout="", stderr="", returncode=0):
+    return SimpleNamespace(stdout=stdout, stderr=stderr, returncode=returncode)
+
+
 msg_file = test_dir / "chat-send.md"
 msg_file.write_text("Review this change.\n", encoding="utf-8")
 
@@ -570,9 +574,9 @@ oracle_calls = []
 legacy_calls = []
 
 
-def modern_try(args, timeout=None):
+def modern_unchecked(args, timeout=None):
     oracle_calls.append(args)
-    return make_result("## Chat Send ✅\n- **Chat**: `modern-chat`\n")
+    return make_completed("## Chat Send ✅\n- **Chat**: `modern-chat`\n")
 
 
 def modern_run(args, timeout=None):
@@ -580,7 +584,7 @@ def modern_run(args, timeout=None):
     raise AssertionError(f"Legacy fallback should not run: {args}")
 
 
-flowctl.try_run_rp_cli = modern_try
+flowctl.run_rp_cli_unchecked = modern_unchecked
 flowctl.run_rp_cli = modern_run
 modern_output = io.StringIO()
 with redirect_stdout(modern_output):
@@ -618,9 +622,9 @@ oracle_calls = []
 legacy_calls = []
 
 
-def legacy_try(args, timeout=None):
+def legacy_unchecked(args, timeout=None):
     oracle_calls.append(args)
-    return None
+    return make_completed(stderr="Error:\nTool not found: oracle_send", returncode=2)
 
 
 def legacy_run(args, timeout=None):
@@ -628,7 +632,7 @@ def legacy_run(args, timeout=None):
     return make_result('{"chat_id":"legacy-chat"}')
 
 
-flowctl.try_run_rp_cli = legacy_try
+flowctl.run_rp_cli_unchecked = legacy_unchecked
 flowctl.run_rp_cli = legacy_run
 legacy_output = io.StringIO()
 with redirect_stdout(legacy_output):
@@ -672,6 +676,49 @@ except json.JSONDecodeError as exc:
 else:
     if parsed.get("chat") != "legacy-chat":
         errors.append(f"legacy chat-send should parse chat id from fallback output, got {parsed!r}")
+
+# Real oracle_send failures should surface directly instead of falling back.
+oracle_calls = []
+legacy_calls = []
+
+
+def broken_unchecked(args, timeout=None):
+    oracle_calls.append(args)
+    return make_completed(stderr="Error:\n[-32602] Invalid params: bad tab", returncode=1)
+
+
+def broken_run(args, timeout=None):
+    legacy_calls.append(args)
+    raise AssertionError(f"Legacy fallback should not run for real oracle failures: {args}")
+
+
+flowctl.run_rp_cli_unchecked = broken_unchecked
+flowctl.run_rp_cli = broken_run
+broken_stderr = io.StringIO()
+try:
+    with redirect_stderr(broken_stderr):
+        flowctl.cmd_rp_chat_send(
+            Namespace(
+                window=3,
+                tab="bad-tab",
+                message_file=str(msg_file),
+                new_chat=False,
+                chat_name=None,
+                chat_id=None,
+                mode="chat",
+                selected_paths=None,
+                json=False,
+            )
+        )
+except SystemExit as exc:
+    if exc.code != 2:
+        errors.append(f"real oracle failures should exit 2, got {exc.code!r}")
+else:
+    errors.append("real oracle failures should exit instead of falling back")
+if "Invalid params: bad tab" not in broken_stderr.getvalue():
+    errors.append(f"real oracle failure should preserve original error, got {broken_stderr.getvalue()!r}")
+if legacy_calls:
+    errors.append(f"real oracle failures should not call legacy chat_send, got {legacy_calls!r}")
 
 if errors:
     print("RepoPrompt chat-send compatibility errors:")

--- a/plugins/flow-next/scripts/flowctl.py
+++ b/plugins/flow-next/scripts/flowctl.py
@@ -417,6 +417,24 @@ def run_rp_cli(
         error_exit(f"rp-cli failed: {msg}", use_json=False, code=2)
 
 
+def run_rp_cli_unchecked(
+    args: list[str], timeout: Optional[int] = None
+) -> subprocess.CompletedProcess:
+    """Run rp-cli without collapsing command failures.
+
+    Used when a caller needs to inspect stderr/stdout before deciding whether a
+    failure is a capability mismatch or a real RepoPrompt error.
+    """
+    if timeout is None:
+        timeout = int(os.environ.get("FLOW_RP_TIMEOUT", "1200"))
+    rp = require_rp_cli()
+    cmd = [rp] + args
+    try:
+        return subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+    except subprocess.TimeoutExpired:
+        error_exit(f"rp-cli timed out after {timeout}s", use_json=False, code=3)
+
+
 def try_run_rp_cli(
     args: list[str], timeout: Optional[int] = None
 ) -> Optional[subprocess.CompletedProcess]:
@@ -435,6 +453,17 @@ def try_run_rp_cli(
         )
     except (subprocess.TimeoutExpired, subprocess.CalledProcessError):
         return None
+
+
+def is_rp_tool_missing_error(output: str, tool_name: str) -> bool:
+    """Return true only for clear RepoPrompt missing-tool capability errors."""
+    patterns = [
+        rf"\bTool not found:\s*{re.escape(tool_name)}\b",
+        rf"\bUnknown tool:\s*{re.escape(tool_name)}\b",
+        rf"\bUnknown function:\s*{re.escape(tool_name)}\b",
+        rf"\bNo such tool:\s*{re.escape(tool_name)}\b",
+    ]
+    return any(re.search(pattern, output, re.I) for pattern in patterns)
 
 
 def normalize_repo_root(path: str) -> list[str]:
@@ -5643,8 +5672,11 @@ def cmd_rp_chat_send(args: argparse.Namespace) -> None:
         "-e",
         f"call chat_send {legacy_payload}",
     ]
-    res = try_run_rp_cli(oracle_cmd)
-    if res is None:
+    res = run_rp_cli_unchecked(oracle_cmd)
+    if res.returncode != 0:
+        oracle_error = (res.stderr or res.stdout or "").strip()
+        if not is_rp_tool_missing_error(oracle_error, "oracle_send"):
+            error_exit(f"rp-cli failed: {oracle_error}", use_json=False, code=2)
         res = run_rp_cli(legacy_cmd)
     output = (res.stdout or "") + ("\n" + res.stderr if res.stderr else "")
     chat_id = parse_chat_id(output)

--- a/plugins/flow-next/scripts/flowctl.py
+++ b/plugins/flow-next/scripts/flowctl.py
@@ -735,6 +735,7 @@ def build_chat_payload(
     chat_name: Optional[str] = None,
     chat_id: Optional[str] = None,
     selected_paths: Optional[list[str]] = None,
+    include_legacy_fields: bool = True,
 ) -> str:
     payload: dict[str, Any] = {
         "message": message,
@@ -742,12 +743,13 @@ def build_chat_payload(
     }
     if new_chat:
         payload["new_chat"] = True
-    if chat_name:
-        payload["chat_name"] = chat_name
     if chat_id:
         payload["chat_id"] = chat_id
-    if selected_paths:
-        payload["selected_paths"] = selected_paths
+    if include_legacy_fields:
+        if chat_name:
+            payload["chat_name"] = chat_name
+        if selected_paths:
+            payload["selected_paths"] = selected_paths
     return json.dumps(payload, ensure_ascii=False, separators=(",", ":"))
 
 
@@ -5610,7 +5612,14 @@ def cmd_rp_chat_send(args: argparse.Namespace) -> None:
     message = read_text_or_exit(Path(args.message_file), "Message file", use_json=False)
     chat_id_arg = getattr(args, "chat_id", None)
     mode = getattr(args, "mode", "chat") or "chat"
-    payload = build_chat_payload(
+    oracle_payload = build_chat_payload(
+        message=message,
+        mode=mode,
+        new_chat=args.new_chat,
+        chat_id=chat_id_arg,
+        include_legacy_fields=False,
+    )
+    legacy_payload = build_chat_payload(
         message=message,
         mode=mode,
         new_chat=args.new_chat,
@@ -5618,15 +5627,25 @@ def cmd_rp_chat_send(args: argparse.Namespace) -> None:
         chat_id=chat_id_arg,
         selected_paths=args.selected_paths,
     )
-    cmd = [
+    oracle_cmd = [
         "-w",
         str(args.window),
         "-t",
         args.tab,
         "-e",
-        f"call chat_send {payload}",
+        f"call oracle_send {oracle_payload}",
     ]
-    res = run_rp_cli(cmd)
+    legacy_cmd = [
+        "-w",
+        str(args.window),
+        "-t",
+        args.tab,
+        "-e",
+        f"call chat_send {legacy_payload}",
+    ]
+    res = try_run_rp_cli(oracle_cmd)
+    if res is None:
+        res = run_rp_cli(legacy_cmd)
     output = (res.stdout or "") + ("\n" + res.stderr if res.stderr else "")
     chat_id = parse_chat_id(output)
     if args.json:

--- a/plugins/flow-next/scripts/hooks/ralph-guard.py
+++ b/plugins/flow-next/scripts/hooks/ralph-guard.py
@@ -17,7 +17,7 @@ Supports both review backends:
 """
 
 # Version for drift detection (bump when making changes)
-RALPH_GUARD_VERSION = "0.13.0"
+RALPH_GUARD_VERSION = "0.13.1"
 
 import json
 import os
@@ -84,6 +84,79 @@ def output_block(reason: str) -> None:
     """Output blocking response (exit code 2 style via stderr)."""
     print(reason, file=sys.stderr)
     sys.exit(2)
+
+
+VALID_RECEIPT_VERDICTS = {"SHIP", "NEEDS_WORK", "MAJOR_RETHINK"}
+
+
+def is_receipt_write_command(command: str, receipt_path: str) -> bool:
+    """Return true when a Bash command redirects output to the active receipt."""
+    if not receipt_path:
+        return False
+
+    patterns = [
+        rf">\s*['\"]?{re.escape(receipt_path)}['\"]?",
+        r">\s*['\"]?.*receipts/.*\.json",
+        r">\s*['\"]?\$[{]?REVIEW_RECEIPT_PATH[}]?['\"]?",
+        r">\s*['\"]?\$[{]?RECEIPT_PATH[}]?['\"]?",
+        r">\s*['\"]?\$[{]?RECEIPT_DIR[}]?/",
+        r"cat\s*>\s*.*receipt",
+        r"\btee\s+['\"]?\$[{]?REVIEW_RECEIPT_PATH[}]?['\"]?",
+        r"\btee\s+['\"]?\$[{]?RECEIPT_PATH[}]?['\"]?",
+    ]
+    receipt_dir = os.path.dirname(receipt_path)
+    if receipt_dir:
+        patterns.append(rf">\s*['\"]?{re.escape(receipt_dir)}")
+    return any(re.search(pattern, command, re.I) for pattern in patterns)
+
+
+def command_has_json_field(command: str, field: str) -> bool:
+    """Best-effort check that a shell command writes a JSON field literally."""
+    return bool(re.search(rf"['\"]{re.escape(field)}['\"]\s*:", command))
+
+
+def validate_receipt_data(
+    data: object,
+    receipt_path: str = "",
+    expected_kind: str = "",
+    expected_id: str = "",
+) -> str:
+    """Return empty string for valid receipt data, otherwise an error string."""
+    if not isinstance(data, dict):
+        return "expected object"
+
+    receipt_type = data.get("type")
+    receipt_id = data.get("id")
+    verdict = data.get("verdict")
+    if not receipt_type or not receipt_id:
+        return "missing type/id"
+    if verdict not in VALID_RECEIPT_VERDICTS:
+        return "missing or invalid verdict"
+
+    if receipt_path and (not expected_kind or not expected_id):
+        parsed_kind, parsed_id = parse_receipt_path(receipt_path)
+        if parsed_id != "UNKNOWN":
+            expected_kind = expected_kind or parsed_kind
+            expected_id = expected_id or parsed_id
+
+    if expected_kind and receipt_type != expected_kind:
+        return f"type mismatch: expected {expected_kind}, got {receipt_type}"
+    if expected_id and receipt_id != expected_id:
+        return f"id mismatch: expected {expected_id}, got {receipt_id}"
+
+    return ""
+
+
+def validate_receipt_file(receipt_path: str) -> str:
+    """Return empty string for a valid receipt file, otherwise an error string."""
+    path = Path(receipt_path)
+    if not path.exists():
+        return "missing receipt"
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        return f"invalid JSON: {exc}"
+    return validate_receipt_data(data, receipt_path=receipt_path)
 
 
 # --- Memory helpers ---
@@ -236,13 +309,7 @@ def handle_pre_tool_use(data: dict) -> None:
     # Block receipt writes unless chat-send has succeeded + validate format
     receipt_path = os.environ.get("REVIEW_RECEIPT_PATH", "")
     if receipt_path:
-        # Check if this command writes to a receipt path
-        receipt_dir = os.path.dirname(receipt_path)
-        is_receipt_write = receipt_dir and (
-            re.search(rf">\s*['\"]?{re.escape(receipt_dir)}", command)
-            or re.search(r">\s*['\"]?.*receipts/.*\.json", command)
-            or re.search(r"cat\s*>\s*.*receipt", command, re.I)
-        )
+        is_receipt_write = is_receipt_write_command(command, receipt_path)
         if is_receipt_write:
             state = load_state(session_id)
             if not state.get("chat_send_succeeded") and not state.get(
@@ -253,36 +320,40 @@ def handle_pre_tool_use(data: dict) -> None:
                     "You must run 'flowctl rp chat-send' or 'flowctl codex impl-review/plan-review' "
                     "and receive a review response before writing the receipt."
                 )
-            # Validate receipt has required 'id' field
-            if '"id"' not in command and "'id'" not in command:
+            # Validate receipt has required fields. Stop/ralph.sh validate the actual file.
+            if not command_has_json_field(command, "type"):
+                output_block(
+                    "BLOCKED: Receipt JSON is missing required 'type' field. "
+                    'Receipt must include: {"type":"...","id":"...","verdict":"...",...} '
+                    "Copy the exact command from the prompt template."
+                )
+            if not command_has_json_field(command, "id"):
                 output_block(
                     "BLOCKED: Receipt JSON is missing required 'id' field. "
                     'Receipt must include: {"type":"...","id":"<TASK_OR_EPIC_ID>",...} '
                     "Copy the exact command from the prompt template."
                 )
-            # Validate completion_review receipts have verdict field
-            if "completion_review" in command or "completion-" in receipt_path:
-                if '"verdict"' not in command and "'verdict'" not in command:
-                    output_block(
-                        "BLOCKED: Receipt JSON is missing required 'verdict' field. "
-                        'Completion review receipts must include: {"verdict":"SHIP",...} '
-                        "Copy the exact command from the prompt template."
-                    )
+            if not command_has_json_field(command, "verdict"):
+                output_block(
+                    "BLOCKED: Receipt JSON is missing required 'verdict' field. "
+                    'Review receipts must include: {"verdict":"SHIP",...} '
+                    "Copy the exact command from the prompt template."
+                )
             # For impl receipts, verify flowctl done was called
-            if "impl_review" in command:
+            receipt_type, item_id = parse_receipt_path(receipt_path)
+            if receipt_type == "impl_review" or "impl_review" in command:
                 # Extract task id from receipt
                 id_match = re.search(r'"id"\s*:\s*"([^"]+)"', command)
-                if id_match:
-                    task_id = id_match.group(1)
-                    done_set = state.get("flowctl_done_called", set())
-                    if isinstance(done_set, list):
-                        done_set = set(done_set)
-                    if task_id not in done_set:
-                        output_block(
-                            f"BLOCKED: Cannot write impl receipt for {task_id} - flowctl done was not called. "
-                            f"You MUST run 'flowctl done {task_id} --evidence ...' BEFORE writing the receipt. "
-                            "The task is NOT complete until flowctl done succeeds."
-                        )
+                task_id = id_match.group(1) if id_match else item_id
+                done_set = state.get("flowctl_done_called", set())
+                if isinstance(done_set, list):
+                    done_set = set(done_set)
+                if task_id not in done_set:
+                    output_block(
+                        f"BLOCKED: Cannot write impl receipt for {task_id} - flowctl done was not called. "
+                        f"You MUST run 'flowctl done {task_id} --evidence ...' BEFORE writing the receipt. "
+                        "The task is NOT complete until flowctl done succeeds."
+                    )
 
     # All checks passed
     sys.exit(0)
@@ -414,13 +485,7 @@ def handle_post_tool_use(data: dict) -> None:
     # that merely contain the receipt path as an argument (e.g. --receipt flag)
     receipt_path = os.environ.get("REVIEW_RECEIPT_PATH", "")
     if receipt_path:
-        receipt_dir = os.path.dirname(receipt_path)
-        is_receipt_write = receipt_dir and (
-            re.search(rf">\s*['\"]?{re.escape(receipt_dir)}", command)
-            or re.search(r">\s*['\"]?.*receipts/.*\.json", command)
-            or re.search(r"cat\s*>\s*.*receipt", command, re.I)
-        )
-        if is_receipt_write:
+        if is_receipt_write_command(command, receipt_path):
             state["chat_send_succeeded"] = False  # Reset for next review
             state["codex_review_succeeded"] = False  # Reset codex state too
             save_state(session_id, state)
@@ -542,7 +607,8 @@ def handle_stop(data: dict) -> None:
     receipt_path = os.environ.get("REVIEW_RECEIPT_PATH", "")
 
     if receipt_path:
-        if not Path(receipt_path).exists():
+        validation_error = validate_receipt_file(receipt_path)
+        if validation_error:
             # Derive type and id from receipt path
             receipt_type, item_id = parse_receipt_path(receipt_path)
             # Tell worker to invoke the review skill, not write receipt manually
@@ -560,7 +626,7 @@ def handle_stop(data: dict) -> None:
                 {
                     "decision": "block",
                     "reason": (
-                        f"Cannot stop: {skill_desc} not completed.\n"
+                        f"Cannot stop: {skill_desc} not completed ({validation_error}).\n"
                         f"You MUST invoke `{skill} {item_id}` to complete the review.\n"
                         f"The skill writes the receipt on SHIP verdict.\n"
                         f"Do NOT write the receipt manually - that skips the actual review."

--- a/plugins/flow-next/scripts/hooks/ralph-receipt-guard.sh
+++ b/plugins/flow-next/scripts/hooks/ralph-receipt-guard.sh
@@ -16,7 +16,9 @@ fi
 
 python3 - "$REVIEW_RECEIPT_PATH" <<'PY'
 import json
+import re
 import sys
+from pathlib import Path
 
 path = sys.argv[1]
 try:
@@ -33,6 +35,24 @@ if not isinstance(data, dict):
 if not data.get("type") or not data.get("id"):
     print("Invalid receipt JSON: missing type/id", file=sys.stderr)
     sys.exit(2)
+
+if data.get("verdict") not in ("SHIP", "NEEDS_WORK", "MAJOR_RETHINK"):
+    print("Invalid receipt JSON: missing or invalid verdict", file=sys.stderr)
+    sys.exit(2)
+
+basename = Path(path).name
+patterns = [
+    (r"^plan-(fn-\d+(?:-[a-z0-9][a-z0-9-]*[a-z0-9]|-[a-z0-9]{1,3})?)\.json$", "plan_review"),
+    (r"^impl-(fn-\d+(?:-[a-z0-9][a-z0-9-]*[a-z0-9]|-[a-z0-9]{1,3})?\.\d+)\.json$", "impl_review"),
+    (r"^completion-(fn-\d+(?:-[a-z0-9][a-z0-9-]*[a-z0-9]|-[a-z0-9]{1,3})?)\.json$", "completion_review"),
+]
+for pattern, expected_type in patterns:
+    match = re.match(pattern, basename)
+    if match:
+        if data.get("type") != expected_type or data.get("id") != match.group(1):
+            print("Invalid receipt JSON: type/id do not match receipt filename", file=sys.stderr)
+            sys.exit(2)
+        break
 
 sys.exit(0)
 PY

--- a/plugins/flow-next/scripts/ralph_smoke_test.sh
+++ b/plugins/flow-next/scripts/ralph_smoke_test.sh
@@ -32,6 +32,10 @@ YELLOW='\033[1;33m'
 NC='\033[0m'
 
 cleanup() {
+  if [[ "${KEEP_TEST_DIR:-0}" == "1" ]]; then
+    echo "Keeping test dir: $TEST_DIR"
+    return
+  fi
   rm -rf "$TEST_DIR"
 }
 trap cleanup EXIT
@@ -62,22 +66,25 @@ scaffold() {
 write_config() {
   local plan="$1"
   local work="$2"
-  local require="$3"
-  local branch="$4"
-  local max_iter="$5"
-  local max_turns="$6"
-  local max_attempts="$7"
-  "$PYTHON_BIN" - <<'PY' "$plan" "$work" "$require" "$branch" "$max_iter" "$max_turns" "$max_attempts"
+  local completion="$3"
+  local require="$4"
+  local branch="$5"
+  local max_iter="$6"
+  local max_turns="$7"
+  local max_attempts="$8"
+  "$PYTHON_BIN" - <<'PY' "$plan" "$work" "$completion" "$require" "$branch" "$max_iter" "$max_turns" "$max_attempts"
 from pathlib import Path
 import re, sys
-plan, work, require, branch, max_iter, max_turns, max_attempts = sys.argv[1:8]
+plan, work, completion, require, branch, max_iter, max_turns, max_attempts = sys.argv[1:9]
 cfg = Path("scripts/ralph/config.env")
 text = cfg.read_text()
 # Replace template placeholders first (for initial setup)
 text = text.replace("{{PLAN_REVIEW}}", plan).replace("{{WORK_REVIEW}}", work)
+text = text.replace("{{COMPLETION_REVIEW}}", completion)
 # Then use re.sub for subsequent calls (when values are already set)
 text = re.sub(r"^PLAN_REVIEW=.*$", f"PLAN_REVIEW={plan}", text, flags=re.M)
 text = re.sub(r"^WORK_REVIEW=.*$", f"WORK_REVIEW={work}", text, flags=re.M)
+text = re.sub(r"^COMPLETION_REVIEW=.*$", f"COMPLETION_REVIEW={completion}", text, flags=re.M)
 text = re.sub(r"^REQUIRE_PLAN_REVIEW=.*$", f"REQUIRE_PLAN_REVIEW={require}", text, flags=re.M)
 text = re.sub(r"^BRANCH_MODE=.*$", f"BRANCH_MODE={branch}", text, flags=re.M)
 text = re.sub(r"^MAX_ITERATIONS=.*$", f"MAX_ITERATIONS={max_iter}", text, flags=re.M)
@@ -118,6 +125,7 @@ set -euo pipefail
  write_receipt="${STUB_WRITE_RECEIPT:-1}"
  write_plan="${STUB_WRITE_PLAN_RECEIPT:-$write_receipt}"
  write_impl="${STUB_WRITE_IMPL_RECEIPT:-$write_receipt}"
+ write_completion="${STUB_WRITE_COMPLETION_RECEIPT:-$write_receipt}"
  exit_code="${STUB_EXIT_CODE:-0}"
  skip_done="${STUB_SKIP_DONE:-0}"
 has_p=0
@@ -136,7 +144,7 @@ fi
 
 if [[ "$prompt" == *"Ralph plan gate iteration"* ]]; then
   # Extract epic ID with optional suffix (fn-N or fn-N-xxx)
-  epic_id="$(printf '%s\n' "$prompt" | sed -n 's/.*EPIC_ID=\(fn-[0-9][0-9]*\(-[a-z0-9][a-z0-9][a-z0-9]\)\{0,1\}\).*/\1/p' | head -n1)"
+  epic_id="$(printf '%s\n' "$prompt" | sed -n 's/^- EPIC_ID=//p' | head -n1)"
   if [[ -n "$epic_id" ]]; then
     scripts/ralph/flowctl epic set-plan-review-status "$epic_id" --status ship --json >/dev/null
   fi
@@ -144,7 +152,7 @@ if [[ "$prompt" == *"Ralph plan gate iteration"* ]]; then
     ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
     mkdir -p "$(dirname "$REVIEW_RECEIPT_PATH")"
     cat > "$REVIEW_RECEIPT_PATH" <<EOF_RECEIPT
-{"type":"plan_review","id":"$epic_id","mode":"stub","timestamp":"$ts"}
+{"type":"plan_review","id":"$epic_id","mode":"stub","verdict":"SHIP","timestamp":"$ts"}
 EOF_RECEIPT
     echo "REVIEW_RECEIPT_WRITTEN: $REVIEW_RECEIPT_PATH"
   fi
@@ -154,7 +162,7 @@ fi
 
 if [[ "$prompt" == *"Ralph work iteration"* ]]; then
   # Extract task ID with optional suffix (fn-N.M or fn-N-xxx.M)
-  task_id="$(printf '%s\n' "$prompt" | sed -n 's/.*TASK_ID=\(fn-[0-9][0-9]*\(-[a-z0-9][a-z0-9][a-z0-9]\)\{0,1\}\.[0-9][0-9]*\).*/\1/p' | head -n1)"
+  task_id="$(printf '%s\n' "$prompt" | sed -n 's/^- TASK_ID=//p' | head -n1)"
   if [[ "$skip_done" != "1" ]]; then
     summary="$(mktemp)"
     evidence="$(mktemp)"
@@ -168,11 +176,28 @@ if [[ "$prompt" == *"Ralph work iteration"* ]]; then
     ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
     mkdir -p "$(dirname "$REVIEW_RECEIPT_PATH")"
     cat > "$REVIEW_RECEIPT_PATH" <<EOF_RECEIPT
-{"type":"impl_review","id":"$task_id","mode":"stub","timestamp":"$ts"}
+{"type":"impl_review","id":"$task_id","mode":"stub","verdict":"SHIP","timestamp":"$ts"}
 EOF_RECEIPT
     echo "REVIEW_RECEIPT_WRITTEN: $REVIEW_RECEIPT_PATH"
   fi
   echo "done $task_id"
+  exit "$exit_code"
+fi
+
+if [[ "$prompt" == *"Ralph epic completion review iteration"* ]]; then
+  epic_id="$(printf '%s\n' "$prompt" | sed -n 's/^- EPIC_ID=//p' | head -n1)"
+  if [[ -n "$epic_id" ]]; then
+    scripts/ralph/flowctl epic set-completion-review-status "$epic_id" --status ship --json >/dev/null
+  fi
+  if [[ "$write_completion" == "1" && -n "${REVIEW_RECEIPT_PATH:-}" ]]; then
+    ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    mkdir -p "$(dirname "$REVIEW_RECEIPT_PATH")"
+    cat > "$REVIEW_RECEIPT_PATH" <<EOF_RECEIPT
+{"type":"completion_review","id":"$epic_id","mode":"stub","verdict":"SHIP","timestamp":"$ts"}
+EOF_RECEIPT
+    echo "REVIEW_RECEIPT_WRITTEN: $REVIEW_RECEIPT_PATH"
+  fi
+  echo "<verdict>SHIP</verdict>"
   exit "$exit_code"
 fi
 
@@ -191,7 +216,7 @@ echo -e "${YELLOW}--- ralph_once ---${NC}"
 EPIC1_JSON="$(scripts/ralph/flowctl epic create --title "Ralph Epic" --json)"
 EPIC1="$(echo "$EPIC1_JSON" | extract_id)"
 scripts/ralph/flowctl task create --epic "$EPIC1" --title "Ralph Task" --json >/dev/null
-write_config "none" "none" "0" "new" "3" "5" "2"
+write_config "none" "none" "none" "0" "new" "3" "5" "2"
 CLAUDE_BIN="$TEST_DIR/bin/claude" scripts/ralph/ralph_once.sh >/dev/null
 # Mark plan review done so it doesn't block later tests when REQUIRE_PLAN_REVIEW=1
 scripts/ralph/flowctl epic set-plan-review-status "$EPIC1" --status ship --json >/dev/null
@@ -205,8 +230,8 @@ TASK2_1_JSON="$(scripts/ralph/flowctl task create --epic "$EPIC2" --title "Task 
 TASK2_1="$(echo "$TASK2_1_JSON" | extract_id)"
 TASK2_2_JSON="$(scripts/ralph/flowctl task create --epic "$EPIC2" --title "Task 2" --json)"
 TASK2_2="$(echo "$TASK2_2_JSON" | extract_id)"
-# Use rp for both to test receipt generation (none skips receipts correctly via fix for #8)
-write_config "rp" "rp" "1" "new" "6" "5" "2"
+# Use rp for all gates to test verdict-bearing receipt generation.
+write_config "rp" "rp" "rp" "1" "new" "6" "5" "2"
 STUB_MODE=success STUB_WRITE_RECEIPT=1 CLAUDE_BIN="$TEST_DIR/bin/claude" scripts/ralph/ralph.sh >/dev/null
 # Use flowctl show to get merged state (definition + runtime)
 # Note: Definition files don't store status; runtime state is in .git/flow-state/
@@ -225,10 +250,16 @@ run_dir, epic2, task2_1 = sys.argv[1:4]
 receipts = Path(f"scripts/ralph/runs/{run_dir}/receipts")
 plan = json.loads((receipts / f"plan-{epic2}.json").read_text())
 impl = json.loads((receipts / f"impl-{task2_1}.json").read_text())
+completion = json.loads((receipts / f"completion-{epic2}.json").read_text())
 assert plan["type"] == "plan_review"
 assert plan["id"] == epic2
+assert plan["verdict"] == "SHIP"
 assert impl["type"] == "impl_review"
 assert impl["id"] == task2_1
+assert impl["verdict"] == "SHIP"
+assert completion["type"] == "completion_review"
+assert completion["id"] == epic2
+assert completion["verdict"] == "SHIP"
 PY
 iter_log="scripts/ralph/runs/$run_dir/iter-001.log"
 if [[ -f "$iter_log" ]]; then
@@ -261,7 +292,7 @@ echo -e "${YELLOW}--- UI output verification ---${NC}"
 EPIC3_JSON="$(scripts/ralph/flowctl epic create --title "UI Test Epic" --json)"
 EPIC3="$(echo "$EPIC3_JSON" | extract_id)"
 scripts/ralph/flowctl task create --epic "$EPIC3" --title "UI Test Task" --json >/dev/null
-write_config "none" "none" "0" "new" "3" "5" "2"
+write_config "none" "none" "none" "0" "new" "3" "5" "2"
 ui_output="$(STUB_MODE=success CLAUDE_BIN="$TEST_DIR/bin/claude" scripts/ralph/ralph.sh 2>&1)"
 
 # Check elapsed time format [X:XX]
@@ -314,7 +345,7 @@ EPIC4_JSON="$(scripts/ralph/flowctl epic create --title "Ralph Epic 4" --json)"
 EPIC4="$(echo "$EPIC4_JSON" | extract_id)"
 TASK4_1_JSON="$(scripts/ralph/flowctl task create --epic "$EPIC4" --title "Stuck Task" --json)"
 TASK4_1="$(echo "$TASK4_1_JSON" | extract_id)"
-write_config "none" "none" "0" "new" "3" "5" "2"
+write_config "none" "none" "none" "0" "new" "3" "5" "2"
 STUB_MODE=retry CLAUDE_BIN="$TEST_DIR/bin/claude" scripts/ralph/ralph.sh >/dev/null
 status=$(scripts/ralph/flowctl show "$TASK4_1" --json | "$PYTHON_BIN" -c "import sys,json; print(json.load(sys.stdin)['status'])")
 if [[ "$status" != "blocked" ]]; then
@@ -329,7 +360,7 @@ EPIC5_JSON="$(scripts/ralph/flowctl epic create --title "Ralph Epic 5" --json)"
 EPIC5="$(echo "$EPIC5_JSON" | extract_id)"
 TASK5_1_JSON="$(scripts/ralph/flowctl task create --epic "$EPIC5" --title "Receipt Task" --json)"
 TASK5_1="$(echo "$TASK5_1_JSON" | extract_id)"
-write_config "none" "rp" "0" "new" "3" "5" "1"
+write_config "none" "rp" "none" "0" "new" "3" "5" "1"
 set +e
 STUB_MODE=success STUB_WRITE_PLAN_RECEIPT=1 STUB_WRITE_IMPL_RECEIPT=0 CLAUDE_BIN="$TEST_DIR/bin/claude" scripts/ralph/ralph.sh >/dev/null
 rc=$?
@@ -362,7 +393,7 @@ EPIC6_JSON="$(scripts/ralph/flowctl epic create --title "Exit Code Epic 1" --jso
 EPIC6="$(echo "$EPIC6_JSON" | extract_id)"
 TASK6_1_JSON="$(scripts/ralph/flowctl task create --epic "$EPIC6" --title "Done but exit 1" --json)"
 TASK6_1="$(echo "$TASK6_1_JSON" | extract_id)"
-write_config "none" "none" "0" "new" "3" "5" "2"
+write_config "none" "none" "none" "0" "new" "3" "5" "2"
 set +e
 STUB_MODE=success STUB_EXIT_CODE=1 CLAUDE_BIN="$TEST_DIR/bin/claude" scripts/ralph/ralph.sh >/dev/null 2>&1
 rc=$?
@@ -381,7 +412,7 @@ EPIC7_JSON="$(scripts/ralph/flowctl epic create --title "Exit Code Epic 2" --jso
 EPIC7="$(echo "$EPIC7_JSON" | extract_id)"
 TASK7_1_JSON="$(scripts/ralph/flowctl task create --epic "$EPIC7" --title "Not done and exit 1" --json)"
 TASK7_1="$(echo "$TASK7_1_JSON" | extract_id)"
-write_config "none" "none" "0" "new" "3" "5" "1"
+write_config "none" "none" "none" "0" "new" "3" "5" "1"
 set +e
 STUB_MODE=success STUB_EXIT_CODE=1 STUB_SKIP_DONE=1 CLAUDE_BIN="$TEST_DIR/bin/claude" scripts/ralph/ralph.sh >/dev/null 2>&1
 rc=$?

--- a/plugins/flow-next/scripts/smoke_test.sh
+++ b/plugins/flow-next/scripts/smoke_test.sh
@@ -657,8 +657,41 @@ assert rid == "fn-7-abc", f"Expected fn-7-abc, got {rid}"
 rtype, rid = guard.parse_receipt_path("/tmp/unknown.json")
 assert rtype == "impl_review"
 assert rid == "UNKNOWN"
+
+# Receipt write detection must catch variable-based redirects like:
+#   printf ... > "$RECEIPT_PATH"
+# This was the bypass observed in a real Ralph run.
+receipt_path = "/tmp/run/receipts/completion-fn-7-ci.json"
+command = (
+    "RECEIPT_DIR='/tmp/run/receipts'\n"
+    'RECEIPT_PATH="$RECEIPT_DIR/completion-fn-7-ci.json"\n'
+    "printf '{\"type\":\"completion_review\",\"id\":\"fn-7-ci\",\"mode\":\"rp\"}\\n' > \"$RECEIPT_PATH\""
+)
+assert guard.is_receipt_write_command(command, receipt_path), "variable receipt redirect not detected"
+assert guard.command_has_json_field(command, "type")
+assert guard.command_has_json_field(command, "id")
+assert not guard.command_has_json_field(command, "verdict")
+
+# All review receipts require a valid verdict and must match the filename.
+assert guard.validate_receipt_data({
+    "type": "completion_review",
+    "id": "fn-7-ci",
+    "mode": "rp",
+}, receipt_path=receipt_path) == "missing or invalid verdict"
+assert guard.validate_receipt_data({
+    "type": "completion_review",
+    "id": "fn-7-ci",
+    "mode": "rp",
+    "verdict": "SHIP",
+}, receipt_path=receipt_path) == ""
+assert guard.validate_receipt_data({
+    "type": "completion_review",
+    "id": "fn-7-other",
+    "mode": "rp",
+    "verdict": "SHIP",
+}, receipt_path=receipt_path).startswith("id mismatch")
 PY
-echo -e "${GREEN}✓${NC} parse_receipt_path works"
+echo -e "${GREEN}✓${NC} receipt path parsing and validation works"
 PASS=$((PASS + 1))
 
 echo -e "${YELLOW}--- codex e2e (requires codex CLI) ---${NC}"

--- a/plugins/flow-next/skills/flow-next-impl-review/workflow.md
+++ b/plugins/flow-next/skills/flow-next-impl-review/workflow.md
@@ -241,7 +241,20 @@ EOF
 ### Send to RepoPrompt
 
 ```bash
-$FLOWCTL rp chat-send --window "$W" --tab "$T" --message-file /tmp/review-prompt.md --new-chat --chat-name "Impl Review: $BRANCH"
+REVIEW_RESPONSE="$($FLOWCTL rp chat-send --window "$W" --tab "$T" --message-file /tmp/review-prompt.md --new-chat --chat-name "Impl Review: $BRANCH")"
+echo "$REVIEW_RESPONSE"
+
+VERDICT="$(echo "$REVIEW_RESPONSE" \
+  | tr -d '\r' \
+  | grep -oE '<verdict>(SHIP|NEEDS_WORK|MAJOR_RETHINK)</verdict>' \
+  | tail -n 1 \
+  | sed -E 's#</?verdict>##g')"
+
+if [[ -z "$VERDICT" ]]; then
+  echo "No verdict tag found in response"
+  echo "<promise>RETRY</promise>"
+  exit 0
+fi
 ```
 
 **WAIT** for response. Takes 1-5+ minutes.
@@ -257,7 +270,7 @@ if [[ -n "${REVIEW_RECEIPT_PATH:-}" ]]; then
   ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
   mkdir -p "$(dirname "$REVIEW_RECEIPT_PATH")"
   cat > "$REVIEW_RECEIPT_PATH" <<EOF
-{"type":"impl_review","id":"<TASK_ID>","mode":"rp","timestamp":"$ts"}
+{"type":"impl_review","id":"<TASK_ID>","mode":"rp","verdict":"$VERDICT","timestamp":"$ts"}
 EOF
   echo "REVIEW_RECEIPT_WRITTEN: $REVIEW_RECEIPT_PATH"
 fi

--- a/plugins/flow-next/skills/flow-next-plan-review/workflow.md
+++ b/plugins/flow-next/skills/flow-next-plan-review/workflow.md
@@ -231,7 +231,20 @@ EOF
 ### Send to RepoPrompt
 
 ```bash
-$FLOWCTL rp chat-send --window "$W" --tab "$T" --message-file /tmp/review-prompt.md --new-chat --chat-name "Plan Review: <EPIC_ID>"
+REVIEW_RESPONSE="$($FLOWCTL rp chat-send --window "$W" --tab "$T" --message-file /tmp/review-prompt.md --new-chat --chat-name "Plan Review: <EPIC_ID>")"
+echo "$REVIEW_RESPONSE"
+
+VERDICT="$(echo "$REVIEW_RESPONSE" \
+  | tr -d '\r' \
+  | grep -oE '<verdict>(SHIP|NEEDS_WORK|MAJOR_RETHINK)</verdict>' \
+  | tail -n 1 \
+  | sed -E 's#</?verdict>##g')"
+
+if [[ -z "$VERDICT" ]]; then
+  echo "No verdict tag found in response"
+  echo "<promise>RETRY</promise>"
+  exit 0
+fi
 ```
 
 **WAIT** for response. Takes 1-5+ minutes.
@@ -247,7 +260,7 @@ if [[ -n "${REVIEW_RECEIPT_PATH:-}" ]]; then
   ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
   mkdir -p "$(dirname "$REVIEW_RECEIPT_PATH")"
   cat > "$REVIEW_RECEIPT_PATH" <<EOF
-{"type":"plan_review","id":"<EPIC_ID>","mode":"rp","timestamp":"$ts"}
+{"type":"plan_review","id":"<EPIC_ID>","mode":"rp","verdict":"$VERDICT","timestamp":"$ts"}
 EOF
   echo "REVIEW_RECEIPT_WRITTEN: $REVIEW_RECEIPT_PATH"
 fi
@@ -255,7 +268,6 @@ fi
 
 ### Update status
 
-Extract verdict from response, then:
 ```bash
 # If SHIP
 $FLOWCTL epic set-plan-review-status <EPIC_ID> --status ship --json

--- a/plugins/flow-next/skills/flow-next-ralph-init/templates/prompt_completion.md
+++ b/plugins/flow-next/skills/flow-next-ralph-init/templates/prompt_completion.md
@@ -40,12 +40,12 @@ Ralph mode rules (must follow):
    mkdir -p "$(dirname '{{REVIEW_RECEIPT_PATH}}')"
    ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
    cat > '{{REVIEW_RECEIPT_PATH}}' <<EOF
-   {"type":"completion_review","id":"{{EPIC_ID}}","mode":"rp","timestamp":"$ts","iteration":{{RALPH_ITERATION}}}
+   {"type":"completion_review","id":"{{EPIC_ID}}","mode":"rp","verdict":"SHIP","timestamp":"$ts","iteration":{{RALPH_ITERATION}}}
    EOF
    ```
    For codex mode, receipt is written automatically by `flowctl codex completion-review --receipt`.
-   **CRITICAL: Copy EXACTLY. The `"id":"{{EPIC_ID}}"` field is REQUIRED.**
-   Missing id = verification fails = forced retry.
+   **CRITICAL: Copy EXACTLY. The `"id":"{{EPIC_ID}}"` and `"verdict":"SHIP"` fields are REQUIRED.**
+   Missing id/verdict = verification fails = forced retry.
 
 6) After SHIP:
    - `scripts/ralph/flowctl epic set-completion-review-status {{EPIC_ID}} --status ship --json`

--- a/plugins/flow-next/skills/flow-next-ralph-init/templates/prompt_plan.md
+++ b/plugins/flow-next/skills/flow-next-ralph-init/templates/prompt_plan.md
@@ -44,12 +44,12 @@ Ralph mode rules (must follow):
    mkdir -p "$(dirname '{{REVIEW_RECEIPT_PATH}}')"
    ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
    cat > '{{REVIEW_RECEIPT_PATH}}' <<EOF
-   {"type":"plan_review","id":"{{EPIC_ID}}","mode":"rp","timestamp":"$ts","iteration":{{RALPH_ITERATION}}}
+   {"type":"plan_review","id":"{{EPIC_ID}}","mode":"rp","verdict":"SHIP","timestamp":"$ts","iteration":{{RALPH_ITERATION}}}
    EOF
    ```
    For codex mode, receipt is written automatically by `flowctl codex plan-review --receipt`.
-   **CRITICAL: Copy EXACTLY. The `"id":"{{EPIC_ID}}"` field is REQUIRED.**
-   Missing id = verification fails = forced retry.
+   **CRITICAL: Copy EXACTLY. The `"id":"{{EPIC_ID}}"` and `"verdict":"SHIP"` fields are REQUIRED.**
+   Missing id/verdict = verification fails = forced retry.
 
 6) After SHIP:
    - `scripts/ralph/flowctl epic set-plan-review-status {{EPIC_ID}} --status ship --json`

--- a/plugins/flow-next/skills/flow-next-ralph-init/templates/prompt_work.md
+++ b/plugins/flow-next/skills/flow-next-ralph-init/templates/prompt_work.md
@@ -28,13 +28,13 @@ For rp mode:
 mkdir -p "$(dirname '{{REVIEW_RECEIPT_PATH}}')"
 ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 cat > '{{REVIEW_RECEIPT_PATH}}' <<EOF
-{"type":"impl_review","id":"{{TASK_ID}}","mode":"rp","timestamp":"$ts","iteration":{{RALPH_ITERATION}}}
+{"type":"impl_review","id":"{{TASK_ID}}","mode":"rp","verdict":"SHIP","timestamp":"$ts","iteration":{{RALPH_ITERATION}}}
 EOF
 echo "Receipt written: {{REVIEW_RECEIPT_PATH}}"
 ```
 For codex mode, receipt is written automatically by `flowctl codex impl-review --receipt`.
-**CRITICAL: Copy the command EXACTLY. The `"id":"{{TASK_ID}}"` field is REQUIRED.**
-Ralph verifies receipts match this exact schema. Missing id = verification fails = forced retry.
+**CRITICAL: Copy the command EXACTLY. The `"id":"{{TASK_ID}}"` and `"verdict":"SHIP"` fields are REQUIRED.**
+Ralph verifies receipts match this exact schema. Missing id/verdict = verification fails = forced retry.
 
 **Step 4: Validate epic**
 ```bash

--- a/plugins/flow-next/skills/flow-next-ralph-init/templates/ralph.sh
+++ b/plugins/flow-next/skills/flow-next-ralph-init/templates/ralph.sh
@@ -830,6 +830,8 @@ if data.get("type") != kind:
     sys.exit(1)
 if data.get("id") != rid:
     sys.exit(1)
+if data.get("verdict") not in ("SHIP", "NEEDS_WORK", "MAJOR_RETHINK"):
+    sys.exit(1)
 sys.exit(0)
 PY
 }


### PR DESCRIPTION
## Summary
- update `flowctl rp chat-send` to use RepoPrompt 2.x `oracle_send`, with legacy `chat_send` fallback only when the modern tool is unavailable
- strip legacy-only fields from the modern RepoPrompt payload so RP 2.1.x does not reject review sends
- harden Ralph review receipts so plan, implementation, and completion gates require a valid `verdict` plus matching `type`/`id`
- catch variable-based receipt writes such as `printf ... > "$RECEIPT_PATH"`, which previously bypassed the guard
- update Ralph prompt templates, review workflows, and smoke coverage for verdict-bearing receipts

## Root cause
Ralph runs in `/Users/claire/dev/Humanizer/scripts/ralph/runs/20260410-192734-49b5` were failing for two related reasons. First, `flowctl rp chat-send` still called RepoPrompt's legacy `chat_send` tool. RepoPrompt 2.x uses `oracle_send`, and RP 2.1.x rejects legacy payload fields like `chat_name` and `selected_paths`. That meant RP reviews could fail through the wrapper even when direct RepoPrompt calls worked.

Second, the receipt gate was not strict enough. Real run receipts were accepted without a `verdict`, and the guard did not reliably detect variable-based shell redirects to the active receipt path. That let agents write structurally incomplete receipts or miss the receipt hook path entirely, causing Ralph to thrash around review completion.

## Fix
- `cmd_rp_chat_send` now prefers `oracle_send` with a modern payload and falls back to `chat_send` only on missing-tool errors.
- Receipt validation now requires `type`, `id`, and `verdict` in `SHIP`, `NEEDS_WORK`, or `MAJOR_RETHINK`.
- Stop-time and shell receipt guards validate the actual receipt file and ensure filename-derived `type`/`id` match the JSON payload.
- Ralph RP review prompts and generated Codex copies now write verdict-bearing receipts consistently.
- Smoke tests cover both RepoPrompt compatibility and the receipt bypass pattern from the run logs.

## Validation
- `plugins/flow-next/scripts/smoke_test.sh`: 52 passed, 0 failed
- `plugins/flow-next/scripts/ralph_smoke_test.sh`: 15 passed, 0 failed
- `plugins/flow-next/scripts/ci_test.sh`: 47 passed, 0 failed
- GitHub Actions: Ubuntu, macOS, and Windows all passed

## Notes
- No plugin version metadata or changelog bump is included.
