### PR TITLE
fix(flow-next): rp-cli 2.1.6 builder raw-json + datetime deprecation

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,13 +6,13 @@
   },
   "metadata": {
     "description": "Plan-first workflows for Claude Code and Factory Droid. Two plugins: flow-next (recommended, zero-dep, Ralph autonomous mode) and flow (Beads integration).",
-    "version": "0.29.3"
+    "version": "0.29.4"
   },
   "plugins": [
     {
       "name": "flow-next",
       "description": "Zero-dependency planning + execution with .flow/ task tracking and Ralph autonomous mode (multi-model review gates). Worker subagent per task for context isolation. Includes 20 subagents, 11 commands, 16 skills.",
-      "version": "0.29.3",
+      "version": "0.29.4",
       "author": {
         "name": "Gordon Mickel",
         "email": "gordon@mickel.tech",

--- a/.flow/bin/flowctl.py
+++ b/.flow/bin/flowctl.py
@@ -20,7 +20,7 @@ import tempfile
 import unicodedata
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, ContextManager, Optional
 
@@ -382,7 +382,7 @@ def error_exit(message: str, code: int = 1, use_json: bool = True) -> None:
 
 def now_iso() -> str:
     """Current timestamp in ISO format."""
-    return datetime.utcnow().isoformat() + "Z"
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
 
 
 def require_rp_cli() -> str:
@@ -2844,7 +2844,7 @@ def cmd_memory_add(args: argparse.Namespace) -> None:
     # Format entry
     from datetime import datetime
 
-    today = datetime.utcnow().strftime("%Y-%m-%d")
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
 
     # Normalize type name
     type_name = args.type.lower().rstrip("s")  # pitfalls -> pitfall
@@ -5556,11 +5556,10 @@ def cmd_rp_builder(args: argparse.Namespace) -> None:
     cmd = [
         "-w",
         str(window),
-        "--raw-json" if response_type else "",
+        "--raw-json",
         "-e",
         builder_expr,
     ]
-    cmd = [c for c in cmd if c]
     res = run_rp_cli(cmd)
     output = (res.stdout or "") + ("\n" + res.stderr if res.stderr else "")
 
@@ -5594,7 +5593,15 @@ def cmd_rp_builder(args: argparse.Namespace) -> None:
             else:
                 print(tab)
     else:
-        tab = parse_builder_tab(output)
+        # Try JSON first (RP 2.1.4+), fall back to regex for older versions
+        tab = ""
+        try:
+            data = json.loads(res.stdout or "{}")
+            tab = extract_builder_tab_from_payload(data) or ""
+        except json.JSONDecodeError:
+            pass
+        if not tab:
+            tab = parse_builder_tab(output)
         if args.json:
             print(json.dumps({"window": window, "tab": tab}))
         else:
@@ -5819,11 +5826,10 @@ def cmd_rp_setup_review(args: argparse.Namespace) -> None:
     builder_cmd = [
         "-w",
         str(win_id),
-        "--raw-json" if response_type else "",
+        "--raw-json",
         "-e",
         builder_expr,
     ]
-    builder_cmd = [c for c in builder_cmd if c]  # Remove empty strings
     builder_res = run_rp_cli(builder_cmd)
     output = (builder_res.stdout or "") + (
         "\n" + builder_res.stderr if builder_res.stderr else ""
@@ -5861,7 +5867,15 @@ def cmd_rp_setup_review(args: argparse.Namespace) -> None:
         except json.JSONDecodeError:
             error_exit("Failed to parse builder review response", use_json=False, code=2)
     else:
-        tab = parse_builder_tab(output)
+        # Try JSON first (RP 2.1.4+), fall back to regex for older versions
+        tab = ""
+        try:
+            data = json.loads(builder_res.stdout or "{}")
+            tab = extract_builder_tab_from_payload(data) or ""
+        except json.JSONDecodeError:
+            pass
+        if not tab:
+            tab = parse_builder_tab(output)
         if not tab:
             error_exit("Builder did not return a tab/context id", use_json=False, code=2)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to the flow-next.
 
+## [flow-next 0.29.4] - 2026-04-12
+
+### Fixed
+- **rp-cli 2.1.6: builder output missing tab/context ID** — `cmd_rp_builder` and `cmd_rp_setup_review` now always pass `--raw-json` to builder (was conditional on `--response-type`). RP 2.1.6 removed the `Tab:`/`Context:` text line from plain-text output; IDs are only in JSON mode. JSON parse tried first, regex fallback for older RP versions. Closes #109. Thanks @berhanbero
+- **Python 3.12+ `datetime.utcnow()` deprecation** — replaced with `datetime.now(timezone.utc)` in `now_iso()` and `cmd_memory_add`. Eliminates `DeprecationWarning` on Python 3.12+.
+
+### Changed
+- README recommends RepoPrompt v2.1.6+ and documents update path (`brew upgrade --cask repoprompt`)
+
 ## [flow-next 0.29.3] - 2026-04-12
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Flow-Next
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Flow-next](https://img.shields.io/badge/Flow--next-v0.29.3-green)](plugins/flow-next/)
+[![Flow-next](https://img.shields.io/badge/Flow--next-v0.29.4-green)](plugins/flow-next/)
 [![Docs](https://img.shields.io/badge/Docs-📖-informational)](plugins/flow-next/README.md)
 
 [![Author](https://img.shields.io/badge/Author-Gordon_Mickel-orange)](https://mickel.tech)

--- a/plugins/flow-next/.claude-plugin/plugin.json
+++ b/plugins/flow-next/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "flow-next",
-  "version": "0.29.3",
+  "version": "0.29.4",
   "description": "Zero-dependency planning + execution with .flow/ task tracking and Ralph autonomous mode (multi-model review gates). Worker subagent per task for context isolation. Prime assesses 8 pillars (48 criteria) with GitHub API integration. Includes 20 subagents, 11 commands, 16 skills.",
   "author": {
     "name": "Gordon Mickel",

--- a/plugins/flow-next/.codex-plugin/plugin.json
+++ b/plugins/flow-next/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "flow-next",
-  "version": "0.29.3",
+  "version": "0.29.4",
   "description": "Zero-dependency planning + execution with .flow/ task tracking and Ralph autonomous mode. Worker subagent per task for context isolation. Compatible with Codex, Claude Code, and Factory Droid.",
   "author": {
     "name": "Gordon Mickel",

--- a/plugins/flow-next/README.md
+++ b/plugins/flow-next/README.md
@@ -6,7 +6,7 @@
 [![Claude Code](https://img.shields.io/badge/Claude_Code-Plugin-blueviolet)](https://claude.ai/code)
 [![OpenAI Codex](https://img.shields.io/badge/OpenAI_Codex-Plugin-10a37f)](https://developers.openai.com/codex/cli/)
 
-[![Version](https://img.shields.io/badge/Version-0.29.3-green)](../../CHANGELOG.md)
+[![Version](https://img.shields.io/badge/Version-0.29.4-green)](../../CHANGELOG.md)
 
 [![Status](https://img.shields.io/badge/Status-Active_Development-brightgreen)](../../CHANGELOG.md)
 [![Discord](https://img.shields.io/badge/Discord-Join-5865F2?logo=discord&logoColor=white)](https://discord.gg/f3DYq8AAm5)
@@ -880,15 +880,16 @@ Reviews block progress until `<verdict>SHIP</verdict>`. Fix → re-review cycles
 
 **Setup:**
 
-1. Install RepoPrompt:
+1. Install RepoPrompt (v2.1.6+ recommended):
    ```bash
    brew install --cask repoprompt
    ```
+   Already installed? Update via RepoPrompt → Check for Updates, or `brew upgrade --cask repoprompt`.
 
 2. **Enable MCP Server** (required for rp-cli):
    - Settings → MCP Server → Enable
    - Click "Install CLI to PATH" (creates `/usr/local/bin/rp-cli`)
-   - Verify: `rp-cli --version`
+   - Verify: `rp-cli --version` (should show 2.1.6+)
 
 3. **Configure models** — RepoPrompt uses two models that must be set in the UI (not controllable via CLI):
 

--- a/plugins/flow-next/scripts/ci_test.sh
+++ b/plugins/flow-next/scripts/ci_test.sh
@@ -442,8 +442,8 @@ def fake_bind_context(args, timeout=None):
 
 def fake_bind_context_builder(args, timeout=None):
     commands.append(args)
-    if args == ["-w", "55", "-e", 'builder "Bind me"']:
-        return make_result("Tab: tab-55\n")
+    if args == ["-w", "55", "--raw-json", "-e", 'builder "Bind me"']:
+        return make_result(json.dumps({"context_id": "tab-55"}))
     raise AssertionError(f"Unexpected rp-cli args: {args}")
 
 
@@ -475,8 +475,8 @@ def fake_reuse_existing(args, timeout=None):
                 "showingWindows": [42],
             }
         ]))
-    if args == ["-w", "42", "-e", 'builder "Review me"']:
-        return make_result("Tab: tab-123\n")
+    if args == ["-w", "42", "--raw-json", "-e", 'builder "Review me"']:
+        return make_result(json.dumps({"context_id": "tab-123"}))
     raise AssertionError(f"Unexpected rp-cli args: {args}")
 
 
@@ -514,8 +514,8 @@ def fake_reopen_hidden_workspace(args, timeout=None):
         'call manage_workspaces {"action": "switch", "workspace": "ws-hidden", "open_in_new_window": true}',
     ]:
         return make_result(json.dumps({"window_id": 84}))
-    if args == ["-w", "84", "-e", 'builder "Reopen me"']:
-        return make_result("Tab: tab-84\n")
+    if args == ["-w", "84", "--raw-json", "-e", 'builder "Reopen me"']:
+        return make_result(json.dumps({"context_id": "tab-84"}))
     raise AssertionError(f"Unexpected rp-cli args: {args}")
 
 

--- a/plugins/flow-next/scripts/flowctl.py
+++ b/plugins/flow-next/scripts/flowctl.py
@@ -20,7 +20,7 @@ import tempfile
 import unicodedata
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, ContextManager, Optional
 
@@ -382,7 +382,7 @@ def error_exit(message: str, code: int = 1, use_json: bool = True) -> None:
 
 def now_iso() -> str:
     """Current timestamp in ISO format."""
-    return datetime.utcnow().isoformat() + "Z"
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
 
 
 def require_rp_cli() -> str:
@@ -2844,7 +2844,7 @@ def cmd_memory_add(args: argparse.Namespace) -> None:
     # Format entry
     from datetime import datetime
 
-    today = datetime.utcnow().strftime("%Y-%m-%d")
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
 
     # Normalize type name
     type_name = args.type.lower().rstrip("s")  # pitfalls -> pitfall
@@ -5556,11 +5556,10 @@ def cmd_rp_builder(args: argparse.Namespace) -> None:
     cmd = [
         "-w",
         str(window),
-        "--raw-json" if response_type else "",
+        "--raw-json",
         "-e",
         builder_expr,
     ]
-    cmd = [c for c in cmd if c]
     res = run_rp_cli(cmd)
     output = (res.stdout or "") + ("\n" + res.stderr if res.stderr else "")
 
@@ -5594,7 +5593,15 @@ def cmd_rp_builder(args: argparse.Namespace) -> None:
             else:
                 print(tab)
     else:
-        tab = parse_builder_tab(output)
+        # Try JSON first (RP 2.1.4+), fall back to regex for older versions
+        tab = ""
+        try:
+            data = json.loads(res.stdout or "{}")
+            tab = extract_builder_tab_from_payload(data) or ""
+        except json.JSONDecodeError:
+            pass
+        if not tab:
+            tab = parse_builder_tab(output)
         if args.json:
             print(json.dumps({"window": window, "tab": tab}))
         else:
@@ -5819,11 +5826,10 @@ def cmd_rp_setup_review(args: argparse.Namespace) -> None:
     builder_cmd = [
         "-w",
         str(win_id),
-        "--raw-json" if response_type else "",
+        "--raw-json",
         "-e",
         builder_expr,
     ]
-    builder_cmd = [c for c in builder_cmd if c]  # Remove empty strings
     builder_res = run_rp_cli(builder_cmd)
     output = (builder_res.stdout or "") + (
         "\n" + builder_res.stderr if builder_res.stderr else ""
@@ -5861,7 +5867,15 @@ def cmd_rp_setup_review(args: argparse.Namespace) -> None:
         except json.JSONDecodeError:
             error_exit("Failed to parse builder review response", use_json=False, code=2)
     else:
-        tab = parse_builder_tab(output)
+        # Try JSON first (RP 2.1.4+), fall back to regex for older versions
+        tab = ""
+        try:
+            data = json.loads(builder_res.stdout or "{}")
+            tab = extract_builder_tab_from_payload(data) or ""
+        except json.JSONDecodeError:
+            pass
+        if not tab:
+            tab = parse_builder_tab(output)
         if not tab:
             error_exit("Builder did not return a tab/context id", use_json=False, code=2)
 


### PR DESCRIPTION
## Summary

- Always pass `--raw-json` to builder in `cmd_rp_builder` and `cmd_rp_setup_review` — RP 2.1.6 removed `Tab:`/`Context:` text lines from plain-text output, IDs only available in JSON mode
- JSON parse first, regex fallback for older RP versions (backward-compatible)
- Replace `datetime.utcnow()` with `datetime.now(timezone.utc)` (Python 3.12+ deprecation)
- README recommends RepoPrompt v2.1.6+ with update instructions

Closes #109. Thanks @berhanbero for the report.

## Test plan
- [x] Smoke test 52/52
- [x] Verified with rp-cli 2.1.6: `--raw-json` builder returns `context_id` in JSON
- [x] Codex sync clean