### PR TITLE
feat(flow-next): unified backend:model:effort spec parser (v0.31.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,13 +6,13 @@
   },
   "metadata": {
     "description": "Plan-first workflows for Claude Code and Factory Droid. Two plugins: flow-next (recommended, zero-dep, Ralph autonomous mode) and flow (Beads integration).",
-    "version": "0.30.0"
+    "version": "0.31.0"
   },
   "plugins": [
     {
       "name": "flow-next",
       "description": "Zero-dependency planning + execution with .flow/ task tracking and Ralph autonomous mode (multi-model review gates). Worker subagent per task for context isolation. Includes 20 subagents, 11 commands, 16 skills.",
-      "version": "0.30.0",
+      "version": "0.31.0",
       "author": {
         "name": "Gordon Mickel",
         "email": "gordon@mickel.tech",

--- a/.flow/bin/flowctl.py
+++ b/.flow/bin/flowctl.py
@@ -21,6 +21,7 @@ import unicodedata
 import uuid
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, ContextManager, Optional
@@ -1535,12 +1536,18 @@ def run_codex_exec(
     prompt: str,
     session_id: Optional[str] = None,
     sandbox: str = "read-only",
-    model: Optional[str] = None,
+    spec: Optional["BackendSpec"] = None,
 ) -> tuple[str, Optional[str], int, str]:
     """Run codex exec and return (stdout, thread_id, exit_code, stderr).
 
     If session_id provided, tries to resume. Falls back to new session if resume fails.
-    Model: FLOW_CODEX_MODEL env > parameter > default (gpt-5.4 + high reasoning).
+
+    ``spec``: a resolved ``BackendSpec`` (backend=codex) whose ``model`` and
+    ``effort`` are used verbatim. The spec is assumed to be already resolved
+    by ``resolve_review_spec()`` or ``.resolve()`` so env-var fills live
+    upstream — this function just reads ``spec.model`` / ``spec.effort``.
+    When ``spec`` is ``None`` (defensive path for non-review callers), fall
+    back to bare-codex resolution (env + registry defaults).
 
     Note: Prompt is passed via stdin (using '-') to avoid Windows command-line
     length limits (~8191 chars) and special character escaping issues. (GH-35)
@@ -1551,8 +1558,14 @@ def run_codex_exec(
         - stderr contains error output from the process
     """
     codex = require_codex()
-    # Model priority: env > parameter > default (gpt-5.4 + high reasoning = GPT 5.4 High)
-    effective_model = os.environ.get("FLOW_CODEX_MODEL") or model or "gpt-5.4"
+    # Resolve spec so model+effort are populated. Defensive: older call sites
+    # (or tests) may pass spec=None; treat that as bare-codex resolution.
+    if spec is None:
+        spec = BackendSpec("codex").resolve()
+    elif spec.model is None or spec.effort is None:
+        spec = spec.resolve()
+    effective_model = spec.model or "gpt-5.4"
+    effective_effort = spec.effort or "high"
 
     if session_id:
         # Try resume first - use stdin for prompt (model already set in original session)
@@ -1576,7 +1589,7 @@ def run_codex_exec(
             # Resume failed - fall through to new session
             pass
 
-    # New session with model + high reasoning effort
+    # New session with model + reasoning effort from resolved spec
     # --skip-git-repo-check: safe with read-only sandbox, allows reviews from /tmp etc (GH-33)
     # Use '-' to read prompt from stdin - avoids Windows CLI length limits (GH-35)
     cmd = [
@@ -1585,7 +1598,7 @@ def run_codex_exec(
         "--model",
         effective_model,
         "-c",
-        'model_reasoning_effort="high"',
+        f'model_reasoning_effort="{effective_effort}"',
         "--sandbox",
         sandbox,
         "--skip-git-repo-check",
@@ -1691,6 +1704,350 @@ def is_sandbox_failure(exit_code: int, stdout: str, stderr: str) -> bool:
     return False
 
 
+# --- Backend Spec Parser (unified model + effort grammar, fn-28) ---
+#
+# Spec grammar: ``backend[:model[:effort]]`` — colon-delimited, three parts max,
+# trailing parts optional. Examples:
+#   - ``rp``                              backend only (RP uses window/session, not per-call model)
+#   - ``codex``                           backend only, defaults from registry
+#   - ``codex:gpt-5.4``                   backend + model, default effort
+#   - ``codex:gpt-5.4:xhigh``             full spec
+#   - ``copilot:claude-opus-4.5:xhigh``   copilot with its own effort set
+#
+# ``BACKEND_REGISTRY`` is a static dict (no plugin discovery). When the registry
+# has ``models`` or ``efforts`` set to ``None``, that backend rejects the
+# corresponding spec field (e.g. ``rp:opus`` is invalid — RP doesn't accept a
+# model). Every validation error lists the valid set sorted alphabetically so
+# users get a deterministic, copy-pasteable hint.
+#
+# Codex ``minimal`` effort caveat: passes codex config validation but the server
+# returns 400 when the ``web_search`` tool is enabled. flowctl reviews do not
+# enable web_search, so ``minimal`` is safe here — documented for the day we do.
+
+BACKEND_REGISTRY: dict[str, dict[str, Any]] = {
+    "rp": {
+        # RepoPrompt picks model via window/session config, not per-call.
+        "models": None,
+        "efforts": None,
+    },
+    "codex": {
+        "models": {
+            "gpt-5.4",
+            "gpt-5.2",
+            "gpt-5",
+            "gpt-5-mini",
+            "gpt-5-codex",
+        },
+        # ``none`` / ``minimal`` accepted at CLI layer; ``minimal`` is gated by
+        # server-side web_search check (not applicable to our reviews).
+        "efforts": {"none", "minimal", "low", "medium", "high", "xhigh"},
+        "default_model": "gpt-5.4",
+        "default_effort": "high",
+    },
+    "copilot": {
+        # Verified via ``copilot --help`` + live probe (fn-27 §Model Catalog).
+        "models": {
+            "claude-sonnet-4.5",
+            "claude-haiku-4.5",
+            "claude-opus-4.5",
+            "claude-sonnet-4",
+            "gpt-5.2",
+            "gpt-5.2-codex",
+            "gpt-5-mini",
+            "gpt-4.1",
+        },
+        # Copilot exposes ``xhigh`` in addition to standard tiers. No ``none`` /
+        # ``minimal`` — Claude-family models reject ``--effort`` entirely, which
+        # ``run_copilot_exec`` handles by dropping the flag when model starts
+        # with ``claude-``.
+        "efforts": {"low", "medium", "high", "xhigh"},
+        "default_model": "gpt-5.2",
+        "default_effort": "high",
+    },
+    "none": {
+        # Explicit opt-out. Parser still validates it so ``--review=none`` can
+        # be stored as a spec without special-casing upstream.
+        "models": None,
+        "efforts": None,
+    },
+}
+
+
+# Sorted list of backend names. Handy for argparse ``choices=`` and for any
+# call-site that needs the valid set without touching registry internals.
+VALID_BACKENDS: list[str] = sorted(BACKEND_REGISTRY.keys())
+
+
+@dataclass(frozen=True)
+class BackendSpec:
+    """Parsed review-backend spec: ``backend[:model[:effort]]``.
+
+    Fields are ``None`` when unspecified. Use ``.resolve()`` to fill missing
+    fields from ``FLOW_<BACKEND>_MODEL`` / ``FLOW_<BACKEND>_EFFORT`` env vars
+    then registry defaults (env only fills fields that the spec left blank —
+    explicit spec values always win).
+    """
+
+    backend: str
+    model: Optional[str] = None
+    effort: Optional[str] = None
+
+    @classmethod
+    def parse(cls, spec: str) -> "BackendSpec":
+        """Parse ``backend[:model[:effort]]``. Raises ``ValueError`` on invalid.
+
+        Validation:
+          - empty / whitespace-only → ``Empty backend spec``
+          - more than 3 colon-separated parts → explicit ValueError
+          - unknown backend → lists valid backends
+          - model on backend that doesn't accept one (rp/none) → ValueError
+          - unknown model → lists valid models for that backend
+          - effort on backend that doesn't accept one → ValueError
+          - unknown effort → lists valid efforts for that backend
+
+        Backend names are case-sensitive and lowercase. Model and effort are
+        matched exactly against the registry (no case-folding) so users see
+        consistent spec strings everywhere.
+        """
+        if spec is None or not str(spec).strip():
+            raise ValueError("Empty backend spec")
+        raw = str(spec).strip()
+        parts = raw.split(":")
+        if len(parts) > 3:
+            raise ValueError(
+                f"Too many ':' separators in spec: {raw!r} "
+                f"(expected backend[:model[:effort]], max 3 parts)"
+            )
+        backend = parts[0].strip()
+        if not backend:
+            raise ValueError(f"Empty backend in spec: {raw!r}")
+        if backend not in BACKEND_REGISTRY:
+            valid = sorted(BACKEND_REGISTRY.keys())
+            raise ValueError(
+                f"Unknown backend: {backend!r}. Valid: {valid}"
+            )
+        reg = BACKEND_REGISTRY[backend]
+
+        model: Optional[str] = None
+        if len(parts) > 1:
+            m = parts[1].strip()
+            model = m if m else None
+        effort: Optional[str] = None
+        if len(parts) > 2:
+            e = parts[2].strip()
+            effort = e if e else None
+
+        if model is not None:
+            if reg["models"] is None:
+                raise ValueError(
+                    f"Backend {backend!r} does not accept a model "
+                    f"(got {model!r})"
+                )
+            if model not in reg["models"]:
+                raise ValueError(
+                    f"Unknown model for {backend}: {model!r}. "
+                    f"Valid: {sorted(reg['models'])}"
+                )
+        if effort is not None:
+            if reg["efforts"] is None:
+                raise ValueError(
+                    f"Backend {backend!r} does not accept an effort "
+                    f"(got {effort!r})"
+                )
+            if effort not in reg["efforts"]:
+                raise ValueError(
+                    f"Unknown effort for {backend}: {effort!r}. "
+                    f"Valid: {sorted(reg['efforts'])}"
+                )
+        return cls(backend=backend, model=model, effort=effort)
+
+    def resolve(self) -> "BackendSpec":
+        """Fill missing fields from env vars then registry defaults.
+
+        Precedence (per field, most specific wins):
+          1. explicit value on this spec
+          2. ``FLOW_<BACKEND>_MODEL`` / ``FLOW_<BACKEND>_EFFORT`` env var
+          3. registry ``default_model`` / ``default_effort``
+
+        Backends with ``models is None`` (rp, none) always resolve ``model`` to
+        ``None`` — env vars are ignored for fields the backend doesn't accept.
+        Same for ``effort``. This prevents a stray ``FLOW_RP_MODEL`` from
+        leaking into an RP spec.
+        """
+        reg = BACKEND_REGISTRY[self.backend]
+        env_model_key = f"FLOW_{self.backend.upper()}_MODEL"
+        env_effort_key = f"FLOW_{self.backend.upper()}_EFFORT"
+
+        if reg["models"] is None:
+            model = None
+        else:
+            model = (
+                self.model
+                or os.environ.get(env_model_key)
+                or reg.get("default_model")
+            )
+
+        if reg["efforts"] is None:
+            effort = None
+        else:
+            effort = (
+                self.effort
+                or os.environ.get(env_effort_key)
+                or reg.get("default_effort")
+            )
+
+        return BackendSpec(self.backend, model, effort)
+
+    def __str__(self) -> str:
+        """Serialize back to ``backend[:model[:effort]]``.
+
+        Trailing ``None`` parts are dropped so ``str(BackendSpec("codex"))``
+        round-trips to ``"codex"`` (not ``"codex::"``). If only ``effort`` is
+        set (no model) we still emit ``backend::effort`` — that's a legal spec
+        shape and keeps the round-trip honest.
+        """
+        if self.model is None and self.effort is None:
+            return self.backend
+        if self.effort is None:
+            return f"{self.backend}:{self.model}"
+        # effort set; model may be None
+        model_part = self.model if self.model is not None else ""
+        return f"{self.backend}:{model_part}:{self.effort}"
+
+
+def parse_backend_spec_lenient(
+    raw: str, *, warn: bool = True
+) -> Optional[BackendSpec]:
+    """Parse a stored spec, degrading to bare backend on validation failure.
+
+    Used at read time (show-backend, runtime resolution) so pre-epic stored
+    values like ``codex:gpt-5.4-high`` (no colon between model and effort) do
+    not crash. On ValueError we:
+
+      1. Try the first colon-separated part as a bare backend name.
+      2. If that is a known backend, emit a stderr warning (when ``warn``) and
+         return ``BackendSpec(backend=<first>)``.
+      3. Otherwise return ``None`` — caller decides how to surface it.
+
+    Returns ``None`` for empty / whitespace-only input (no warning — that is
+    just "unset").
+    """
+    if raw is None or not str(raw).strip():
+        return None
+    try:
+        return BackendSpec.parse(raw)
+    except ValueError as e:
+        # Try bare-backend fallback: first ':'-separated part.
+        first = str(raw).strip().split(":", 1)[0].strip()
+        if first in BACKEND_REGISTRY:
+            if warn:
+                print(
+                    f'warning: spec {str(raw)!r} failed validation: {e}. '
+                    f'Treating as bare backend {first!r}.',
+                    file=sys.stderr,
+                )
+            return BackendSpec(backend=first)
+        if warn:
+            print(
+                f'warning: spec {str(raw)!r} failed validation: {e}. '
+                f'No recognizable backend prefix; ignoring.',
+                file=sys.stderr,
+            )
+        return None
+
+
+def resolve_review_spec(
+    backend_hint: str, task_id: Optional[str] = None
+) -> BackendSpec:
+    """Resolve a fully-filled ``BackendSpec`` for a review invocation.
+
+    ``backend_hint`` is the command-level backend name (``"codex"`` or
+    ``"copilot"``) — what the user typed when running ``flowctl codex
+    impl-review`` vs ``flowctl copilot impl-review``. It anchors the fallback
+    when no per-task / per-epic / env / config spec is found.
+
+    Precedence (first hit wins, then ``.resolve()`` fills missing fields):
+      1. Per-task ``review`` field (stored spec; may be legacy → lenient parse)
+      2. Per-epic ``default_review`` field (stored spec; lenient parse)
+      3. ``FLOW_REVIEW_BACKEND`` env var (lenient parse — user-typed at shell,
+         but we tolerate stale values)
+      4. ``.flow/config.json`` ``review.backend`` (lenient parse)
+      5. Bare ``backend_hint`` — caller's CLI subcommand name
+
+    The resolved spec's backend is **not** forced to ``backend_hint`` when a
+    per-task / per-epic / env spec picked a different backend. Example: task
+    has ``review: "copilot:gpt-5.2"`` and user runs ``flowctl codex
+    impl-review`` — we return a copilot spec. The caller (cmd_codex_*_review)
+    decides whether to warn or honor it. Current call sites ignore the
+    mismatch and pass the spec straight to ``run_codex_exec`` /
+    ``run_copilot_exec``; the command name already pins the execution path.
+
+    This helper does NOT read ``--spec`` argv — cmd functions call
+    ``BackendSpec.parse(args.spec)`` directly when set (strict parse, since
+    the user just typed it).
+    """
+    # 1 + 2: per-task / per-epic stored specs
+    if task_id is not None and is_task_id(task_id) and ensure_flow_exists():
+        flow_dir = get_flow_dir()
+        task_path = flow_dir / TASKS_DIR / f"{task_id}.json"
+        if task_path.exists():
+            try:
+                task_data = normalize_task(
+                    json.loads(task_path.read_text(encoding="utf-8"))
+                )
+                task_review = task_data.get("review")
+                if task_review:
+                    parsed = parse_backend_spec_lenient(task_review, warn=True)
+                    if parsed is not None:
+                        return parsed.resolve()
+                # Epic fallback
+                epic_id = task_data.get("epic")
+                if epic_id:
+                    epic_path = flow_dir / EPICS_DIR / f"{epic_id}.json"
+                    if epic_path.exists():
+                        try:
+                            epic_data = normalize_epic(
+                                json.loads(
+                                    epic_path.read_text(encoding="utf-8")
+                                )
+                            )
+                            epic_review = epic_data.get("default_review")
+                            if epic_review:
+                                parsed = parse_backend_spec_lenient(
+                                    epic_review, warn=True
+                                )
+                                if parsed is not None:
+                                    return parsed.resolve()
+                        except (json.JSONDecodeError, OSError):
+                            pass
+            except (json.JSONDecodeError, OSError):
+                pass
+
+    # 3: FLOW_REVIEW_BACKEND env (spec-form or bare backend)
+    env_val = os.environ.get("FLOW_REVIEW_BACKEND", "").strip()
+    if env_val:
+        parsed = parse_backend_spec_lenient(env_val, warn=True)
+        if parsed is not None:
+            return parsed.resolve()
+
+    # 4: .flow/config.json review.backend
+    if ensure_flow_exists():
+        cfg_val = get_config("review.backend")
+        if cfg_val:
+            parsed = parse_backend_spec_lenient(str(cfg_val), warn=True)
+            if parsed is not None:
+                return parsed.resolve()
+
+    # 5: fall back to bare backend_hint and resolve defaults
+    if backend_hint not in BACKEND_REGISTRY:
+        # Defensive — caller always passes a known backend, but don't crash.
+        raise ValueError(
+            f"Unknown backend_hint: {backend_hint!r}. "
+            f"Valid: {sorted(BACKEND_REGISTRY.keys())}"
+        )
+    return BackendSpec(backend_hint).resolve()
+
+
 # --- Copilot Backend Helpers ---
 
 
@@ -1733,8 +2090,7 @@ def run_copilot_exec(
     prompt: str,
     session_id: str,
     repo_root: Path,
-    model: Optional[str] = None,
-    effort: Optional[str] = None,
+    spec: Optional["BackendSpec"] = None,
 ) -> tuple[str, str, int, str]:
     """Run copilot -p and return (stdout, session_id, exit_code, stderr).
 
@@ -1750,9 +2106,16 @@ def run_copilot_exec(
       syntax). The temp file is removed in ``finally`` so KeyboardInterrupt,
       TimeoutExpired, and non-zero exits all clean up.
 
-    Config cascade (env > parameter > default):
-    - Model:  FLOW_COPILOT_MODEL  > ``model``  > ``claude-opus-4.5``
-    - Effort: FLOW_COPILOT_EFFORT > ``effort`` > ``high``
+    ``spec``: a resolved ``BackendSpec`` (backend=copilot) whose ``model`` and
+    ``effort`` are used verbatim. Env-var fills happen upstream in
+    ``resolve_review_spec()`` / ``BackendSpec.resolve()``; this function
+    reads ``spec.model`` / ``spec.effort`` directly. When ``spec`` is
+    ``None`` (defensive / non-review callers), fall back to bare-copilot
+    resolution (env + registry defaults).
+
+    Claude-model effort skip: the ``--effort`` flag is passed unless
+    ``effective_model`` starts with ``claude-`` (Copilot rejects
+    reasoning-effort on Claude-family models).
 
     Returns:
         tuple: (stdout, session_id, exit_code, stderr)
@@ -1761,12 +2124,12 @@ def run_copilot_exec(
     """
     copilot = require_copilot()
 
-    effective_model = (
-        os.environ.get("FLOW_COPILOT_MODEL") or model or "gpt-5.2"
-    )
-    effective_effort = (
-        os.environ.get("FLOW_COPILOT_EFFORT") or effort or "high"
-    )
+    if spec is None:
+        spec = BackendSpec("copilot").resolve()
+    elif spec.model is None or spec.effort is None:
+        spec = spec.resolve()
+    effective_model = spec.model or "gpt-5.2"
+    effective_effort = spec.effort or "high"
 
     # For large prompts, stage to disk then read back. Copilot has no @file
     # syntax for -p, so we always end up with the prompt in argv — but the
@@ -2828,28 +3191,65 @@ def cmd_config_set(args: argparse.Namespace) -> None:
 
 
 def cmd_review_backend(args: argparse.Namespace) -> None:
-    """Get review backend for skill conditionals. Returns ASK if not configured."""
+    """Get review backend for skill conditionals. Returns ASK if not configured.
+
+    Accepts spec-form values (``codex:gpt-5.4:high``) from ``FLOW_REVIEW_BACKEND``
+    and ``.flow/config.json`` ``review.backend``. JSON mode returns the full
+    resolved spec plus model + effort fields so skills / Ralph can route model
+    choice. Text mode still prints just the bare backend name for back-compat
+    with skill greps (``BACKEND=$(flowctl review-backend)``).
+    """
     # Priority: FLOW_REVIEW_BACKEND env > config > ASK
+    spec: Optional[BackendSpec] = None
+    source = "none"
+
     env_val = os.environ.get("FLOW_REVIEW_BACKEND", "").strip()
-    if env_val and env_val in ("rp", "codex", "copilot", "none"):
-        backend = env_val
-        source = "env"
-    elif ensure_flow_exists():
+    if env_val:
+        # Lenient parse handles spec-form and legacy bare values; degrades on
+        # bad input rather than silently falling to ASK (previous behavior
+        # quietly dropped ``codex:gpt-5.2``).
+        parsed = parse_backend_spec_lenient(env_val, warn=False)
+        if parsed is not None:
+            spec = parsed.resolve()
+            source = "env"
+
+    if spec is None and ensure_flow_exists():
         cfg_val = get_config("review.backend")
-        if cfg_val and cfg_val in ("rp", "codex", "copilot", "none"):
-            backend = cfg_val
-            source = "config"
-        else:
-            backend = "ASK"
-            source = "none"
-    else:
+        if cfg_val:
+            parsed = parse_backend_spec_lenient(str(cfg_val), warn=False)
+            if parsed is not None:
+                spec = parsed.resolve()
+                source = "config"
+
+    if spec is None:
         backend = "ASK"
-        source = "none"
+        if args.json:
+            json_output(
+                {
+                    "backend": backend,
+                    "spec": backend,
+                    "source": source,
+                    "model": None,
+                    "effort": None,
+                }
+            )
+        else:
+            print(backend)
+        return
 
     if args.json:
-        json_output({"backend": backend, "source": source})
+        json_output(
+            {
+                "backend": spec.backend,
+                "spec": str(spec),
+                "source": source,
+                "model": spec.model,
+                "effort": spec.effort,
+            }
+        )
     else:
-        print(backend)
+        # Text mode: bare backend name only (skills grep this output).
+        print(spec.backend)
 
 
 MEMORY_TEMPLATES = {
@@ -4233,7 +4633,23 @@ def cmd_epic_set_backend(args: argparse.Namespace) -> None:
         load_json_or_exit(epic_path, f"Epic {args.id}", use_json=args.json)
     )
 
-    # Update fields (empty string means clear)
+    # Validate each non-empty spec up front — reject bad specs before we touch
+    # disk. Empty string is a clear-signal and skips validation.
+    for field, value in (
+        ("--impl", args.impl),
+        ("--review", args.review),
+        ("--sync", args.sync),
+    ):
+        if value:
+            try:
+                BackendSpec.parse(value)
+            except ValueError as e:
+                error_exit(
+                    f"Invalid spec for {field}: {e}", use_json=args.json
+                )
+
+    # Update fields (empty string means clear). Store raw strings as typed —
+    # no normalization — so users see back exactly what they set.
     updated = []
     if args.impl is not None:
         epic_data["default_impl"] = args.impl if args.impl else None
@@ -4291,7 +4707,22 @@ def cmd_task_set_backend(args: argparse.Namespace) -> None:
 
     task_data = load_json_or_exit(task_path, f"Task {task_id}", use_json=args.json)
 
-    # Update fields (empty string means clear)
+    # Validate each non-empty spec up front — reject bad specs before we touch
+    # disk. Empty string is a clear-signal and skips validation.
+    for field, value in (
+        ("--impl", args.impl),
+        ("--review", args.review),
+        ("--sync", args.sync),
+    ):
+        if value:
+            try:
+                BackendSpec.parse(value)
+            except ValueError as e:
+                error_exit(
+                    f"Invalid spec for {field}: {e}", use_json=args.json
+                )
+
+    # Update fields (empty string means clear). Store raw strings as typed.
     updated = []
     if args.impl is not None:
         task_data["impl"] = args.impl if args.impl else None
@@ -4353,9 +4784,9 @@ def cmd_task_show_backend(args: argparse.Namespace) -> None:
                 load_json_or_exit(epic_path, f"Epic {epic_id}", use_json=args.json)
             )
 
-    # Compute effective values with source tracking
+    # Compute effective values with source tracking.
     def resolve_spec(task_key: str, epic_key: str) -> tuple:
-        """Return (spec, source) tuple."""
+        """Return (raw_spec, source) tuple for a given field."""
         task_val = task_data.get(task_key)
         if task_val:
             return (task_val, "task")
@@ -4365,29 +4796,136 @@ def cmd_task_show_backend(args: argparse.Namespace) -> None:
                 return (epic_val, "epic")
         return (None, None)
 
-    impl_spec, impl_source = resolve_spec("impl", "default_impl")
-    review_spec, review_source = resolve_spec("review", "default_review")
-    sync_spec, sync_source = resolve_spec("sync", "default_sync")
+    def resolve_field(raw: Optional[str], spec_source: Optional[str]) -> dict:
+        """Build the richer JSON shape: raw + resolved + per-field sources.
+
+        ``raw`` is what's stored (possibly invalid legacy data). ``spec_source``
+        is where it came from ("task" / "epic" / None when unset).
+
+        Per-field sources ("model_source" / "effort_source") distinguish
+        between an explicit spec value ("spec"), env-var fill
+        ("env:FLOW_<BACKEND>_<FIELD>"), registry default
+        ("registry_default"), or n/a when the backend rejects the field.
+
+        Returns a dict with keys: ``raw``, ``source``, ``resolved``,
+        ``model_source``, ``effort_source``. On legacy-data parse failure we
+        degrade to bare backend (warning already went to stderr from
+        parse_backend_spec_lenient) so callers don't crash on old values.
+        """
+        if raw is None:
+            return {
+                "raw": None,
+                "source": None,
+                "resolved": None,
+                "model_source": None,
+                "effort_source": None,
+            }
+
+        parsed = parse_backend_spec_lenient(raw, warn=True)
+        if parsed is None:
+            # Unrecognizable — surface what we have without a resolved form.
+            return {
+                "raw": raw,
+                "source": spec_source,
+                "resolved": None,
+                "model_source": None,
+                "effort_source": None,
+            }
+
+        resolved = parsed.resolve()
+        reg = BACKEND_REGISTRY[parsed.backend]
+        env_model_key = f"FLOW_{parsed.backend.upper()}_MODEL"
+        env_effort_key = f"FLOW_{parsed.backend.upper()}_EFFORT"
+
+        # Derive per-field source to mirror resolve()'s precedence.
+        if reg["models"] is None:
+            model_source: Optional[str] = None
+        elif parsed.model is not None:
+            model_source = "spec"
+        elif os.environ.get(env_model_key):
+            model_source = f"env:{env_model_key}"
+        else:
+            model_source = "registry_default"
+
+        if reg["efforts"] is None:
+            effort_source: Optional[str] = None
+        elif parsed.effort is not None:
+            effort_source = "spec"
+        elif os.environ.get(env_effort_key):
+            effort_source = f"env:{env_effort_key}"
+        else:
+            effort_source = "registry_default"
+
+        return {
+            "raw": raw,
+            "source": spec_source,
+            "resolved": {
+                "backend": resolved.backend,
+                "model": resolved.model,
+                "effort": resolved.effort,
+                "str": str(resolved),
+            },
+            "model_source": model_source,
+            "effort_source": effort_source,
+        }
+
+    impl_raw, impl_source = resolve_spec("impl", "default_impl")
+    review_raw, review_source = resolve_spec("review", "default_review")
+    sync_raw, sync_source = resolve_spec("sync", "default_sync")
+
+    impl_field = resolve_field(impl_raw, impl_source)
+    review_field = resolve_field(review_raw, review_source)
+    sync_field = resolve_field(sync_raw, sync_source)
 
     if args.json:
         json_output(
             {
                 "id": task_id,
                 "epic": epic_id,
-                "impl": {"spec": impl_spec, "source": impl_source},
-                "review": {"spec": review_spec, "source": review_source},
-                "sync": {"spec": sync_spec, "source": sync_source},
+                "impl": impl_field,
+                "review": review_field,
+                "sync": sync_field,
             }
         )
     else:
-        def fmt(spec, source):
-            if spec:
-                return f"{spec} ({source})"
-            return "null"
+        def _short_src(src: Optional[str]) -> Optional[str]:
+            """Compact a per-field source tag for non-JSON display.
 
-        print(f"impl: {fmt(impl_spec, impl_source)}")
-        print(f"review: {fmt(review_spec, review_source)}")
-        print(f"sync: {fmt(sync_spec, sync_source)}")
+            ``env:FLOW_CODEX_EFFORT`` → ``env`` (keeps line short; JSON output
+            still has the full key for anyone who cares).
+            """
+            if src is None:
+                return None
+            if src.startswith("env:"):
+                return "env"
+            if src == "registry_default":
+                return "registry"
+            return src
+
+        def fmt(field: dict) -> str:
+            raw = field["raw"]
+            if raw is None:
+                return "null"
+            src = field["source"] or "unknown"
+            resolved = field["resolved"]
+            if resolved is None:
+                return f"{raw} ({src}) [unresolved - invalid spec]"
+            # Use str(resolved) so empty-model slot round-trips honestly
+            # (e.g. codex::high stays codex::high, not codex:high).
+            resolved_str = resolved["str"]
+            annotations = []
+            ms = field.get("model_source")
+            if ms and ms != "spec":
+                annotations.append(f"model: {_short_src(ms)}")
+            es = field.get("effort_source")
+            if es and es != "spec":
+                annotations.append(f"effort: {_short_src(es)}")
+            suffix = f" ({', '.join(annotations)})" if annotations else ""
+            return f"{raw} ({src}) -> {resolved_str}{suffix}"
+
+        print(f"impl: {fmt(impl_field)}")
+        print(f"review: {fmt(review_field)}")
+        print(f"sync: {fmt(sync_field)}")
 
 
 def cmd_task_set_description(args: argparse.Namespace) -> None:
@@ -6401,9 +6939,12 @@ def cmd_codex_impl_review(args: argparse.Namespace) -> None:
     except ValueError as e:
         error_exit(str(e), use_json=args.json, code=2)
 
+    # Resolve review spec (--spec overrides task/epic/env/config resolution)
+    resolved_spec = _resolve_codex_review_spec(args, task_id)
+
     # Run codex
     output, thread_id, exit_code, stderr = run_codex_exec(
-        prompt, session_id=session_id, sandbox=sandbox
+        prompt, session_id=session_id, sandbox=sandbox, spec=resolved_spec
     )
 
     # Check for sandbox failures (clear stale receipt and exit)
@@ -6461,6 +7002,9 @@ def cmd_codex_impl_review(args: argparse.Namespace) -> None:
             "base": base_branch,
             "verdict": verdict,
             "session_id": thread_id,
+            "model": resolved_spec.model,
+            "effort": resolved_spec.effort,
+            "spec": str(resolved_spec),
             "timestamp": now_iso(),
             "review": output,  # Full review feedback for fix loop
         }
@@ -6486,6 +7030,9 @@ def cmd_codex_impl_review(args: argparse.Namespace) -> None:
                 "verdict": verdict,
                 "session_id": thread_id,
                 "mode": "codex",
+                "model": resolved_spec.model,
+                "effort": resolved_spec.effort,
+                "spec": str(resolved_spec),
                 "standalone": standalone,
                 "review": output,  # Full review feedback for fix loop
             }
@@ -6493,6 +7040,30 @@ def cmd_codex_impl_review(args: argparse.Namespace) -> None:
     else:
         print(output)
         print(f"\nVERDICT={verdict or 'UNKNOWN'}")
+
+
+def _resolve_codex_review_spec(
+    args: argparse.Namespace, task_id: Optional[str]
+) -> BackendSpec:
+    """Resolve ``BackendSpec`` for a codex review command.
+
+    Precedence:
+      1. ``--spec`` argv (strict parse — user just typed it, surface errors)
+      2. ``resolve_review_spec("codex", task_id)`` — task/epic/env/config/defaults
+
+    The resolved spec's backend is whatever the source said (task spec might
+    request ``copilot:gpt-5.2`` from a codex command); the codex command
+    still executes via codex CLI because the subcommand name pins the path.
+    Model/effort from the spec are still honored (codex accepts whatever
+    model string you pass; misconfigured ones fail at codex-CLI layer).
+    """
+    spec_arg = getattr(args, "spec", None)
+    if spec_arg:
+        try:
+            return BackendSpec.parse(spec_arg).resolve()
+        except ValueError as e:
+            error_exit(f"Invalid --spec: {e}", use_json=args.json, code=2)
+    return resolve_review_spec("codex", task_id)
 
 
 def cmd_codex_plan_review(args: argparse.Namespace) -> None:
@@ -6617,9 +7188,12 @@ def cmd_codex_plan_review(args: argparse.Namespace) -> None:
     except ValueError as e:
         error_exit(str(e), use_json=args.json, code=2)
 
+    # Resolve review spec — plan reviews are epic-scoped (no task_id context)
+    resolved_spec = _resolve_codex_review_spec(args, None)
+
     # Run codex
     output, thread_id, exit_code, stderr = run_codex_exec(
-        prompt, session_id=session_id, sandbox=sandbox
+        prompt, session_id=session_id, sandbox=sandbox, spec=resolved_spec
     )
 
     # Check for sandbox failures (clear stale receipt and exit)
@@ -6673,6 +7247,9 @@ def cmd_codex_plan_review(args: argparse.Namespace) -> None:
             "mode": "codex",
             "verdict": verdict,
             "session_id": thread_id,
+            "model": resolved_spec.model,
+            "effort": resolved_spec.effort,
+            "spec": str(resolved_spec),
             "timestamp": now_iso(),
             "review": output,  # Full review feedback for fix loop
         }
@@ -6696,6 +7273,9 @@ def cmd_codex_plan_review(args: argparse.Namespace) -> None:
                 "verdict": verdict,
                 "session_id": thread_id,
                 "mode": "codex",
+                "model": resolved_spec.model,
+                "effort": resolved_spec.effort,
+                "spec": str(resolved_spec),
                 "review": output,  # Full review feedback for fix loop
             }
         )
@@ -6971,9 +7551,12 @@ def cmd_codex_completion_review(args: argparse.Namespace) -> None:
     except ValueError as e:
         error_exit(str(e), use_json=args.json, code=2)
 
+    # Resolve review spec — completion reviews are epic-scoped
+    resolved_spec = _resolve_codex_review_spec(args, None)
+
     # Run codex
     output, thread_id, exit_code, stderr = run_codex_exec(
-        prompt, session_id=session_id, sandbox=sandbox
+        prompt, session_id=session_id, sandbox=sandbox, spec=resolved_spec
     )
 
     # Check for sandbox failures
@@ -7028,6 +7611,9 @@ def cmd_codex_completion_review(args: argparse.Namespace) -> None:
             "base": base_branch,
             "verdict": verdict,
             "session_id": session_id_to_write,
+            "model": resolved_spec.model,
+            "effort": resolved_spec.effort,
+            "spec": str(resolved_spec),
             "timestamp": now_iso(),
             "review": output,  # Full review feedback for fix loop
         }
@@ -7052,6 +7638,9 @@ def cmd_codex_completion_review(args: argparse.Namespace) -> None:
                 "verdict": verdict,
                 "session_id": session_id_to_write,
                 "mode": "codex",
+                "model": resolved_spec.model,
+                "effort": resolved_spec.effort,
+                "spec": str(resolved_spec),
                 "review": output,
             }
         )
@@ -7063,17 +7652,26 @@ def cmd_codex_completion_review(args: argparse.Namespace) -> None:
 # --- Copilot Review Commands ---
 
 
-def _resolve_copilot_model_effort(
-    model_arg: Optional[str] = None, effort_arg: Optional[str] = None
-) -> tuple[str, str]:
-    """Resolve effective copilot model + effort using env > arg > default.
+def _resolve_copilot_review_spec(
+    args: argparse.Namespace, task_id: Optional[str]
+) -> BackendSpec:
+    """Resolve ``BackendSpec`` for a copilot review command.
 
-    Matches the cascade inside ``run_copilot_exec`` so the receipt reflects
-    the exact values sent to copilot.
+    Precedence:
+      1. ``--spec`` argv (strict parse — user just typed it, surface errors)
+      2. ``resolve_review_spec("copilot", task_id)`` — task/epic/env/config/defaults
+
+    Caller uses ``resolved.model`` / ``resolved.effort`` for receipts and
+    passes the spec to ``run_copilot_exec`` which honors ``spec.model`` /
+    ``spec.effort`` and still skips ``--effort`` for ``claude-*`` models.
     """
-    model = os.environ.get("FLOW_COPILOT_MODEL") or model_arg or "gpt-5.2"
-    effort = os.environ.get("FLOW_COPILOT_EFFORT") or effort_arg or "high"
-    return model, effort
+    spec_arg = getattr(args, "spec", None)
+    if spec_arg:
+        try:
+            return BackendSpec.parse(spec_arg).resolve()
+        except ValueError as e:
+            error_exit(f"Invalid --spec: {e}", use_json=args.json, code=2)
+    return resolve_review_spec("copilot", task_id)
 
 
 def cmd_copilot_impl_review(args: argparse.Namespace) -> None:
@@ -7204,13 +7802,15 @@ def cmd_copilot_impl_review(args: argparse.Namespace) -> None:
             )
             prompt = rereview_preamble + prompt
 
-    # Resolve model + effort for receipt (matches run_copilot_exec cascade)
-    effective_model, effective_effort = _resolve_copilot_model_effort()
+    # Resolve review spec (task/epic/env/config/defaults or --spec override)
+    resolved_spec = _resolve_copilot_review_spec(args, task_id)
+    effective_model = resolved_spec.model or "gpt-5.2"
+    effective_effort = resolved_spec.effort or "high"
 
     # Run copilot
     repo_root = get_repo_root()
     output, returned_session_id, exit_code, stderr = run_copilot_exec(
-        prompt, session_id=session_id, repo_root=repo_root
+        prompt, session_id=session_id, repo_root=repo_root, spec=resolved_spec
     )
 
     # Handle failures (no sandbox branch — copilot has no sandbox)
@@ -7251,6 +7851,7 @@ def cmd_copilot_impl_review(args: argparse.Namespace) -> None:
             "session_id": returned_session_id,
             "model": effective_model,
             "effort": effective_effort,
+            "spec": str(resolved_spec),
             "timestamp": now_iso(),
             "review": output,
         }
@@ -7276,6 +7877,7 @@ def cmd_copilot_impl_review(args: argparse.Namespace) -> None:
                 "mode": "copilot",
                 "model": effective_model,
                 "effort": effective_effort,
+                "spec": str(resolved_spec),
                 "standalone": standalone,
                 "review": output,
             }
@@ -7387,10 +7989,13 @@ def cmd_copilot_plan_review(args: argparse.Namespace) -> None:
         rereview_preamble = build_rereview_preamble(spec_files, "plan", files_embedded)
         prompt = rereview_preamble + prompt
 
-    effective_model, effective_effort = _resolve_copilot_model_effort()
+    # Resolve review spec — plan reviews are epic-scoped (no task_id context)
+    resolved_spec = _resolve_copilot_review_spec(args, None)
+    effective_model = resolved_spec.model or "gpt-5.2"
+    effective_effort = resolved_spec.effort or "high"
 
     output, returned_session_id, exit_code, stderr = run_copilot_exec(
-        prompt, session_id=session_id, repo_root=repo_root
+        prompt, session_id=session_id, repo_root=repo_root, spec=resolved_spec
     )
 
     if exit_code != 0:
@@ -7426,6 +8031,7 @@ def cmd_copilot_plan_review(args: argparse.Namespace) -> None:
             "session_id": returned_session_id,
             "model": effective_model,
             "effort": effective_effort,
+            "spec": str(resolved_spec),
             "timestamp": now_iso(),
             "review": output,
         }
@@ -7449,6 +8055,7 @@ def cmd_copilot_plan_review(args: argparse.Namespace) -> None:
                 "mode": "copilot",
                 "model": effective_model,
                 "effort": effective_effort,
+                "spec": str(resolved_spec),
                 "review": output,
             }
         )
@@ -7568,11 +8175,14 @@ def cmd_copilot_completion_review(args: argparse.Namespace) -> None:
             )
             prompt = rereview_preamble + prompt
 
-    effective_model, effective_effort = _resolve_copilot_model_effort()
+    # Resolve review spec — completion reviews are epic-scoped
+    resolved_spec = _resolve_copilot_review_spec(args, None)
+    effective_model = resolved_spec.model or "gpt-5.2"
+    effective_effort = resolved_spec.effort or "high"
 
     repo_root = get_repo_root()
     output, returned_session_id, exit_code, stderr = run_copilot_exec(
-        prompt, session_id=session_id, repo_root=repo_root
+        prompt, session_id=session_id, repo_root=repo_root, spec=resolved_spec
     )
 
     if exit_code != 0:
@@ -7612,6 +8222,7 @@ def cmd_copilot_completion_review(args: argparse.Namespace) -> None:
             "session_id": session_id_to_write,
             "model": effective_model,
             "effort": effective_effort,
+            "spec": str(resolved_spec),
             "timestamp": now_iso(),
             "review": output,
         }
@@ -7636,6 +8247,7 @@ def cmd_copilot_completion_review(args: argparse.Namespace) -> None:
                 "mode": "copilot",
                 "model": effective_model,
                 "effort": effective_effort,
+                "spec": str(resolved_spec),
                 "review": output,
             }
         )
@@ -8593,6 +9205,11 @@ def main() -> None:
         default="auto",
         help="Sandbox mode (auto: danger-full-access on Windows, read-only on Unix)",
     )
+    p_codex_impl.add_argument(
+        "--spec",
+        help="Backend spec override (e.g. 'codex:gpt-5.2:medium'). "
+        "Overrides task/epic/env/config resolution. Strict parse.",
+    )
     p_codex_impl.set_defaults(func=cmd_codex_impl_review)
 
     p_codex_plan = codex_sub.add_parser("plan-review", help="Plan review")
@@ -8613,6 +9230,11 @@ def main() -> None:
         default="auto",
         help="Sandbox mode (auto: danger-full-access on Windows, read-only on Unix)",
     )
+    p_codex_plan.add_argument(
+        "--spec",
+        help="Backend spec override (e.g. 'codex:gpt-5.2:medium'). "
+        "Overrides env/config resolution. Strict parse.",
+    )
     p_codex_plan.set_defaults(func=cmd_codex_plan_review)
 
     p_codex_completion = codex_sub.add_parser(
@@ -8631,6 +9253,11 @@ def main() -> None:
         choices=["read-only", "workspace-write", "danger-full-access", "auto"],
         default="auto",
         help="Sandbox mode (auto: danger-full-access on Windows, read-only on Unix)",
+    )
+    p_codex_completion.add_argument(
+        "--spec",
+        help="Backend spec override (e.g. 'codex:gpt-5.2:medium'). "
+        "Overrides env/config resolution. Strict parse.",
     )
     p_codex_completion.set_defaults(func=cmd_codex_completion_review)
 
@@ -8667,6 +9294,11 @@ def main() -> None:
         "--receipt", help="Receipt file path for session continuity"
     )
     p_copilot_impl.add_argument("--json", action="store_true", help="JSON output")
+    p_copilot_impl.add_argument(
+        "--spec",
+        help="Backend spec override (e.g. 'copilot:claude-opus-4.5:xhigh'). "
+        "Overrides task/epic/env/config resolution. Strict parse.",
+    )
     p_copilot_impl.set_defaults(func=cmd_copilot_impl_review)
 
     p_copilot_plan = copilot_sub.add_parser("plan-review", help="Plan review")
@@ -8681,6 +9313,11 @@ def main() -> None:
         "--receipt", help="Receipt file path for session continuity"
     )
     p_copilot_plan.add_argument("--json", action="store_true", help="JSON output")
+    p_copilot_plan.add_argument(
+        "--spec",
+        help="Backend spec override (e.g. 'copilot:claude-opus-4.5:xhigh'). "
+        "Overrides env/config resolution. Strict parse.",
+    )
     p_copilot_plan.set_defaults(func=cmd_copilot_plan_review)
 
     p_copilot_completion = copilot_sub.add_parser(
@@ -8696,6 +9333,11 @@ def main() -> None:
         "--receipt", help="Receipt file path for session continuity"
     )
     p_copilot_completion.add_argument("--json", action="store_true", help="JSON output")
+    p_copilot_completion.add_argument(
+        "--spec",
+        help="Backend spec override (e.g. 'copilot:claude-opus-4.5:xhigh'). "
+        "Overrides env/config resolution. Strict parse.",
+    )
     p_copilot_completion.set_defaults(func=cmd_copilot_completion_review)
 
     args = parser.parse_args()

--- a/.flow/epics/fn-28-unified-review-backend-spec-parser.json
+++ b/.flow/epics/fn-28-unified-review-backend-spec-parser.json
@@ -9,7 +9,7 @@
   "plan_review_status": "unknown",
   "plan_reviewed_at": null,
   "spec_path": ".flow/specs/fn-28-unified-review-backend-spec-parser.md",
-  "status": "open",
+  "status": "done",
   "title": "Unified review backend spec parser (model + effort)",
-  "updated_at": "2026-04-21T22:42:16.902115Z"
+  "updated_at": "2026-04-22T11:58:45.285619Z"
 }

--- a/.flow/specs/fn-28-unified-review-backend-spec-parser.md
+++ b/.flow/specs/fn-28-unified-review-backend-spec-parser.md
@@ -79,7 +79,7 @@ Depends on fn-27 landing first (copilot runtime needs to exist before its spec c
 
 5. **RP gets only `backend` form.** RP doesn't have per-call model or effort (model is determined by the RP window configuration). Spec `rp:anything` rejected. `rp` accepted.
 
-6. **Receipt schema unchanged.** fn-27 already writes `model` + `effort` into receipts. fn-28 just makes those fields come from the resolved spec instead of only from env vars / defaults.
+6. **Receipt schema: additive change.** fn-27 already writes `model` + `effort` into receipts. fn-28.3 additionally stamps a new `spec` field (`str(resolved_spec)`) as the canonical round-trippable form. `model` + `effort` remain for backward compatibility; readers tolerant of missing `spec` stay correct. <!-- Updated by plan-sync: fn-28.3 added `spec` field; original claim "unchanged" was aspirational -->
 
 7. **Back-compat**: existing `default_review` / `review` stored values are either bare backend (`codex`, `rp`) or never-parsed strings. Bare backend passes validation unchanged. Any stored string that fails validation falls back to backend-only with a warning — don't crash on old data.
 

--- a/.flow/tasks/fn-28-unified-review-backend-spec-parser.1.md
+++ b/.flow/tasks/fn-28-unified-review-backend-spec-parser.1.md
@@ -63,9 +63,8 @@ Inside `flowctl.py`, add a new section (suggested location: right after the exis
 - [ ] No call sites wired yet (task 3 does that); adding the module doesn't regress existing commands
 
 ## Done summary
-
-(filled in when task completes)
-
+Added `BackendSpec` frozen dataclass + `BACKEND_REGISTRY` (rp/codex/copilot/none) to `flowctl.py` with `parse`/`resolve`/`__str__`, plus a 56-case unit-test file covering every invalid-input branch (empty, unknown backend/model/effort, too-many-colons, rp-rejects-model, case sensitivity, idempotent resolve, frozen+hashable invariants). No call sites wired yet — task 3 does that. Full flow-next smoke test still green (59/59).
 ## Evidence
-
-(filled in when task completes)
+- Commits: f1976879c6ccf3d725ae9a41a7e0cb9a4281a971
+- Tests: python3 -m unittest plugins.flow-next.tests.test_backend_spec -v, cd /tmp && /Users/gordon/work/gmickel-claude-marketplace/plugins/flow-next/scripts/smoke_test.sh
+- PRs:

--- a/.flow/tasks/fn-28-unified-review-backend-spec-parser.2.md
+++ b/.flow/tasks/fn-28-unified-review-backend-spec-parser.2.md
@@ -7,14 +7,14 @@ Wire validation into store-time commands (`cmd_epic_set_backend`, `cmd_task_set_
 
 ## Approach
 
-**`cmd_epic_set_backend`** at `flowctl.py:4206`:
+**`cmd_epic_set_backend`** at `flowctl.py:4413` <!-- Updated by plan-sync: task 1 added BackendSpec+registry at 1715-1898, shifting later defs -->:
 - Before storing each of `--impl`, `--review`, `--sync`, call `BackendSpec.parse(value)` if non-empty. On ValueError, call `error_exit` with the parser's message (which already includes valid-values hints).
 - Store the raw string (validated) as-is — we don't normalize. User sees back exactly what they typed.
 
-**`cmd_task_set_backend`** at `flowctl.py:4265`:
+**`cmd_task_set_backend`** at `flowctl.py:4472`:
 - Same pattern.
 
-**`cmd_task_show_backend`** at `flowctl.py:4322`:
+**`cmd_task_show_backend`** at `flowctl.py:4529`:
 - After `resolve_spec` computes the source-traced raw spec, also call `BackendSpec.parse(raw).resolve()` to get the full backend/model/effort triple.
 - Extend JSON output to show both raw (stored) and resolved (runtime) forms:
   ```json
@@ -32,21 +32,27 @@ Wire validation into store-time commands (`cmd_epic_set_backend`, `cmd_task_set_
   ```
 - Per-field source tracking: `spec` / `task_spec` / `epic_spec` / `env:FLOW_CODEX_EFFORT` / `registry_default`.
 - Text output (non-JSON) shows both lines: `review: codex:gpt-5.4 (task) → codex:gpt-5.4:high (effort: registry)`.
+- Display the resolved form via `str(resolved_spec)` — task 1's `__str__` preserves the empty-model slot (`codex::high` round-trips), which keeps effort-only specs honest. <!-- plan-sync note from fn-28.1 -->
+
 
 **Graceful legacy fallback**:
 - If a stored value fails `BackendSpec.parse(...)` (pre-existing data before this epic), DO NOT crash:
   - At read time (`show-backend`, runtime resolution): warn to stderr: `warning: spec "codex:gpt-5.4-high" failed validation: <reason>. Treating as bare backend "codex".`
   - Fall back to bare `BackendSpec(backend=<first-part-if-valid>)` and continue.
   - At store time, we always validate, so new stores don't need fallback.
+  <!-- plan-sync note: task 1's parser raises "Unknown model for codex: 'gpt-5.4-high'. Valid: [...]" for this example (not a separator-count error). Fallback logic must catch ValueError generically, not match on message text. -->
 
-**Constants**: export a `VALID_BACKENDS` list (`list(BACKEND_REGISTRY.keys())`) for use in argparse `choices=` where helpful.
+
+**Constants**: export a `VALID_BACKENDS` list (`list(BACKEND_REGISTRY.keys())`) for use in argparse `choices=` where helpful. <!-- plan-sync note: task 1 did NOT add VALID_BACKENDS — grep `^VALID_BACKENDS` returns nothing. Add it here alongside the set-backend wiring. -->
 
 ## Investigation targets
 
 **Required:**
-- `plugins/flow-next/scripts/flowctl.py:4206-` — `cmd_epic_set_backend`
-- `plugins/flow-next/scripts/flowctl.py:4265-` — `cmd_task_set_backend`
-- `plugins/flow-next/scripts/flowctl.py:4322-` — `cmd_task_show_backend` (full function)
+- `plugins/flow-next/scripts/flowctl.py:4413-` — `cmd_epic_set_backend` <!-- Updated by plan-sync: fn-28.1 inserted BackendSpec+registry at 1715-1898 -->
+- `plugins/flow-next/scripts/flowctl.py:4472-` — `cmd_task_set_backend`
+- `plugins/flow-next/scripts/flowctl.py:4529-` — `cmd_task_show_backend` (full function)
+- `plugins/flow-next/scripts/flowctl.py:1715` — `BACKEND_REGISTRY` dict (codex models: gpt-5.4, gpt-5.2, gpt-5, gpt-5-mini, gpt-5-codex)
+- `plugins/flow-next/scripts/flowctl.py:1765` — `BackendSpec` class with `parse`/`resolve`/`__str__`
 - `plugins/flow-next/scripts/flowctl.py` — look inside `cmd_task_show_backend` for the existing `resolve_spec` inner helper (extend to return sources)
 
 **Optional:**
@@ -64,9 +70,8 @@ Wire validation into store-time commands (`cmd_epic_set_backend`, `cmd_task_set_
 - [ ] No regression: tasks / epics with bare backend values (`codex`, `rp`) still work end-to-end
 
 ## Done summary
-
-(filled in when task completes)
-
+Wired BackendSpec.parse validation into cmd_epic_set_backend and cmd_task_set_backend, added VALID_BACKENDS constant, and rebuilt cmd_task_show_backend to emit raw + resolved + per-field model/effort sources with graceful legacy fallback (warns to stderr on unparseable stored values, degrades to bare backend). 24 new unittests (80 total) and 8 new smoke tests.
 ## Evidence
-
-(filled in when task completes)
+- Commits: 628d6046b42023245d712b35fde5e1732927bf04
+- Tests: python3 -m unittest plugins.flow-next.tests.test_backend_spec (80/80 OK), plugins/flow-next/scripts/smoke_test.sh (67/67 OK)
+- PRs:

--- a/.flow/tasks/fn-28-unified-review-backend-spec-parser.3.md
+++ b/.flow/tasks/fn-28-unified-review-backend-spec-parser.3.md
@@ -14,17 +14,20 @@ Thread the resolved `BackendSpec` (backend + model + effort) from spec sources t
   3. If no per-task/per-epic spec: read `FLOW_REVIEW_BACKEND` env → may itself be a spec string
   4. Read `.flow/config.json` `review.backend` (same may be spec string)
   5. Call `.resolve()` on whatever BackendSpec falls out → fills missing fields from `FLOW_<BACKEND>_MODEL` / `FLOW_<BACKEND>_EFFORT` env → then registry defaults
-- Return resolved spec. Graceful fallback via task 2's legacy rules if any stored value fails to parse.
+- Return resolved spec. For stored values (per-task/per-epic/config — anything that may be legacy), use `parse_backend_spec_lenient(raw, warn=True)` from task 2 (`flowctl.py:1906`) rather than `BackendSpec.parse` directly. That helper returns `Optional[BackendSpec]` (None when unparseable), warns to stderr on degrade, and handles the bare-backend fallback uniformly. <!-- Updated by plan-sync: fn-28.2 added parse_backend_spec_lenient; reuse it instead of rewriting fallback -->
+- For a value typed right now (e.g. `--spec` argv), use strict `BackendSpec.parse` — the user should see a parse error immediately.
 
-**`run_codex_exec` at `flowctl.py:1534`**:
-- Current signature (as of fn-27 landed): `(prompt: str, session_id: Optional[str] = None, sandbox: str = "read-only", model: Optional[str] = None)`
+**`run_codex_exec` at `flowctl.py:1535`** <!-- Updated by plan-sync: verified post-fn-28.2; lines unchanged -->:
+- Current signature (verified): `(prompt: str, session_id: Optional[str] = None, sandbox: str = "read-only", model: Optional[str] = None)`
 - New: `(prompt, session_id, sandbox, spec: BackendSpec)`
-- Drop the `os.environ.get("FLOW_CODEX_MODEL")` fallback at line 1543 — that lives inside `spec.resolve()` now
-- Build the `-c model_reasoning_effort=<spec.effort>` flag from the spec instead of hard-coding `"high"` at line 1576
-- Receipt continues to get `model` + `effort` populated from `spec.model` + `spec.effort`
+- Drop the `os.environ.get("FLOW_CODEX_MODEL")` fallback at line **1556** — that lives inside `spec.resolve()` now
+- Build the `-c model_reasoning_effort=<spec.effort>` flag from the spec instead of hard-coding `"high"` at line **1589**
+- Receipt continues to get `model` + `effort` populated from `spec.model` + `spec.effort`. Prefer writing `str(resolved_spec)` as the canonical spec string alongside model/effort so receipts round-trip with `show-backend` output. <!-- plan-sync note: fn-28.2 uses str(resolved) as the canonical form in show-backend's resolved.str field -->
 
-**`run_copilot_exec` (from fn-27 task 1)**:
-- Same pattern. Drop direct env reads for model/effort. Take `spec: BackendSpec`. Pass `spec.model` to `--model`, `spec.effort` to `--effort`.
+**`run_copilot_exec` (from fn-27 task 1) at `flowctl.py:1985`** <!-- Updated by plan-sync: was 1939 pre-fn-28.2, shifted by +46 after parse_backend_spec_lenient + VALID_BACKENDS insertion -->:
+- Same pattern. Drop direct env reads for model/effort (currently at **flowctl.py:2017-2022**). Take `spec: BackendSpec`. Pass `spec.model` to `--model`, `spec.effort` to `--effort`.
+- **Preserve existing claude-* effort skip** at **flowctl.py:2061** (`if not effective_model.startswith("claude-"):`). Keep that branch — the registry accepts `{low,medium,high,xhigh}` for all copilot models, but the runtime must still strip effort for Claude models. <!-- plan-sync note: verified post-fn-28.2 at line 2061 -->
+
 
 **Six `cmd_*_review` functions** (`cmd_codex_impl_review`, `cmd_codex_plan_review`, `cmd_codex_completion_review`, and the three copilot equivalents from fn-27):
 - Add `--spec` argument to each (optional; defaults to result of `resolve_review_spec(task_id)`).
@@ -36,16 +39,18 @@ Thread the resolved `BackendSpec` (backend + model + effort) from spec sources t
 
 ## Investigation targets
 
-**Required:**
-- `plugins/flow-next/scripts/flowctl.py:1534` — `run_codex_exec` signature to change
-- `plugins/flow-next/scripts/flowctl.py` — `cmd_codex_impl_review` (add --spec); caller at line 6405
-- `plugins/flow-next/scripts/flowctl.py` — `cmd_codex_plan_review`; caller at line 6621
-- `plugins/flow-next/scripts/flowctl.py` — `cmd_codex_completion_review`; caller at line 6975
-- The three copilot equivalents (from fn-27 task 3)
-- `plugins/flow-next/scripts/flowctl.py:2830-2852` — `cmd_review_backend` (task 4 extends this; stay aware)
+**Required:** <!-- Updated by plan-sync: line numbers shifted after fn-28.2; cmd_*_review line nums approximate — grep `def cmd_codex_impl_review` etc. to confirm -->
+- `plugins/flow-next/scripts/flowctl.py:1535` — `run_codex_exec` signature to change
+- `plugins/flow-next/scripts/flowctl.py:1985` — `run_copilot_exec` (was 1939 pre-fn-28.2)
+- `plugins/flow-next/scripts/flowctl.py:1906` — `parse_backend_spec_lenient` — reuse for stored-value resolution (added by fn-28.2)
+- `plugins/flow-next/scripts/flowctl.py:1766` — `VALID_BACKENDS` — use in any argparse `choices=` that needs bare-backend validation (added by fn-28.2)
+- `plugins/flow-next/scripts/flowctl.py` — grep `^def cmd_codex_impl_review` / `^def cmd_codex_plan_review` / `^def cmd_codex_completion_review` / `^def cmd_copilot_impl_review` / `^def cmd_copilot_plan_review` / `^def cmd_copilot_completion_review` (line numbers drifted by ~+60 from fn-28.2 insertions; grep is more reliable than line refs here)
+- `plugins/flow-next/scripts/flowctl.py:3083` — `cmd_review_backend` (was 3037 pre-fn-28.2; task 4 extends)
+- `plugins/flow-next/scripts/flowctl.py:1715` — `BACKEND_REGISTRY` (codex backend: gpt-5.4, gpt-5.2, gpt-5, gpt-5-mini, gpt-5-codex — no `gpt-5.2-codex`; copilot backend does include `gpt-5.2-codex`)
+- `plugins/flow-next/scripts/flowctl.py:1769` — `BackendSpec` class (was 1765)
 
 **Optional:**
-- `plugins/flow-next/scripts/flowctl.py:4322` — `cmd_task_show_backend` (for source-tracking semantics)
+- `plugins/flow-next/scripts/flowctl.py:4606` — `cmd_task_show_backend` (was 4529 pre-fn-28.2; reference for source-tracking semantics: sources are `task` / `epic` / `None` + per-field `spec` / `env:FLOW_<BACKEND>_<FIELD>` / `registry_default`) <!-- Updated by plan-sync -->
 
 ## Acceptance
 

--- a/.flow/tasks/fn-28-unified-review-backend-spec-parser.3.md
+++ b/.flow/tasks/fn-28-unified-review-backend-spec-parser.3.md
@@ -65,9 +65,8 @@ Thread the resolved `BackendSpec` (backend + model + effort) from spec sources t
 - [ ] All six review commands pass `--help` smoke; new `--spec` flag documented
 
 ## Done summary
-
-(filled in when task completes)
-
+Threaded resolved BackendSpec through run_codex_exec, run_copilot_exec, and all six review commands. Added resolve_review_spec() with task/epic/env/config/defaults precedence, --spec CLI flag (strict parse), and receipt fields (model, effort, spec) stamped from resolved spec - per-task review: "codex:gpt-5.2" now actually runs gpt-5.2. Copilot's claude-* --effort skip preserved; 18 new unit tests (80 -> 98).
 ## Evidence
-
-(filled in when task completes)
+- Commits: 9bc0d2288f5736b9531bbf1d4013f5c179b13481
+- Tests: python3 -m unittest discover -s plugins/flow-next/tests (98 pass, +18 new), plugins/flow-next/scripts/smoke_test.sh (67 pass)
+- PRs:

--- a/.flow/tasks/fn-28-unified-review-backend-spec-parser.4.md
+++ b/.flow/tasks/fn-28-unified-review-backend-spec-parser.4.md
@@ -13,13 +13,14 @@ Lift the spec grammar into the top-of-the-cascade surfaces: `FLOW_REVIEW_BACKEND
 
 ## Approach
 
-**`cmd_review_backend`** at `flowctl.py:3083` <!-- Updated by plan-sync: was 3037; post-fn-28.2 layout. Current tuple at line 3087 is ("rp", "codex", "copilot", "none") — replace the whole tuple check -->:
+**`cmd_review_backend`** at `flowctl.py:3193` <!-- Updated by plan-sync: drifted +110 after fn-28.3 added resolve_review_spec + --spec args to 6 cmd_*_review. Current tuple at line 3197 is ("rp", "codex", "copilot", "none") — replace the whole tuple check -->:
 - Replace the hardcoded `(env_val in ("rp", "codex", "copilot", "none"))` tuple check. Instead:
   1. Get `env_val` from `FLOW_REVIEW_BACKEND`.
-  2. If non-empty, try `parse_backend_spec_lenient(env_val, warn=False)` (from fn-28.2 at `flowctl.py:1906`). Degrades to bare backend on invalid; returns None only if nothing recognizable. If valid: return `{backend: spec.backend, spec: str(spec.resolve()), source: "env", model: resolved.model, effort: resolved.effort}`.
+  2. If non-empty, try `parse_backend_spec_lenient(env_val, warn=False)` (from fn-28.2 at `flowctl.py:1918`). Degrades to bare backend on invalid; returns None only if nothing recognizable. If valid: return `{backend: spec.backend, spec: str(spec.resolve()), source: "env", model: resolved.model, effort: resolved.effort}`.
   3. Same for `.flow/config.json review.backend`.
   4. Else `ASK`.
 - Note: legacy fallback is already baked into `parse_backend_spec_lenient`. Do not reimplement it here. <!-- plan-sync note: reuse helper instead of duplicating -->
+- **Alternative (simpler)**: fn-28.3 added `resolve_review_spec(backend_hint, task_id)` at `flowctl.py:1959` which already cascades env > config > bare hint with the lenient parser. `cmd_review_backend` can largely delegate — but note it currently distinguishes `source` ("env" vs "config" vs "none") which `resolve_review_spec` collapses. You'll likely still need separate env/config lookup for `source` field, but the parsing logic is identical to what's in `resolve_review_spec` lines 2027-2039. <!-- plan-sync note: see how fn-28.3 handled it -->
 - `VALID_BACKENDS` (`flowctl.py:1766`) is available if argparse `choices=` is wanted on any new `--backend`-style flag, but the env/config paths should use the lenient parser, not `choices=`.
 - Output in JSON mode: `{backend, spec, source, model, effort}` where spec is the resolved form (via `str(resolved)`).
 - Output in text mode: `backend` (backward compatible for skills that grep stdout).
@@ -39,21 +40,32 @@ Lift the spec grammar into the top-of-the-cascade surfaces: `FLOW_REVIEW_BACKEND
 **Ralph templates**:
 - `config.env`: extend `PLAN_REVIEW` / `WORK_REVIEW` / `COMPLETION_REVIEW` comment to note spec form: `# e.g. PLAN_REVIEW=codex:gpt-5.4:xhigh or PLAN_REVIEW=copilot:claude-opus-4.5`.
 - `ralph.sh`: backend-check gates at lines **1082, 1096, 1119** (plus display-name checks at 228-236) already handle bare backends. Add: after env export, strip to bare backend for the equality check (`${PLAN_REVIEW%%:*}`). Pass the full spec via the `FLOW_REVIEW_BACKEND` export so flowctl resolves. <!-- Updated by plan-sync: actual gate lines verified -->
+- **Simpler alternative** (preferred): fn-28.3 added `--spec <spec>` arg to all 6 `cmd_*_review` functions. Ralph can pass `--spec "$PLAN_REVIEW"` directly to the review invocation instead of (or alongside) exporting `FLOW_REVIEW_BACKEND`. The bare-backend equality check still applies for the backend-name gate; the `--spec` flag handles model+effort. <!-- plan-sync note: fn-28.3 --spec exists on all 6 cmds -->
 - `prompt_plan.md`, `prompt_work.md`, `prompt_completion.md`: show a spec-form example alongside the existing bare-backend examples.
+
+**Receipt schema awareness** <!-- Updated by plan-sync: fn-28.3 added `spec` field -->:
+- Receipts now include a new `spec` field alongside existing `model` + `effort`: `{"mode": "codex", "model": "gpt-5.4", "effort": "high", "spec": "codex:gpt-5.4:high", ...}`.
+- `verify_receipt` in ralph.sh does NOT currently inspect model/effort/spec — receipt verification is promise/verdict-based. No ralph.sh changes needed for the new field. If a future step adds spec-based receipt checks, read `spec` (not model/effort) as the canonical form.
 
 **ralph-guard.py**: no changes needed — it guards tool calls, not spec strings.
 
 ## Investigation targets
 
-**Required:** <!-- Updated by plan-sync: line numbers reverified post-fn-28.2 -->
-- `plugins/flow-next/scripts/flowctl.py:3083` — `cmd_review_backend` (was 3037; already accepts bare copilot as of fn-27; task 4 adds spec-form support)
+**Required:** <!-- Updated by plan-sync: line numbers reverified post-fn-28.3; drift from task 3's insertions -->
+- `plugins/flow-next/scripts/flowctl.py:3193` — `cmd_review_backend` (was 3083 pre-fn-28.3; already accepts bare copilot as of fn-27; task 4 adds spec-form support)
 - `plugins/flow-next/scripts/flowctl.py:1715` — `BACKEND_REGISTRY` (source of truth for spec validation)
 - `plugins/flow-next/scripts/flowctl.py:1766` — `VALID_BACKENDS` (available as `sorted(BACKEND_REGISTRY.keys())`, added by fn-28.2)
-- `plugins/flow-next/scripts/flowctl.py:1906` — `parse_backend_spec_lenient` (use this for env/config reads; returns `Optional[BackendSpec]`, handles legacy fallback, added by fn-28.2)
+- `plugins/flow-next/scripts/flowctl.py:1918` — `parse_backend_spec_lenient` (use this for env/config reads; returns `Optional[BackendSpec]`, handles legacy fallback, added by fn-28.2)
+- `plugins/flow-next/scripts/flowctl.py:1959` — `resolve_review_spec(backend_hint, task_id)` (added by fn-28.3; already implements env > config > bare cascade; consider delegating most of cmd_review_backend to this helper)
 - `plugins/flow-next/skills/flow-next-impl-review/workflow.md` — current invocation comments
 - `plugins/flow-next/skills/flow-next-ralph-init/templates/config.env` — current comment block
 - `plugins/flow-next/skills/flow-next-ralph-init/templates/ralph.sh:1082, 1096, 1119` — backend equality checks (plus 228-236 for display-name branches)
 - `.flow/specs/fn-28-unified-review-backend-spec-parser.md` §Resolution Precedence
+
+**Available from fn-28.3** <!-- Added by plan-sync -->:
+- `--spec <spec>` CLI flag on all 6 `cmd_*_review` functions (strict parse via `BackendSpec.parse`; grep `def cmd_codex_impl_review` / `def cmd_copilot_impl_review` etc.)
+- Private helpers `_resolve_codex_review_spec` / `_resolve_copilot_review_spec` — model for the strict-parse-argv + fallback-to-resolve_review_spec pattern
+- Receipt schema now includes `"spec": str(resolved_spec)` field alongside `model` + `effort`
 
 **Optional:**
 - `plugins/flow-next/skills/flow-next-setup/workflow.md:150-349` — where backend-selection question lives

--- a/.flow/tasks/fn-28-unified-review-backend-spec-parser.4.md
+++ b/.flow/tasks/fn-28-unified-review-backend-spec-parser.4.md
@@ -83,9 +83,8 @@ Lift the spec grammar into the top-of-the-cascade surfaces: `FLOW_REVIEW_BACKEND
 - [ ] No edits to generated codex mirror files (task 5 regens)
 
 ## Done summary
-
-(filled in when task completes)
-
+cmd_review_backend now accepts spec form (codex:gpt-5.4:xhigh) from FLOW_REVIEW_BACKEND and .flow/config.json via parse_backend_spec_lenient; JSON mode returns full {backend, spec, model, effort, source} and text mode still prints bare backend for skill grep back-compat. Six review skill files (impl/plan/epic x SKILL+workflow), flow-next-setup workflow, and all Ralph templates (config.env, ralph.sh, prompt_{plan,work,completion}.md) now document the spec grammar and pass full spec through FLOW_REVIEW_BACKEND while keeping equality/gate checks on the bare backend (extracted via ${VAR%%:*}).
 ## Evidence
-
-(filled in when task completes)
+- Commits: 59eeb68bcee06cdd068d8456338e51c392417a8f
+- Tests: python3 -m unittest discover -s plugins/flow-next/tests (112 pass, +14 new), plugins/flow-next/scripts/smoke_test.sh (67 pass), bash -n plugins/flow-next/skills/flow-next-ralph-init/templates/ralph.sh (syntax OK), manual: FLOW_REVIEW_BACKEND=codex:gpt-5.4:xhigh flowctl review-backend --json returns full spec + model + effort + source (env), manual: text mode still prints bare 'codex' for skill grep back-compat, manual: legacy FLOW_REVIEW_BACKEND=codex still resolves to codex:gpt-5.4:high, manual: bash ${VAR%%:*} extracts bare backend from both spec and bare forms
+- PRs:

--- a/.flow/tasks/fn-28-unified-review-backend-spec-parser.4.md
+++ b/.flow/tasks/fn-28-unified-review-backend-spec-parser.4.md
@@ -13,14 +13,15 @@ Lift the spec grammar into the top-of-the-cascade surfaces: `FLOW_REVIEW_BACKEND
 
 ## Approach
 
-**`cmd_review_backend`** at `flowctl.py:2830-2852`:
-- Replace the hardcoded tuple check. Instead:
+**`cmd_review_backend`** at `flowctl.py:3083` <!-- Updated by plan-sync: was 3037; post-fn-28.2 layout. Current tuple at line 3087 is ("rp", "codex", "copilot", "none") — replace the whole tuple check -->:
+- Replace the hardcoded `(env_val in ("rp", "codex", "copilot", "none"))` tuple check. Instead:
   1. Get `env_val` from `FLOW_REVIEW_BACKEND`.
-  2. If non-empty, try `BackendSpec.parse(env_val)`. If valid: return `{backend: spec.backend, spec: str(spec), source: "env"}`.
+  2. If non-empty, try `parse_backend_spec_lenient(env_val, warn=False)` (from fn-28.2 at `flowctl.py:1906`). Degrades to bare backend on invalid; returns None only if nothing recognizable. If valid: return `{backend: spec.backend, spec: str(spec.resolve()), source: "env", model: resolved.model, effort: resolved.effort}`.
   3. Same for `.flow/config.json review.backend`.
-  4. Legacy fallback: if parse fails, try to interpret as bare backend (`env_val in VALID_BACKENDS`). Return bare.
-  5. Else `ASK`.
-- Output in JSON mode: `{backend, spec, source, model, effort}` where spec is the resolved form.
+  4. Else `ASK`.
+- Note: legacy fallback is already baked into `parse_backend_spec_lenient`. Do not reimplement it here. <!-- plan-sync note: reuse helper instead of duplicating -->
+- `VALID_BACKENDS` (`flowctl.py:1766`) is available if argparse `choices=` is wanted on any new `--backend`-style flag, but the env/config paths should use the lenient parser, not `choices=`.
+- Output in JSON mode: `{backend, spec, source, model, effort}` where spec is the resolved form (via `str(resolved)`).
 - Output in text mode: `backend` (backward compatible for skills that grep stdout).
 
 **Skills** — the three review workflows (`flow-next-impl-review/workflow.md`, etc.):
@@ -37,18 +38,21 @@ Lift the spec grammar into the top-of-the-cascade surfaces: `FLOW_REVIEW_BACKEND
 
 **Ralph templates**:
 - `config.env`: extend `PLAN_REVIEW` / `WORK_REVIEW` / `COMPLETION_REVIEW` comment to note spec form: `# e.g. PLAN_REVIEW=codex:gpt-5.4:xhigh or PLAN_REVIEW=copilot:claude-opus-4.5`.
-- `ralph.sh`: backend-check gates (lines 1061-1098 area) already handle bare backends. Add: after env export, strip to bare backend for the equality check (`${PLAN_REVIEW%%:*}`). Pass the full spec via the `FLOW_REVIEW_BACKEND` export so flowctl resolves.
+- `ralph.sh`: backend-check gates at lines **1082, 1096, 1119** (plus display-name checks at 228-236) already handle bare backends. Add: after env export, strip to bare backend for the equality check (`${PLAN_REVIEW%%:*}`). Pass the full spec via the `FLOW_REVIEW_BACKEND` export so flowctl resolves. <!-- Updated by plan-sync: actual gate lines verified -->
 - `prompt_plan.md`, `prompt_work.md`, `prompt_completion.md`: show a spec-form example alongside the existing bare-backend examples.
 
 **ralph-guard.py**: no changes needed — it guards tool calls, not spec strings.
 
 ## Investigation targets
 
-**Required:**
-- `plugins/flow-next/scripts/flowctl.py:2830-2852` — `cmd_review_backend` (already accepts bare copilot as of fn-27; task 4 adds spec-form support)
+**Required:** <!-- Updated by plan-sync: line numbers reverified post-fn-28.2 -->
+- `plugins/flow-next/scripts/flowctl.py:3083` — `cmd_review_backend` (was 3037; already accepts bare copilot as of fn-27; task 4 adds spec-form support)
+- `plugins/flow-next/scripts/flowctl.py:1715` — `BACKEND_REGISTRY` (source of truth for spec validation)
+- `plugins/flow-next/scripts/flowctl.py:1766` — `VALID_BACKENDS` (available as `sorted(BACKEND_REGISTRY.keys())`, added by fn-28.2)
+- `plugins/flow-next/scripts/flowctl.py:1906` — `parse_backend_spec_lenient` (use this for env/config reads; returns `Optional[BackendSpec]`, handles legacy fallback, added by fn-28.2)
 - `plugins/flow-next/skills/flow-next-impl-review/workflow.md` — current invocation comments
 - `plugins/flow-next/skills/flow-next-ralph-init/templates/config.env` — current comment block
-- `plugins/flow-next/skills/flow-next-ralph-init/templates/ralph.sh:1061-1098` — backend equality checks
+- `plugins/flow-next/skills/flow-next-ralph-init/templates/ralph.sh:1082, 1096, 1119` — backend equality checks (plus 228-236 for display-name branches)
 - `.flow/specs/fn-28-unified-review-backend-spec-parser.md` §Resolution Precedence
 
 **Optional:**

--- a/.flow/tasks/fn-28-unified-review-backend-spec-parser.5.md
+++ b/.flow/tasks/fn-28-unified-review-backend-spec-parser.5.md
@@ -40,7 +40,7 @@ scripts/sync-codex.sh
 scripts/bump.sh patch flow-next
 ```
 
-**Tests verified green**: run `plugins/flow-next/scripts/smoke_test.sh` (67 tests as of fn-28.2) and `python3 -m unittest plugins.flow-next.tests.test_backend_spec` (80 tests total as of fn-28.2 — 56 from task 1 + 24 from task 2) before committing the bump. Task 3 and task 4 will add more unit/smoke tests; update the counts here when those land. <!-- Updated by plan-sync: counts refreshed from fn-28.2 evidence (was 56 after task 1 only) -->
+**Tests verified green**: run `plugins/flow-next/scripts/smoke_test.sh` (67 tests as of fn-28.3 — unchanged) and `python3 -m unittest discover -s plugins/flow-next/tests` (98 tests total as of fn-28.3 — 56 from task 1 + 24 from task 2 + 18 from task 3) before committing the bump. Task 4 may add more unit/smoke tests; update the counts here when those land. <!-- Updated by plan-sync: counts refreshed from fn-28.3 evidence (was 80 after fn-28.2; +18 from fn-28.3 --spec/resolve_review_spec tests) -->
 
 ## Investigation targets
 
@@ -64,7 +64,10 @@ scripts/bump.sh patch flow-next
 - [ ] `scripts/bump.sh patch flow-next` has bumped all three manifest versions consistently
 - [ ] `jq . .claude-plugin/marketplace.json` parses cleanly
 - [ ] `plugins/flow-next/scripts/smoke_test.sh` green (67+ tests)
-- [ ] `python3 -m unittest plugins.flow-next.tests.test_backend_spec` green (80+ tests — 56 from task 1, +24 from task 2, plus any from tasks 3-4) <!-- Updated by plan-sync -->
+- [ ] `python3 -m unittest discover -s plugins/flow-next/tests` green (98+ tests — 56 from task 1, +24 from task 2, +18 from task 3, plus any from task 4) <!-- Updated by plan-sync: fn-28.3 landed 18 new unit tests -->
+
+**Receipt schema note for docs** <!-- Added by plan-sync -->:
+- Receipts now include a `spec` field alongside `model` + `effort`: `{"mode": "codex", "model": "gpt-5.4", "effort": "high", "spec": "codex:gpt-5.4:high"}`. README should mention this if it documents receipt schema. The `spec` field is the canonical round-trippable form (via `str(resolved_spec)`); `model` + `effort` stay for backward compatibility.
 - [ ] No hand edits under `plugins/flow-next/codex/**`
 
 ## Done summary

--- a/.flow/tasks/fn-28-unified-review-backend-spec-parser.5.md
+++ b/.flow/tasks/fn-28-unified-review-backend-spec-parser.5.md
@@ -24,7 +24,7 @@ Documentation, sync-codex regeneration, and version bump. Gates on all code task
 
 **plugins/flow-next/README.md**:
 - Extend `#### Configuration` block to show spec-form examples for `FLOW_REVIEW_BACKEND` and `review.backend` config key.
-- Add a small table of backend × supported models × supported efforts.
+- Add a small table of backend × supported models × supported efforts. <!-- plan-sync note: pull catalog from flowctl.py:1715 BACKEND_REGISTRY. codex models: gpt-5.4, gpt-5.2, gpt-5, gpt-5-mini, gpt-5-codex. codex efforts: none, minimal, low, medium, high, xhigh. copilot models: claude-sonnet-4.5, claude-haiku-4.5, claude-opus-4.5, claude-sonnet-4, gpt-5.2, gpt-5.2-codex, gpt-5-mini, gpt-4.1. copilot efforts: low, medium, high, xhigh (note: claude-* models drop --effort at runtime). rp/none: no models/efforts. -->
 - Note: per-task pinning via `flowctl task set-backend fn-X.Y --review codex:gpt-5.2`.
 - Note the precedence cascade (per-task > per-epic > env > config > backend-default).
 
@@ -40,7 +40,7 @@ scripts/sync-codex.sh
 scripts/bump.sh patch flow-next
 ```
 
-**Tests verified green**: run `scripts/smoke_test.sh` (and the new `test_backend_spec.py` from task 1) before committing the bump.
+**Tests verified green**: run `plugins/flow-next/scripts/smoke_test.sh` (67 tests as of fn-28.2) and `python3 -m unittest plugins.flow-next.tests.test_backend_spec` (80 tests total as of fn-28.2 — 56 from task 1 + 24 from task 2) before committing the bump. Task 3 and task 4 will add more unit/smoke tests; update the counts here when those land. <!-- Updated by plan-sync: counts refreshed from fn-28.2 evidence (was 56 after task 1 only) -->
 
 ## Investigation targets
 
@@ -63,8 +63,8 @@ scripts/bump.sh patch flow-next
 - [ ] `scripts/sync-codex.sh` has been run; codex mirror reflects all skill changes from task 4
 - [ ] `scripts/bump.sh patch flow-next` has bumped all three manifest versions consistently
 - [ ] `jq . .claude-plugin/marketplace.json` parses cleanly
-- [ ] `scripts/smoke_test.sh` green
-- [ ] `test_backend_spec.py` green (from task 1)
+- [ ] `plugins/flow-next/scripts/smoke_test.sh` green (67+ tests)
+- [ ] `python3 -m unittest plugins.flow-next.tests.test_backend_spec` green (80+ tests — 56 from task 1, +24 from task 2, plus any from tasks 3-4) <!-- Updated by plan-sync -->
 - [ ] No hand edits under `plugins/flow-next/codex/**`
 
 ## Done summary

--- a/.flow/tasks/fn-28-unified-review-backend-spec-parser.5.md
+++ b/.flow/tasks/fn-28-unified-review-backend-spec-parser.5.md
@@ -75,9 +75,8 @@ scripts/bump.sh minor flow-next
 - [ ] No hand edits under `plugins/flow-next/codex/**`
 
 ## Done summary
-
-(filled in when task completes)
-
+Documented spec-grammar surface across CLAUDE.md + plugin README (Configuration section, backend x models x efforts table, 7-level precedence cascade, review-backend --json shape, receipt schema, inspect commands) and CHANGELOG (flow-next 0.31.0). Regenerated codex mirror (sync-codex), then bumped 0.30.0 -> 0.31.0 across all three manifests + README badges. Final gates green: 112 unittest + 67 smoke.
 ## Evidence
-
-(filled in when task completes)
+- Commits: 253bce8e920cff86d581b67aca6097aacdca0591
+- Tests: python3 -m unittest discover -s plugins/flow-next/tests (112 pass), cd /tmp && bash plugins/flow-next/scripts/smoke_test.sh (67 pass), bash scripts/sync-codex.sh (16 skills + 20 agents + hooks.json regen; all validations green), bash scripts/bump.sh minor flow-next (0.30.0 -> 0.31.0 across marketplace.json + both plugin manifests), jq . .claude-plugin/marketplace.json plugins/flow-next/.claude-plugin/plugin.json plugins/flow-next/.codex-plugin/plugin.json (all parse; all at 0.31.0), grep -c -- '--spec' codex mirror skill files (24 occurrences across 6 review skill files — matches upstream), manual: FLOW_REVIEW_BACKEND=codex:gpt-5.4:xhigh flowctl review-backend --json returns full {backend, spec, model, effort, source} shape, manual: FLOW_REVIEW_BACKEND=codex flowctl review-backend text mode prints bare 'codex' for skill grep back-compat
+- PRs:

--- a/.flow/tasks/fn-28-unified-review-backend-spec-parser.5.md
+++ b/.flow/tasks/fn-28-unified-review-backend-spec-parser.5.md
@@ -21,6 +21,9 @@ Documentation, sync-codex regeneration, and version bump. Gates on all code task
     rp  (bare — RP uses window-level model)
   Valid values: flowctl review-backend --help
   ```
+<!-- Added by plan-sync: task 4 delivered these observable behaviors worth documenting alongside the grammar -->
+- Note that `flowctl review-backend --json` returns `{backend, spec, model, effort, source}` (spec-form round-trippable); text mode still prints just the bare backend for back-compat.
+- Note Ralph surface: `config.env` accepts spec form on `PLAN_REVIEW` / `WORK_REVIEW` / `COMPLETION_REVIEW`; `ralph.sh` exports full spec via `FLOW_REVIEW_BACKEND` and exposes derived `PLAN_REVIEW_BACKEND` / `WORK_REVIEW_BACKEND` / `COMPLETION_REVIEW_BACKEND` (bare backend, via `${VAR%%:*}`) to prompts for branching.
 
 **plugins/flow-next/README.md**:
 - Extend `#### Configuration` block to show spec-form examples for `FLOW_REVIEW_BACKEND` and `review.backend` config key.
@@ -37,10 +40,11 @@ scripts/sync-codex.sh
 
 **Version bump**:
 ```bash
-scripts/bump.sh patch flow-next
+scripts/bump.sh minor flow-next
 ```
+<!-- Updated by plan-sync: fn-28 is a feature-level change (new --spec flag on all 6 cmd_*_review, new spec-form support in env/config/per-task/per-epic cascade, new parse_backend_spec_lenient + resolve_review_spec helpers, Ralph spec-form wiring). fn-27 went 0.29.4 → 0.30.0 as a minor; fn-28 should follow suit: 0.30.0 → 0.31.0. Patch is not appropriate. -->
 
-**Tests verified green**: run `plugins/flow-next/scripts/smoke_test.sh` (67 tests as of fn-28.3 — unchanged) and `python3 -m unittest discover -s plugins/flow-next/tests` (98 tests total as of fn-28.3 — 56 from task 1 + 24 from task 2 + 18 from task 3) before committing the bump. Task 4 may add more unit/smoke tests; update the counts here when those land. <!-- Updated by plan-sync: counts refreshed from fn-28.3 evidence (was 80 after fn-28.2; +18 from fn-28.3 --spec/resolve_review_spec tests) -->
+**Tests verified green**: run `plugins/flow-next/scripts/smoke_test.sh` (67 tests — unchanged through fn-28.4) and `python3 -m unittest discover -s plugins/flow-next/tests` (112 tests total as of fn-28.4 — 56 from task 1 + 24 from task 2 + 18 from task 3 + 14 from task 4: TestReviewBackendCmd + TestRalphBareBackendExtraction) before committing the bump. <!-- Updated by plan-sync: counts refreshed from fn-28.4 evidence (98 → 112, +14 from task 4 cmd_review_backend + Ralph bare-backend extraction tests; smoke still 67) -->
 
 ## Investigation targets
 
@@ -60,11 +64,11 @@ scripts/bump.sh patch flow-next
 - [ ] `plugins/flow-next/README.md` shows spec form in Configuration section with precedence cascade documented
 - [ ] Backend × models × efforts table exists in README
 - [ ] CHANGELOG.md entry added
-- [ ] `scripts/sync-codex.sh` has been run; codex mirror reflects all skill changes from task 4
-- [ ] `scripts/bump.sh patch flow-next` has bumped all three manifest versions consistently
+- [ ] `scripts/sync-codex.sh` has been run; codex mirror reflects all skill changes from task 4 (6 review skill files: impl/plan/epic × SKILL.md+workflow.md, plus flow-next-setup workflow)
+- [ ] `scripts/bump.sh minor flow-next` has bumped all three manifest versions consistently (0.30.0 → 0.31.0) <!-- Updated by plan-sync: minor, not patch — fn-28 is feature-level -->
 - [ ] `jq . .claude-plugin/marketplace.json` parses cleanly
-- [ ] `plugins/flow-next/scripts/smoke_test.sh` green (67+ tests)
-- [ ] `python3 -m unittest discover -s plugins/flow-next/tests` green (98+ tests — 56 from task 1, +24 from task 2, +18 from task 3, plus any from task 4) <!-- Updated by plan-sync: fn-28.3 landed 18 new unit tests -->
+- [ ] `plugins/flow-next/scripts/smoke_test.sh` green (67 tests — unchanged from fn-28.4)
+- [ ] `python3 -m unittest discover -s plugins/flow-next/tests` green (112 tests — 56 from task 1, +24 from task 2, +18 from task 3, +14 from task 4) <!-- Updated by plan-sync: fn-28.4 landed 14 new unit tests (TestReviewBackendCmd + TestRalphBareBackendExtraction) -->
 
 **Receipt schema note for docs** <!-- Added by plan-sync -->:
 - Receipts now include a `spec` field alongside `model` + `effort`: `{"mode": "codex", "model": "gpt-5.4", "effort": "high", "spec": "codex:gpt-5.4:high"}`. README should mention this if it documents receipt schema. The `spec` field is the canonical round-trippable form (via `str(resolved_spec)`); `model` + `effort` stay for backward compatibility.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to the flow-next.
 
+## [flow-next 0.31.0] - 2026-04-22
+
+### Added
+- **Unified review backend spec parser** — `backend[:model[:effort]]` grammar accepted at every surface (env, config, per-task, per-epic, CLI flag). `parse_backend_spec()` + `BackendSpec` dataclass + `BACKEND_REGISTRY` (rp/codex/copilot/none) validate specs on store; invalid values rejected with helpful errors listing valid models/efforts. Legacy bare-backend values (`codex`, `copilot`, `rp`) still work unchanged. Unparseable strings on disk degrade to bare backend with a stderr warning — never crash.
+- Backend registry (static dict in `flowctl.py`):
+  - `codex`: models `gpt-5.4`, `gpt-5.2`, `gpt-5`, `gpt-5-mini`, `gpt-5-codex`; efforts `none|minimal|low|medium|high|xhigh`; defaults `gpt-5.4` / `high`.
+  - `copilot`: models `claude-sonnet-4.5`, `claude-haiku-4.5`, `claude-opus-4.5`, `claude-sonnet-4`, `gpt-5.2`, `gpt-5.2-codex`, `gpt-5-mini`, `gpt-4.1`; efforts `low|medium|high|xhigh`; defaults `gpt-5.2` / `high`. `claude-*` models drop `--effort` at runtime.
+  - `rp` and `none`: bare-only (no model/effort).
+- **Resolution precedence** (first match wins): `--spec` CLI flag > per-task `review` > per-epic `default_review` > `FLOW_REVIEW_BACKEND` env > `.flow/config.json` `review.backend` > backend-specific env (`FLOW_CODEX_MODEL` / `FLOW_CODEX_EFFORT` / `FLOW_COPILOT_MODEL` / `FLOW_COPILOT_EFFORT`) > registry default. Env fills **missing** fields only — explicit spec values always win.
+- `--spec backend:model:effort` flag on all six review commands: `flowctl {codex,copilot} {impl,plan,completion}-review`. Parses + resolves + threads `model` + `effort` into `run_codex_exec` / `run_copilot_exec`.
+- `flowctl review-backend --json` now returns `{backend, spec, model, effort, source}` — full resolved spec + field-level source tag (`env` / `config` / `none`). Text mode still prints bare backend for skill grep back-compat.
+- `flowctl task show-backend --json` / `flowctl epic show-backend --json` expose raw stored spec + resolved spec + per-field source (`task` / `epic` / `env` / `default`).
+- `parse_backend_spec_lenient()` + `resolve_review_spec()` helpers centralise spec parsing for skills and Ralph.
+- Ralph integration: `scripts/ralph/config.env` accepts spec form on `PLAN_REVIEW` / `WORK_REVIEW` / `COMPLETION_REVIEW` (e.g. `WORK_REVIEW=codex:gpt-5.4:xhigh`). `ralph.sh` exports the full spec via `FLOW_REVIEW_BACKEND` and derives `PLAN_REVIEW_BACKEND` / `WORK_REVIEW_BACKEND` / `COMPLETION_REVIEW_BACKEND` (bare backend, via `${VAR%%:*}`) so existing prompt-level branching keeps working unchanged.
+- Review skills (`flow-next-impl-review`, `flow-next-plan-review`, `flow-next-epic-review`) document the `--spec` flag + spec grammar + precedence in both SKILL.md and workflow.md. `flow-next-setup` workflow now offers spec-form defaults.
+- Receipts include a new `spec` field alongside `model` + `effort`: `{"mode": "codex", "model": "gpt-5.4", "effort": "high", "spec": "codex:gpt-5.4:high"}`. `spec` is the canonical round-trippable form (via `str(resolved_spec)`); older readers that only look at `model` + `effort` stay correct.
+- Smoke suite: 60 → 67 tests (backend spec validation, set-backend rejection paths, show-backend field sources, legacy fallback). Unit tests: 56 → 112 (parser edges, registry integrity, precedence resolution, Ralph bare-backend extraction, `cmd_review_backend` JSON shape).
+
+### Changed
+- Aspirational `--review=codex:gpt-5.4-high` help text (never implemented) replaced with real `backend:model:effort` grammar. No migration needed; old stored bare-backend values continue to parse.
+- `run_codex_exec` and `run_copilot_exec` now take a resolved `BackendSpec` argument instead of ad-hoc `model=` / `effort=` kwargs. Env-var fallback moved up into `BackendSpec.resolve()`.
+
 ## [flow-next 0.30.0] - 2026-04-22
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,10 +23,21 @@ Commands:
 - `/flow-next:plan-review` → Carmack-level plan review (rp-cli, Codex CLI, or Copilot CLI)
 - `/flow-next:impl-review` → Carmack-level impl review of current branch (rp-cli, Codex CLI, or Copilot CLI)
 
+Review backend spec grammar (v0.31.0+):
+- `backend[:model[:effort]]` — colon-delimited, trailing parts optional
+- Examples: `rp`, `codex`, `codex:gpt-5.4:xhigh`, `copilot:claude-opus-4.5:high`
+- RP bare only (model set via window config); `none` accepted as explicit opt-out
+- Valid values: `flowctl review-backend --help`, full catalog in plugin README
+- Resolution precedence (first match wins): `--spec` CLI flag > per-task `review` > per-epic `default_review` > `FLOW_REVIEW_BACKEND` env > `.flow/config.json` `review.backend` > backend-specific env (`FLOW_CODEX_MODEL`, `FLOW_COPILOT_EFFORT`, ...) > registry default
+- Legacy bare-backend values (`codex`, `copilot`) still work; unparseable strings fall back to bare backend with stderr warning
+- `flowctl review-backend --json` returns `{backend, spec, model, effort, source}` (spec-form round-trippable); text mode prints bare backend for skill grep back-compat
+- Receipts now include a `spec` field alongside `model` + `effort`: `{"mode": "codex", "model": "gpt-5.4", "effort": "high", "spec": "codex:gpt-5.4:high"}`
+
 Ralph (autonomous loop):
 - Script template lives in `plugins/flow-next/skills/flow-next-ralph-init/templates/`.
 - Ralph uses `flowctl rp` wrappers (not direct rp-cli) for reviews.
 - Receipts gate progress when `REVIEW_RECEIPT_PATH` is set.
+- `config.env` accepts spec form on `PLAN_REVIEW` / `WORK_REVIEW` / `COMPLETION_REVIEW` (e.g. `WORK_REVIEW=codex:gpt-5.4:xhigh`). `ralph.sh` exports the full spec via `FLOW_REVIEW_BACKEND` and derives `PLAN_REVIEW_BACKEND` / `WORK_REVIEW_BACKEND` / `COMPLETION_REVIEW_BACKEND` (bare backend, via `${VAR%%:*}`) for prompt-level branching.
 - Runbooks: `plans/ralph-e2e-notes.md`, `plans/ralph-getting-started.md`.
 
 Memory system (opt-in):

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Flow-Next
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Flow-next](https://img.shields.io/badge/Flow--next-v0.30.0-green)](plugins/flow-next/)
+[![Flow-next](https://img.shields.io/badge/Flow--next-v0.31.0-green)](plugins/flow-next/)
 [![Docs](https://img.shields.io/badge/Docs-📖-informational)](plugins/flow-next/README.md)
 
 [![Author](https://img.shields.io/badge/Author-Gordon_Mickel-orange)](https://mickel.tech)

--- a/plugins/flow-next/.claude-plugin/plugin.json
+++ b/plugins/flow-next/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "flow-next",
-  "version": "0.30.0",
+  "version": "0.31.0",
   "description": "Zero-dependency planning + execution with .flow/ task tracking and Ralph autonomous mode (multi-model review gates). Worker subagent per task for context isolation. Prime assesses 8 pillars (48 criteria) with GitHub API integration. Includes 20 subagents, 11 commands, 16 skills.",
   "author": {
     "name": "Gordon Mickel",

--- a/plugins/flow-next/.codex-plugin/plugin.json
+++ b/plugins/flow-next/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "flow-next",
-  "version": "0.30.0",
+  "version": "0.31.0",
   "description": "Zero-dependency planning + execution with .flow/ task tracking and Ralph autonomous mode. Worker subagent per task for context isolation. Compatible with Codex, Claude Code, and Factory Droid.",
   "author": {
     "name": "Gordon Mickel",

--- a/plugins/flow-next/README.md
+++ b/plugins/flow-next/README.md
@@ -6,7 +6,7 @@
 [![Claude Code](https://img.shields.io/badge/Claude_Code-Plugin-blueviolet)](https://claude.ai/code)
 [![OpenAI Codex](https://img.shields.io/badge/OpenAI_Codex-Plugin-10a37f)](https://developers.openai.com/codex/cli/)
 
-[![Version](https://img.shields.io/badge/Version-0.30.0-green)](../../CHANGELOG.md)
+[![Version](https://img.shields.io/badge/Version-0.31.0-green)](../../CHANGELOG.md)
 
 [![Status](https://img.shields.io/badge/Status-Active_Development-brightgreen)](../../CHANGELOG.md)
 [![Discord](https://img.shields.io/badge/Discord-Join-5865F2?logo=discord&logoColor=white)](https://discord.gg/f3DYq8AAm5)
@@ -1009,18 +1009,59 @@ Ralph's `scripts/ralph/config.env` declares all three vars. `ralph.sh` only expo
 
 #### Configuration
 
-Set default review backend:
+Set default review backend (bare or spec form — `backend[:model[:effort]]`):
 ```bash
 # Per-project (saved in .flow/config.json)
-flowctl config set review.backend rp      # or codex, copilot, or none
+flowctl config set review.backend rp                        # bare backend
+flowctl config set review.backend codex:gpt-5.4:xhigh       # full spec
+flowctl config set review.backend copilot:claude-opus-4.5   # backend + model, default effort
 
-# Per-session (environment variable)
-export FLOW_REVIEW_BACKEND=copilot
+# Per-session (environment variable) — same grammar as config key
+export FLOW_REVIEW_BACKEND=copilot:claude-opus-4.5:xhigh
+
+# Per-task / per-epic pinning (stored in .flow/tasks/<id>.json / .flow/epics/<id>.json)
+flowctl task set-backend fn-5.2 --review "codex:gpt-5.2"
+flowctl epic set-backend fn-5   --review "copilot:claude-sonnet-4.5:high"
 ```
 
-Priority: `--review=...` argument > `FLOW_REVIEW_BACKEND` env > `.flow/config.json` > error.
+**Priority cascade** (first match wins):
 
-**No auto-detect.** Run `/flow-next:setup` to configure your preferred review backend, or pass `--review=X` explicitly.
+1. `--spec backend:model:effort` CLI flag on review commands
+2. Per-task `review` field (`.flow/tasks/<id>.json`)
+3. Per-epic `default_review` field (`.flow/epics/<id>.json`)
+4. `FLOW_REVIEW_BACKEND` env var (full spec accepted)
+5. `.flow/config.json` `review.backend`
+6. Backend-specific env vars fill missing fields only: `FLOW_CODEX_MODEL`, `FLOW_CODEX_EFFORT`, `FLOW_COPILOT_MODEL`, `FLOW_COPILOT_EFFORT`
+7. Registry defaults (see table below)
+
+Invalid specs are rejected at `set-backend` time with a helpful error listing valid values. Legacy bare-backend values (`codex`, `copilot`, `rp`) still work. Unparseable strings stored on disk fall back to bare backend with a stderr warning — never crash.
+
+**Spec grammar — `backend[:model[:effort]]`:**
+
+| Backend | Supported models | Supported efforts | Default model | Default effort |
+|---------|------------------|-------------------|---------------|----------------|
+| `rp` | _(bare only — model set via window/session)_ | _(n/a)_ | _n/a_ | _n/a_ |
+| `codex` | `gpt-5.4`, `gpt-5.2`, `gpt-5`, `gpt-5-mini`, `gpt-5-codex` | `none`, `minimal`, `low`, `medium`, `high`, `xhigh` | `gpt-5.4` | `high` |
+| `copilot` | `claude-sonnet-4.5`, `claude-haiku-4.5`, `claude-opus-4.5`, `claude-sonnet-4`, `gpt-5.2`, `gpt-5.2-codex`, `gpt-5-mini`, `gpt-4.1` | `low`, `medium`, `high`, `xhigh` | `gpt-5.2` | `high` |
+| `none` | _(explicit opt-out)_ | _(n/a)_ | _n/a_ | _n/a_ |
+
+Notes:
+- `rp:model` and `rp:model:effort` are rejected — RepoPrompt picks model via its window/session config, not per-call.
+- Codex `minimal` effort passes flowctl validation but is rejected server-side when `web_search` is enabled. Safe for flowctl reviews (no `web_search` used).
+- Copilot `claude-*` models reject `--effort` at runtime — flowctl drops the flag automatically.
+- Field-level resolution: env fills **missing** spec fields only. Task spec `codex:gpt-5.2` plus `FLOW_CODEX_EFFORT=low` resolves to `codex:gpt-5.2:low`. Same task with `FLOW_CODEX_MODEL=gpt-5.4` still resolves to `codex:gpt-5.2:low` — explicit spec values win over env.
+- To override a stored task spec for one session, set `FLOW_REVIEW_BACKEND=codex:gpt-5.4:high` (full spec) or pass `--spec codex:gpt-5.4:high` on the review command.
+
+**Inspect resolved backend:**
+```bash
+flowctl review-backend                    # prints bare backend (skill grep)
+flowctl review-backend --json             # {"backend": "...", "spec": "...", "model": "...", "effort": "...", "source": "env"}
+flowctl task show-backend fn-5.2 --json   # per-task raw + resolved + field-level sources
+```
+
+**Receipt schema:** reviews stamp `{"mode", "model", "effort", "spec"}` into receipts. `spec` is the canonical round-trippable form (`str(resolved_spec)`); `model` + `effort` stay for back-compat with older readers.
+
+**No auto-detect.** Run `/flow-next:setup` to configure your preferred review backend, or pass `--review=X` (or `--spec backend:model:effort`) explicitly.
 
 #### Which to Choose?
 

--- a/plugins/flow-next/codex/skills/flow-next-epic-review/SKILL.md
+++ b/plugins/flow-next/codex/skills/flow-next-epic-review/SKILL.md
@@ -23,8 +23,8 @@ FLOWCTL="${DROID_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT:-$HOME/.codex}}/scripts/flowc
 
 **Priority** (first match wins):
 1. `--review=rp|codex|copilot|none` argument
-2. `FLOW_REVIEW_BACKEND` env var (`rp`, `codex`, `copilot`, `none`)
-3. `.flow/config.json` → `review.backend`
+2. `FLOW_REVIEW_BACKEND` env var — bare backend (`rp`, `codex`, `copilot`, `none`) OR spec form (`codex:gpt-5.4:xhigh`, `copilot:claude-opus-4.5`)
+3. `.flow/config.json` → `review.backend` (same bare / spec forms)
 4. **Error** - no auto-detection
 
 ### Parse from arguments first
@@ -54,8 +54,10 @@ echo "Review backend: $BACKEND (override: --review=rp|codex|copilot|none)"
 ### Backend at a glance
 
 - **rp** — RepoPrompt (macOS GUI); builder auto-selects context. Primary backend.
-- **codex** — Codex CLI (cross-platform); uses OpenAI models (default `gpt-5.4`). `FLOW_CODEX_MODEL` / `FLOW_CODEX_EFFORT` env vars.
-- **copilot** — GitHub Copilot CLI (cross-platform); supports Claude Opus/Sonnet/Haiku 4.5 and GPT-5.2 families via a Copilot subscription. `FLOW_COPILOT_MODEL` / `FLOW_COPILOT_EFFORT` env vars (no CLI flags).
+- **codex** — Codex CLI (cross-platform); uses OpenAI models (default `gpt-5.4`). `FLOW_CODEX_MODEL` / `FLOW_CODEX_EFFORT` env vars, or `--spec codex:gpt-5.4:xhigh`.
+- **copilot** — GitHub Copilot CLI (cross-platform); supports Claude Opus/Sonnet/Haiku 4.5 and GPT-5.2 families via a Copilot subscription. `FLOW_COPILOT_MODEL` / `FLOW_COPILOT_EFFORT` env vars, or `--spec copilot:claude-opus-4.5:xhigh`.
+
+**Spec grammar:** `backend[:model[:effort]]` — `FLOW_REVIEW_BACKEND` and `.flow/config.json review.backend` both accept this. Examples: `codex`, `codex:gpt-5.2`, `copilot:claude-opus-4.5:xhigh`. Per-epic `default_review` (set via `flowctl epic set-backend`) overrides env.
 
 ## Critical Rules
 
@@ -74,7 +76,7 @@ echo "Review backend: $BACKEND (override: --review=rp|codex|copilot|none)"
 **For copilot backend:**
 1. Use `$FLOWCTL copilot completion-review` exclusively
 2. Pass `--receipt` for session continuity on re-reviews (session only resumes when prior receipt has `mode == "copilot"`)
-3. Model + effort are env-only: `FLOW_COPILOT_MODEL`, `FLOW_COPILOT_EFFORT` (no CLI flags)
+3. Model + effort resolved via (first match wins): `--spec backend:model:effort` flag, per-epic `default_review`, `FLOW_REVIEW_BACKEND` spec, `FLOW_COPILOT_MODEL` / `FLOW_COPILOT_EFFORT` env vars, registry defaults
 4. Parse verdict from command output
 
 **For all backends:**
@@ -130,8 +132,10 @@ On NEEDS_WORK: fix code, commit, re-run (receipt enables session continuity).
 ```bash
 RECEIPT_PATH="${REVIEW_RECEIPT_PATH:-/tmp/completion-review-receipt.json}"
 
-# Optional: override model + effort via env (no CLI flags)
-# FLOW_COPILOT_MODEL=gpt-5.2 FLOW_COPILOT_EFFORT=high \
+# Override model + effort (pick one):
+#   --spec copilot:claude-opus-4.5:xhigh   (preferred)
+#   FLOW_REVIEW_BACKEND=copilot:claude-opus-4.5:xhigh
+#   FLOW_COPILOT_MODEL=gpt-5.2 FLOW_COPILOT_EFFORT=high
 
 $FLOWCTL copilot completion-review "$EPIC_ID" --receipt "$RECEIPT_PATH"
 # Output includes VERDICT=SHIP|NEEDS_WORK

--- a/plugins/flow-next/codex/skills/flow-next-epic-review/workflow.md
+++ b/plugins/flow-next/codex/skills/flow-next-epic-review/workflow.md
@@ -51,6 +51,8 @@ FLOWCTL="${DROID_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT:-$HOME/.codex}}/scripts/flowc
 REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 
 # Priority: --review flag > env > config (flag parsed in SKILL.md)
+# Text output is bare backend name for back-compat grep. --json returns full
+# resolved spec (backend, spec, model, effort, source).
 BACKEND=$($FLOWCTL review-backend)
 
 if [[ "$BACKEND" == "ASK" ]]; then
@@ -61,6 +63,17 @@ fi
 
 echo "Review backend: $BACKEND"
 ```
+
+**Spec-form env var (optional):** `FLOW_REVIEW_BACKEND` accepts bare or full spec:
+
+```bash
+FLOW_REVIEW_BACKEND=codex:gpt-5.4:xhigh $FLOWCTL codex completion-review "$EPIC_ID" --receipt "$RECEIPT_PATH"
+FLOW_REVIEW_BACKEND=copilot:claude-opus-4.5 $FLOWCTL copilot completion-review "$EPIC_ID" --receipt "$RECEIPT_PATH"
+# Or pass spec directly:
+$FLOWCTL codex completion-review "$EPIC_ID" --spec "codex:gpt-5.4:xhigh" --receipt "$RECEIPT_PATH"
+```
+
+Per-epic `default_review` (set via `flowctl epic set-backend`) overrides env.
 
 **If backend is "none"**: Skip review, inform user, and exit cleanly (no error).
 
@@ -121,9 +134,11 @@ $FLOWCTL show "$EPIC_ID" --json
 ```bash
 RECEIPT_PATH="${REVIEW_RECEIPT_PATH:-/tmp/completion-review-receipt.json}"
 
-# Runtime config via env vars (no CLI flags for model/effort):
-#   FLOW_COPILOT_MODEL   (default gpt-5.2)
-#   FLOW_COPILOT_EFFORT  (default high)
+# Runtime config:
+#   --spec <spec>           full spec (backend:model:effort), highest priority
+#   FLOW_REVIEW_BACKEND     spec-form ok: copilot:claude-opus-4.5:xhigh
+#   FLOW_COPILOT_MODEL      fills missing model only (default gpt-5.2)
+#   FLOW_COPILOT_EFFORT     fills missing effort only (default high)
 
 $FLOWCTL copilot completion-review "$EPIC_ID" --receipt "$RECEIPT_PATH"
 ```
@@ -142,7 +157,9 @@ If `VERDICT=NEEDS_WORK`:
 ### Step 4: Receipt
 
 Receipt is written automatically by `flowctl copilot completion-review` when `--receipt` provided.
-Format: `{"type":"completion_review","id":"<epic-id>","mode":"copilot","verdict":"<verdict>","session_id":"<uuid>","model":"<model>","effort":"<effort>","timestamp":"..."}`
+Format: `{"type":"completion_review","id":"<epic-id>","mode":"copilot","verdict":"<verdict>","session_id":"<uuid>","model":"<model>","effort":"<effort>","spec":"copilot:<model>:<effort>","timestamp":"..."}`
+
+The `spec` field is the canonical round-trippable form (added in fn-28.3). `model` + `effort` remain for backward compatibility.
 
 Session resume guard: re-review only resumes the copilot session when the existing receipt at `$RECEIPT_PATH` has `mode == "copilot"`. Cross-backend switches start a fresh session.
 
@@ -453,6 +470,6 @@ If verdict is NEEDS_WORK:
 
 **Copilot backend only:**
 - **Direct copilot calls** - Must use `flowctl copilot` wrappers
-- **Inventing `--model`/`--effort` CLI flags** - Those are env-only (`FLOW_COPILOT_MODEL`, `FLOW_COPILOT_EFFORT`)
+- **Inventing `--model`/`--effort` CLI flags** - Use `--spec` for a full backend:model:effort value, or `FLOW_COPILOT_MODEL` / `FLOW_COPILOT_EFFORT` env vars to fill individual fields
 - **Using `--continue`** - Conflicts with parallel usage; session resume uses `--resume=<uuid>` under the hood via `--receipt`
 - **Assuming cross-backend session continuity** - Resume only works when prior receipt has `mode == "copilot"`

--- a/plugins/flow-next/codex/skills/flow-next-impl-review/SKILL.md
+++ b/plugins/flow-next/codex/skills/flow-next-impl-review/SKILL.md
@@ -23,8 +23,8 @@ FLOWCTL="${DROID_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT:-$HOME/.codex}}/scripts/flowc
 
 **Priority** (first match wins):
 1. `--review=rp|codex|copilot|export|none` argument
-2. `FLOW_REVIEW_BACKEND` env var (`rp`, `codex`, `copilot`, `none`)
-3. `.flow/config.json` → `review.backend`
+2. `FLOW_REVIEW_BACKEND` env var — bare backend (`rp`, `codex`, `copilot`, `none`) OR spec form (`codex:gpt-5.4:xhigh`, `copilot:claude-opus-4.5`)
+3. `.flow/config.json` → `review.backend` (same bare / spec forms)
 4. **Error** - no auto-detection
 
 ### Parse from arguments first
@@ -55,8 +55,10 @@ echo "Review backend: $BACKEND (override: --review=rp|codex|copilot|none)"
 ### Backend at a glance
 
 - **rp** — RepoPrompt (macOS GUI); builder auto-selects context. Primary backend.
-- **codex** — Codex CLI (cross-platform); uses OpenAI models (default `gpt-5.4`). `FLOW_CODEX_MODEL` / `FLOW_CODEX_EFFORT` env vars.
-- **copilot** — GitHub Copilot CLI (cross-platform); supports Claude Opus/Sonnet/Haiku 4.5 and GPT-5.2 families via a Copilot subscription. `FLOW_COPILOT_MODEL` / `FLOW_COPILOT_EFFORT` env vars (no CLI flags).
+- **codex** — Codex CLI (cross-platform); uses OpenAI models (default `gpt-5.4`). `FLOW_CODEX_MODEL` / `FLOW_CODEX_EFFORT` env vars, or `--spec codex:gpt-5.4:xhigh`.
+- **copilot** — GitHub Copilot CLI (cross-platform); supports Claude Opus/Sonnet/Haiku 4.5 and GPT-5.2 families via a Copilot subscription. `FLOW_COPILOT_MODEL` / `FLOW_COPILOT_EFFORT` env vars, or `--spec copilot:claude-opus-4.5:xhigh`.
+
+**Spec grammar:** `backend[:model[:effort]]` — `FLOW_REVIEW_BACKEND` and `.flow/config.json review.backend` both accept this. Examples: `codex`, `codex:gpt-5.2`, `copilot:claude-opus-4.5:xhigh`. Per-task `review` (set via `flowctl task set-backend`) overrides env.
 
 ## Critical Rules
 
@@ -75,7 +77,7 @@ echo "Review backend: $BACKEND (override: --review=rp|codex|copilot|none)"
 **For copilot backend:**
 1. Use `$FLOWCTL copilot impl-review` exclusively
 2. Pass `--receipt` for session continuity on re-reviews (session only resumes when prior receipt has `mode == "copilot"`)
-3. Model + effort are env-only: `FLOW_COPILOT_MODEL`, `FLOW_COPILOT_EFFORT` (no CLI flags)
+3. Model + effort resolved via (first match wins): `--spec backend:model:effort` flag, per-task `review`, `FLOW_REVIEW_BACKEND` spec, `FLOW_COPILOT_MODEL` / `FLOW_COPILOT_EFFORT` env vars, registry defaults
 4. Parse verdict from command output
 
 **For all backends:**
@@ -143,8 +145,10 @@ On NEEDS_WORK: fix code, commit, re-run (receipt enables session continuity).
 ```bash
 RECEIPT_PATH="${REVIEW_RECEIPT_PATH:-/tmp/impl-review-receipt.json}"
 
-# Optional: override model + effort via env (no CLI flags)
-# FLOW_COPILOT_MODEL=gpt-5.2 FLOW_COPILOT_EFFORT=high \
+# Override model + effort (pick one):
+#   --spec copilot:claude-opus-4.5:xhigh   (preferred, explicit)
+#   FLOW_REVIEW_BACKEND=copilot:claude-opus-4.5:xhigh  (env, cascades through `review-backend`)
+#   FLOW_COPILOT_MODEL=gpt-5.2 FLOW_COPILOT_EFFORT=high  (env per-field; fills only missing)
 
 if [[ -n "$BASE_COMMIT" ]]; then
   $FLOWCTL copilot impl-review "$TASK_ID" --base "$BASE_COMMIT" --receipt "$RECEIPT_PATH"

--- a/plugins/flow-next/codex/skills/flow-next-impl-review/workflow.md
+++ b/plugins/flow-next/codex/skills/flow-next-impl-review/workflow.md
@@ -47,6 +47,9 @@ FLOWCTL="${DROID_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT:-$HOME/.codex}}/scripts/flowc
 REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 
 # Priority: --review flag > env > config (flag parsed in SKILL.md)
+# Text output is bare backend name for back-compat grep. The same command in
+# --json mode returns {backend, spec, model, effort, source} — use that if you
+# need the model / effort resolved from a spec-form env value.
 BACKEND=$($FLOWCTL review-backend)
 
 if [[ "$BACKEND" == "ASK" ]]; then
@@ -57,6 +60,22 @@ fi
 
 echo "Review backend: $BACKEND (override: --review=rp|codex|copilot|none)"
 ```
+
+**Spec-form env var (optional):** `FLOW_REVIEW_BACKEND` accepts bare or full spec:
+
+```bash
+# Bare backend (back-compat)
+FLOW_REVIEW_BACKEND=codex $FLOWCTL codex impl-review "$TASK_ID" --receipt "$RECEIPT_PATH"
+
+# Full spec — model + effort resolved automatically
+FLOW_REVIEW_BACKEND=codex:gpt-5.4:xhigh $FLOWCTL codex impl-review "$TASK_ID" --receipt "$RECEIPT_PATH"
+FLOW_REVIEW_BACKEND=copilot:claude-opus-4.5 $FLOWCTL copilot impl-review "$TASK_ID" --receipt "$RECEIPT_PATH"
+
+# Or pass spec directly (preferred for one-offs, avoids env pollution):
+$FLOWCTL codex impl-review "$TASK_ID" --spec "codex:gpt-5.4:xhigh" --receipt "$RECEIPT_PATH"
+```
+
+Per-task `review` (set via `flowctl task set-backend`) overrides env.
 
 **If backend is "none"**: Skip review, inform user, and exit cleanly (no error).
 
@@ -137,9 +156,12 @@ git log ${DIFF_BASE}..HEAD --oneline
 ```bash
 RECEIPT_PATH="${REVIEW_RECEIPT_PATH:-/tmp/impl-review-receipt.json}"
 
-# Runtime config via env vars (no CLI flags for model/effort):
-#   FLOW_COPILOT_MODEL   (default gpt-5.2)
-#   FLOW_COPILOT_EFFORT  (default high; values: low|medium|high|xhigh)
+# Runtime config:
+#   --spec <spec>           full spec (backend:model:effort), highest priority
+#   FLOW_REVIEW_BACKEND     env (spec-form ok: copilot:claude-opus-4.5:xhigh)
+#   FLOW_COPILOT_MODEL      env (fills missing model only; default gpt-5.2)
+#   FLOW_COPILOT_EFFORT     env (fills missing effort only; default high)
+#   per-task stored review  via `flowctl task set-backend` (highest if set)
 
 $FLOWCTL copilot impl-review "$TASK_ID" --base "$DIFF_BASE" --receipt "$RECEIPT_PATH"
 ```
@@ -158,7 +180,9 @@ If `VERDICT=NEEDS_WORK`:
 ### Step 4: Receipt
 
 Receipt is written automatically by `flowctl copilot impl-review` when `--receipt` provided.
-Format: `{"type":"impl_review","id":"<id>","mode":"copilot","verdict":"<verdict>","session_id":"<uuid>","model":"<model>","effort":"<effort>","timestamp":"..."}`
+Format: `{"type":"impl_review","id":"<id>","mode":"copilot","verdict":"<verdict>","session_id":"<uuid>","model":"<model>","effort":"<effort>","spec":"copilot:<model>:<effort>","timestamp":"..."}`
+
+The `spec` field is the canonical round-trippable form (added in fn-28.3). `model` + `effort` remain for backward compatibility.
 
 Session resume guard: re-review only resumes the copilot session when the existing receipt at `$RECEIPT_PATH` has `mode == "copilot"`. A cross-backend switch (e.g., codex receipt at the same path) starts a fresh session.
 
@@ -432,6 +456,6 @@ If verdict is NEEDS_WORK:
 
 **Copilot backend only:**
 - **Direct copilot calls** - Must use `flowctl copilot` wrappers
-- **Inventing `--model`/`--effort` CLI flags** - Those are env-only (`FLOW_COPILOT_MODEL`, `FLOW_COPILOT_EFFORT`)
+- **Inventing `--model`/`--effort` CLI flags** - Use `--spec` for a full backend:model:effort value, or `FLOW_COPILOT_MODEL` / `FLOW_COPILOT_EFFORT` env vars to fill individual fields
 - **Using `--continue`** - Conflicts with parallel usage; session resume uses `--resume=<uuid>` under the hood via `--receipt`
 - **Assuming cross-backend session continuity** - Resume only works when prior receipt has `mode == "copilot"`

--- a/plugins/flow-next/codex/skills/flow-next-plan-review/SKILL.md
+++ b/plugins/flow-next/codex/skills/flow-next-plan-review/SKILL.md
@@ -23,8 +23,8 @@ FLOWCTL="${DROID_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT:-$HOME/.codex}}/scripts/flowc
 
 **Priority** (first match wins):
 1. `--review=rp|codex|copilot|export|none` argument
-2. `FLOW_REVIEW_BACKEND` env var (`rp`, `codex`, `copilot`, `none`)
-3. `.flow/config.json` → `review.backend`
+2. `FLOW_REVIEW_BACKEND` env var — bare backend (`rp`, `codex`, `copilot`, `none`) OR spec form (`codex:gpt-5.4:xhigh`, `copilot:claude-opus-4.5`)
+3. `.flow/config.json` → `review.backend` (same bare / spec forms)
 4. **Error** - no auto-detection
 
 ### Parse from arguments first
@@ -56,8 +56,10 @@ echo "Review backend: $BACKEND (override: --review=rp|codex|copilot|none)"
 ### Backend at a glance
 
 - **rp** — RepoPrompt (macOS GUI); builder auto-selects context. Primary backend.
-- **codex** — Codex CLI (cross-platform); uses OpenAI models (default `gpt-5.4`). `FLOW_CODEX_MODEL` / `FLOW_CODEX_EFFORT` env vars.
-- **copilot** — GitHub Copilot CLI (cross-platform); supports Claude Opus/Sonnet/Haiku 4.5 and GPT-5.2 families via a Copilot subscription. `FLOW_COPILOT_MODEL` / `FLOW_COPILOT_EFFORT` env vars (no CLI flags).
+- **codex** — Codex CLI (cross-platform); uses OpenAI models (default `gpt-5.4`). `FLOW_CODEX_MODEL` / `FLOW_CODEX_EFFORT` env vars, or `--spec codex:gpt-5.4:xhigh`.
+- **copilot** — GitHub Copilot CLI (cross-platform); supports Claude Opus/Sonnet/Haiku 4.5 and GPT-5.2 families via a Copilot subscription. `FLOW_COPILOT_MODEL` / `FLOW_COPILOT_EFFORT` env vars, or `--spec copilot:claude-opus-4.5:xhigh`.
+
+**Spec grammar:** `backend[:model[:effort]]` — `FLOW_REVIEW_BACKEND` and `.flow/config.json review.backend` both accept this. Examples: `codex`, `codex:gpt-5.2`, `copilot:claude-opus-4.5:xhigh`. Per-epic `default_review` (set via `flowctl epic set-backend`) overrides env.
 
 ## Critical Rules
 
@@ -76,7 +78,7 @@ echo "Review backend: $BACKEND (override: --review=rp|codex|copilot|none)"
 **For copilot backend:**
 1. Use `$FLOWCTL copilot plan-review` exclusively
 2. Pass `--receipt` for session continuity on re-reviews (session only resumes when prior receipt has `mode == "copilot"`)
-3. Model + effort are env-only: `FLOW_COPILOT_MODEL`, `FLOW_COPILOT_EFFORT` (no CLI flags)
+3. Model + effort resolved via (first match wins): `--spec backend:model:effort` flag, per-epic `default_review`, `FLOW_REVIEW_BACKEND` spec, `FLOW_COPILOT_MODEL` / `FLOW_COPILOT_EFFORT` env vars, registry defaults
 4. Parse verdict from command output
 
 **For all backends:**
@@ -146,8 +148,10 @@ $FLOWCTL checkpoint save --epic "$EPIC_ID" --json
 # Epic/task specs are auto-included; pass files the plan will CREATE or MODIFY
 CODE_FILES="src/main.py,src/config.py"
 
-# Optional: override model + effort via env (no CLI flags)
-# FLOW_COPILOT_MODEL=gpt-5.2 FLOW_COPILOT_EFFORT=high \
+# Override model + effort (pick one):
+#   --spec copilot:claude-opus-4.5:xhigh   (preferred)
+#   FLOW_REVIEW_BACKEND=copilot:claude-opus-4.5:xhigh
+#   FLOW_COPILOT_MODEL=gpt-5.2 FLOW_COPILOT_EFFORT=high
 
 $FLOWCTL copilot plan-review "$EPIC_ID" --files "$CODE_FILES" --receipt "$RECEIPT_PATH"
 # Output includes VERDICT=SHIP|NEEDS_WORK|MAJOR_RETHINK

--- a/plugins/flow-next/codex/skills/flow-next-plan-review/workflow.md
+++ b/plugins/flow-next/codex/skills/flow-next-plan-review/workflow.md
@@ -47,6 +47,8 @@ FLOWCTL="${DROID_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT:-$HOME/.codex}}/scripts/flowc
 REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 
 # Priority: --review flag > env > config (flag parsed in SKILL.md)
+# Text output is bare backend name for back-compat grep. --json returns full
+# resolved spec (backend, spec, model, effort, source).
 BACKEND=$($FLOWCTL review-backend)
 
 if [[ "$BACKEND" == "ASK" ]]; then
@@ -57,6 +59,17 @@ fi
 
 echo "Review backend: $BACKEND (override: --review=rp|codex|copilot|none)"
 ```
+
+**Spec-form env var (optional):** `FLOW_REVIEW_BACKEND` accepts bare or full spec:
+
+```bash
+FLOW_REVIEW_BACKEND=codex:gpt-5.4:xhigh $FLOWCTL codex plan-review "$EPIC_ID" --receipt "$RECEIPT_PATH"
+FLOW_REVIEW_BACKEND=copilot:claude-opus-4.5 $FLOWCTL copilot plan-review "$EPIC_ID" --receipt "$RECEIPT_PATH"
+# Or pass spec directly:
+$FLOWCTL codex plan-review "$EPIC_ID" --spec "codex:gpt-5.4:xhigh" --receipt "$RECEIPT_PATH"
+```
+
+Per-epic `default_review` (set via `flowctl epic set-backend`) overrides env.
 
 **If backend is "none"**: Skip review, inform user, and exit cleanly (no error).
 
@@ -136,9 +149,11 @@ RECEIPT_PATH="${REVIEW_RECEIPT_PATH:-/tmp/plan-review-receipt.json}"
 # Epic/task specs are auto-included; pass files the plan will CREATE or MODIFY
 CODE_FILES="src/main.py,src/config.py"  # Customize per epic
 
-# Runtime config via env vars (no CLI flags for model/effort):
-#   FLOW_COPILOT_MODEL   (default gpt-5.2)
-#   FLOW_COPILOT_EFFORT  (default high)
+# Runtime config:
+#   --spec <spec>           full spec (backend:model:effort), highest priority
+#   FLOW_REVIEW_BACKEND     spec-form ok: copilot:claude-opus-4.5:xhigh
+#   FLOW_COPILOT_MODEL      fills missing model only (default gpt-5.2)
+#   FLOW_COPILOT_EFFORT     fills missing effort only (default high)
 
 $FLOWCTL copilot plan-review "$EPIC_ID" --files "$CODE_FILES" --receipt "$RECEIPT_PATH"
 ```
@@ -165,7 +180,9 @@ If `VERDICT=NEEDS_WORK`:
 ### Step 4: Receipt
 
 Receipt is written automatically by `flowctl copilot plan-review` when `--receipt` provided.
-Format: `{"type":"plan_review","id":"<epic-id>","mode":"copilot","verdict":"<verdict>","session_id":"<uuid>","model":"<model>","effort":"<effort>","timestamp":"..."}`
+Format: `{"type":"plan_review","id":"<epic-id>","mode":"copilot","verdict":"<verdict>","session_id":"<uuid>","model":"<model>","effort":"<effort>","spec":"copilot:<model>:<effort>","timestamp":"..."}`
+
+The `spec` field is the canonical round-trippable form (added in fn-28.3). `model` + `effort` remain for backward compatibility.
 
 Session resume guard: re-review only resumes the copilot session when the existing receipt at `$RECEIPT_PATH` has `mode == "copilot"`. Cross-backend switches start a fresh session.
 
@@ -458,6 +475,6 @@ If verdict is NEEDS_WORK:
 
 **Copilot backend only:**
 - **Direct copilot calls** - Must use `flowctl copilot` wrappers
-- **Inventing `--model`/`--effort` CLI flags** - Those are env-only (`FLOW_COPILOT_MODEL`, `FLOW_COPILOT_EFFORT`)
+- **Inventing `--model`/`--effort` CLI flags** - Use `--spec` for a full backend:model:effort value, or `FLOW_COPILOT_MODEL` / `FLOW_COPILOT_EFFORT` env vars to fill individual fields
 - **Using `--continue`** - Conflicts with parallel usage; session resume uses `--resume=<uuid>` under the hood via `--receipt`
 - **Assuming cross-backend session continuity** - Resume only works when prior receipt has `mode == "copilot"`

--- a/plugins/flow-next/codex/skills/flow-next-ralph-init/templates/config.env
+++ b/plugins/flow-next/codex/skills/flow-next-ralph-init/templates/config.env
@@ -5,15 +5,21 @@ EPICS=
 
 # Plan gate
 REQUIRE_PLAN_REVIEW=0
-# PLAN_REVIEW options: rp (RepoPrompt, macOS), codex (cross-platform), copilot (cross-platform), none
+# PLAN_REVIEW: bare backend or full spec.
+#   Bare: rp (macOS), codex, copilot, none
+#   Spec: backend[:model[:effort]] — e.g. codex:gpt-5.4:xhigh, copilot:claude-opus-4.5:xhigh
+# The bare-backend name is extracted via ${PLAN_REVIEW%%:*} for gating; the full
+# spec flows through FLOW_REVIEW_BACKEND to flowctl which resolves model + effort.
 PLAN_REVIEW={{PLAN_REVIEW}}
 
 # Work gate
-# WORK_REVIEW options: rp (RepoPrompt, macOS), codex (cross-platform), copilot (cross-platform), none
+# WORK_REVIEW: bare backend or full spec (same grammar as PLAN_REVIEW).
+#   e.g. WORK_REVIEW=codex:gpt-5.4:xhigh   or   WORK_REVIEW=copilot:claude-haiku-4.5
 WORK_REVIEW={{WORK_REVIEW}}
 
 # Epic completion gate (runs when all tasks done, before epic closes)
-# COMPLETION_REVIEW options: rp (RepoPrompt, macOS), codex (cross-platform), copilot (cross-platform), none
+# COMPLETION_REVIEW: bare backend or full spec (same grammar).
+#   e.g. COMPLETION_REVIEW=codex:gpt-5.4:xhigh   or   COMPLETION_REVIEW=copilot:claude-opus-4.5
 COMPLETION_REVIEW={{COMPLETION_REVIEW}}
 
 # Codex sandbox mode (only used when PLAN_REVIEW or WORK_REVIEW is codex)
@@ -25,10 +31,10 @@ CODEX_SANDBOX=auto
 # 500KB default (~70% of Codex 200k token context). Set to 0 for unlimited.
 FLOW_CODEX_EMBED_MAX_BYTES=500000
 
-# Copilot runtime config (only used when PLAN/WORK/COMPLETION_REVIEW is copilot).
-# Env-only — no CLI flags. Resolved via env > arg > default cascade in
-# flowctl's _resolve_copilot_model_effort() and stamped into every receipt
-# (model + effort fields), so reviews are reproducible.
+# Copilot runtime config (only used when PLAN/WORK/COMPLETION_REVIEW resolves to copilot).
+# These env vars fill MISSING fields only — a full spec (e.g. WORK_REVIEW=copilot:claude-opus-4.5:xhigh
+# or --spec copilot:claude-opus-4.5:xhigh) always wins. Receipts stamp model,
+# effort, and spec fields so reviews are reproducible.
 # Model catalog: claude-sonnet-4.5, claude-haiku-4.5, claude-opus-4.5,
 #                claude-sonnet-4, gpt-5.2 (default), gpt-5.2-codex, gpt-5-mini, gpt-4.1
 FLOW_COPILOT_MODEL=gpt-5.2

--- a/plugins/flow-next/codex/skills/flow-next-ralph-init/templates/prompt_completion.md
+++ b/plugins/flow-next/codex/skills/flow-next-ralph-init/templates/prompt_completion.md
@@ -2,7 +2,10 @@ You are running one Ralph epic completion review iteration.
 
 Inputs:
 - EPIC_ID={{EPIC_ID}}
-- COMPLETION_REVIEW={{COMPLETION_REVIEW}}
+- COMPLETION_REVIEW={{COMPLETION_REVIEW}}                  (may be spec form, e.g. `codex:gpt-5.4:xhigh`)
+- COMPLETION_REVIEW_BACKEND={{COMPLETION_REVIEW_BACKEND}}  (bare backend name — use this for branching)
+
+The full spec is also exported as `FLOW_REVIEW_BACKEND` for flowctl to resolve model + effort.
 
 Steps:
 1) Re-anchor:
@@ -17,18 +20,25 @@ Steps:
    ```
 
 Ralph mode rules (must follow):
-- If COMPLETION_REVIEW=rp: use `flowctl rp` wrappers (setup-review, select-add, prompt-get, chat-send).
-- If COMPLETION_REVIEW=codex: use `flowctl codex` wrappers (completion-review with --receipt).
-- If COMPLETION_REVIEW=copilot: use `flowctl copilot` wrappers (completion-review with --receipt). Never call `copilot` directly; never pass `--continue`.
+- Branch on COMPLETION_REVIEW_BACKEND (bare name), NOT the full spec.
+  Spec form (e.g. `codex:gpt-5.4:xhigh`) carries model + effort; the backend
+  name picks the wrapper and the full spec flows through `FLOW_REVIEW_BACKEND`.
+- If COMPLETION_REVIEW_BACKEND=rp: use `flowctl rp` wrappers (setup-review, select-add, prompt-get, chat-send).
+- If COMPLETION_REVIEW_BACKEND=codex: use `flowctl codex` wrappers (completion-review with --receipt).
+- If COMPLETION_REVIEW_BACKEND=copilot: use `flowctl copilot` wrappers (completion-review with --receipt). Never call `copilot` directly; never pass `--continue`.
 - Write receipt via bash heredoc (no Write tool) if `REVIEW_RECEIPT_PATH` set.
 - If any rule is violated, output `<promise>RETRY</promise>` and stop.
 
-3) Completion review gate:
-   - If COMPLETION_REVIEW=rp: run `/flow-next:epic-review {{EPIC_ID}} --review=rp`
-   - If COMPLETION_REVIEW=codex: run `/flow-next:epic-review {{EPIC_ID}} --review=codex`
-   - If COMPLETION_REVIEW=copilot: run `/flow-next:epic-review {{EPIC_ID}} --review=copilot`
-   - If COMPLETION_REVIEW=none: set ship and stop:
+3) Completion review gate (branch on bare backend; full spec is already in env):
+   - If COMPLETION_REVIEW_BACKEND=rp: run `/flow-next:epic-review {{EPIC_ID}} --review=rp`
+   - If COMPLETION_REVIEW_BACKEND=codex: run `/flow-next:epic-review {{EPIC_ID}} --review=codex`
+   - If COMPLETION_REVIEW_BACKEND=copilot: run `/flow-next:epic-review {{EPIC_ID}} --review=copilot`
+   - If COMPLETION_REVIEW_BACKEND=none: set ship and stop:
      `scripts/ralph/flowctl epic set-completion-review-status {{EPIC_ID}} --status ship --json`
+
+   Note: when COMPLETION_REVIEW is spec form (e.g. `codex:gpt-5.4:xhigh`), the
+   /flow-next:epic-review skill picks up the spec from `FLOW_REVIEW_BACKEND`
+   automatically — no extra flag needed.
 
 4) The skill will loop internally until `<verdict>SHIP</verdict>`:
    - First review uses `--new-chat`

--- a/plugins/flow-next/codex/skills/flow-next-ralph-init/templates/prompt_plan.md
+++ b/plugins/flow-next/codex/skills/flow-next-ralph-init/templates/prompt_plan.md
@@ -2,8 +2,11 @@ You are running one Ralph plan gate iteration.
 
 Inputs:
 - EPIC_ID={{EPIC_ID}}
-- PLAN_REVIEW={{PLAN_REVIEW}}
+- PLAN_REVIEW={{PLAN_REVIEW}}                  (may be spec form, e.g. `codex:gpt-5.4:xhigh`)
+- PLAN_REVIEW_BACKEND={{PLAN_REVIEW_BACKEND}}  (bare backend name — use this for branching)
 - REQUIRE_PLAN_REVIEW={{REQUIRE_PLAN_REVIEW}}
+
+The full spec is also exported as `FLOW_REVIEW_BACKEND` for flowctl to resolve model + effort.
 
 Steps:
 1) Re-anchor:
@@ -18,21 +21,28 @@ Steps:
    ```
 
 Ralph mode rules (must follow):
-- If PLAN_REVIEW=rp: use `flowctl rp` wrappers (setup-review, select-add, prompt-get, chat-send).
-- If PLAN_REVIEW=codex: use `flowctl codex` wrappers (plan-review with --receipt).
-- If PLAN_REVIEW=copilot: use `flowctl copilot` wrappers (plan-review with --receipt). Never call `copilot` directly; never pass `--continue`.
+- Branch on PLAN_REVIEW_BACKEND (bare name), NOT the full PLAN_REVIEW spec.
+  Spec form (e.g. `codex:gpt-5.4:xhigh`) carries model + effort; the backend
+  name picks the wrapper and the full spec flows through `FLOW_REVIEW_BACKEND`.
+- If PLAN_REVIEW_BACKEND=rp: use `flowctl rp` wrappers (setup-review, select-add, prompt-get, chat-send).
+- If PLAN_REVIEW_BACKEND=codex: use `flowctl codex` wrappers (plan-review with --receipt).
+- If PLAN_REVIEW_BACKEND=copilot: use `flowctl copilot` wrappers (plan-review with --receipt). Never call `copilot` directly; never pass `--continue`.
 - Write receipt via bash heredoc (no Write tool) if `REVIEW_RECEIPT_PATH` set.
 - If any rule is violated, output `<promise>RETRY</promise>` and stop.
 
-3) Plan review gate:
-   - If PLAN_REVIEW=rp: run `/flow-next:plan-review {{EPIC_ID}} --review=rp`
-   - If PLAN_REVIEW=codex: run `/flow-next:plan-review {{EPIC_ID}} --review=codex`
-   - If PLAN_REVIEW=copilot: run `/flow-next:plan-review {{EPIC_ID}} --review=copilot`
-   - If PLAN_REVIEW=export: run `/flow-next:plan-review {{EPIC_ID}} --review=export`
-   - If PLAN_REVIEW=none:
+3) Plan review gate (branch on bare backend; full spec is already in env):
+   - If PLAN_REVIEW_BACKEND=rp: run `/flow-next:plan-review {{EPIC_ID}} --review=rp`
+   - If PLAN_REVIEW_BACKEND=codex: run `/flow-next:plan-review {{EPIC_ID}} --review=codex`
+   - If PLAN_REVIEW_BACKEND=copilot: run `/flow-next:plan-review {{EPIC_ID}} --review=copilot`
+   - If PLAN_REVIEW_BACKEND=export: run `/flow-next:plan-review {{EPIC_ID}} --review=export`
+   - If PLAN_REVIEW_BACKEND=none:
      - If REQUIRE_PLAN_REVIEW=1: output `<promise>RETRY</promise>` and stop.
      - Else: set ship and stop:
        `scripts/ralph/flowctl epic set-plan-review-status {{EPIC_ID}} --status ship --json`
+
+   Note: when PLAN_REVIEW is spec form (e.g. `codex:gpt-5.4:xhigh`), the
+   /flow-next:plan-review skill picks up the spec from `FLOW_REVIEW_BACKEND`
+   automatically — no extra flag needed.
 
 4) The skill will loop internally until `<verdict>SHIP</verdict>`:
    - First review uses `--new-chat`

--- a/plugins/flow-next/codex/skills/flow-next-ralph-init/templates/prompt_work.md
+++ b/plugins/flow-next/codex/skills/flow-next-ralph-init/templates/prompt_work.md
@@ -3,14 +3,22 @@ You are running one Ralph work iteration.
 Inputs:
 - TASK_ID={{TASK_ID}}
 - BRANCH_MODE={{BRANCH_MODE_EFFECTIVE}}
-- WORK_REVIEW={{WORK_REVIEW}}
+- WORK_REVIEW={{WORK_REVIEW}}                  (may be spec form, e.g. `codex:gpt-5.4:xhigh`)
+- WORK_REVIEW_BACKEND={{WORK_REVIEW_BACKEND}}  (bare backend name — use this for `--review`)
+
+The full spec is also exported as `FLOW_REVIEW_BACKEND` for flowctl to resolve model + effort.
 
 ## Steps (execute ALL in order)
 
 **Step 1: Execute task**
 ```
-/flow-next:work {{TASK_ID}} --branch={{BRANCH_MODE_EFFECTIVE}} --review={{WORK_REVIEW}}
+/flow-next:work {{TASK_ID}} --branch={{BRANCH_MODE_EFFECTIVE}} --review={{WORK_REVIEW_BACKEND}}
 ```
+`--review` takes the bare backend name (`rp`, `codex`, `copilot`, `none`). If
+WORK_REVIEW was spec form (e.g. `copilot:claude-opus-4.5:xhigh`), the exported
+`FLOW_REVIEW_BACKEND` carries the full spec through to flowctl which resolves
+model + effort automatically.
+
 When `--review=rp`, the worker subagent invokes `/flow-next:impl-review` internally.
 When `--review=codex`, the worker uses `flowctl codex impl-review` for review.
 When `--review=copilot`, the worker uses `flowctl copilot impl-review` for review.
@@ -24,7 +32,7 @@ scripts/ralph/flowctl show {{TASK_ID}} --json
 ```
 If status != `done`, output `<promise>RETRY</promise>` and stop.
 
-**Step 3: Write impl receipt** (MANDATORY if WORK_REVIEW=rp, codex, or copilot)
+**Step 3: Write impl receipt** (MANDATORY if WORK_REVIEW_BACKEND=rp, codex, or copilot)
 For rp mode:
 ```bash
 mkdir -p "$(dirname '{{REVIEW_RECEIPT_PATH}}')"

--- a/plugins/flow-next/codex/skills/flow-next-ralph-init/templates/ralph.sh
+++ b/plugins/flow-next/codex/skills/flow-next-ralph-init/templates/ralph.sh
@@ -224,16 +224,24 @@ ui_config() {
   ui "${C_DIM}   Branch:${C_RESET} ${C_BOLD}$git_branch${C_RESET}"
   ui "${C_DIM}   Progress:${C_RESET} Epic ${epics_done}/${epics_total} ${C_DIM}•${C_RESET} Task ${tasks_done}/${tasks_total}"
 
+  # Show the full spec (so Ralph operators see the model / effort they picked);
+  # map the bare-backend name to a pretty label.
   local plan_display="$PLAN_REVIEW" work_display="$WORK_REVIEW" completion_display="$COMPLETION_REVIEW"
-  [[ "$PLAN_REVIEW" == "rp" ]] && plan_display="RepoPrompt"
-  [[ "$PLAN_REVIEW" == "codex" ]] && plan_display="Codex"
-  [[ "$PLAN_REVIEW" == "copilot" ]] && plan_display="Copilot"
-  [[ "$WORK_REVIEW" == "rp" ]] && work_display="RepoPrompt"
-  [[ "$WORK_REVIEW" == "codex" ]] && work_display="Codex"
-  [[ "$WORK_REVIEW" == "copilot" ]] && work_display="Copilot"
-  [[ "$COMPLETION_REVIEW" == "rp" ]] && completion_display="RepoPrompt"
-  [[ "$COMPLETION_REVIEW" == "codex" ]] && completion_display="Codex"
-  [[ "$COMPLETION_REVIEW" == "copilot" ]] && completion_display="Copilot"
+  case "$PLAN_REVIEW_BACKEND" in
+    rp) plan_display="RepoPrompt${PLAN_REVIEW#rp}" ;;
+    codex) plan_display="Codex${PLAN_REVIEW#codex}" ;;
+    copilot) plan_display="Copilot${PLAN_REVIEW#copilot}" ;;
+  esac
+  case "$WORK_REVIEW_BACKEND" in
+    rp) work_display="RepoPrompt${WORK_REVIEW#rp}" ;;
+    codex) work_display="Codex${WORK_REVIEW#codex}" ;;
+    copilot) work_display="Copilot${WORK_REVIEW#copilot}" ;;
+  esac
+  case "$COMPLETION_REVIEW_BACKEND" in
+    rp) completion_display="RepoPrompt${COMPLETION_REVIEW#rp}" ;;
+    codex) completion_display="Codex${COMPLETION_REVIEW#codex}" ;;
+    copilot) completion_display="Copilot${COMPLETION_REVIEW#copilot}" ;;
+  esac
   ui "${C_DIM}   Reviews:${C_RESET} Plan=$plan_display ${C_DIM}•${C_RESET} Work=$work_display ${C_DIM}•${C_RESET} Completion=$completion_display"
   [[ -n "${EPICS:-}" ]] && ui "${C_DIM}   Scope:${C_RESET} $EPICS"
   ui ""
@@ -398,6 +406,12 @@ BRANCH_MODE="${BRANCH_MODE:-new}"
 PLAN_REVIEW="${PLAN_REVIEW:-none}"
 WORK_REVIEW="${WORK_REVIEW:-none}"
 COMPLETION_REVIEW="${COMPLETION_REVIEW:-none}"
+# Derive bare backend names from possible spec form (backend[:model[:effort]]).
+# Equality checks / UI labels / gating use BARE; full spec is exported via
+# FLOW_REVIEW_BACKEND so flowctl resolves model + effort.
+PLAN_REVIEW_BACKEND="${PLAN_REVIEW%%:*}"
+WORK_REVIEW_BACKEND="${WORK_REVIEW%%:*}"
+COMPLETION_REVIEW_BACKEND="${COMPLETION_REVIEW%%:*}"
 CODEX_SANDBOX="${CODEX_SANDBOX:-auto}"  # Codex sandbox mode; flowctl reads this env var
 REQUIRE_PLAN_REVIEW="${REQUIRE_PLAN_REVIEW:-0}"
 YOLO="${YOLO:-0}"
@@ -515,7 +529,7 @@ render_template() {
 import os, sys
 path = sys.argv[1]
 text = open(path, encoding="utf-8").read()
-keys = ["EPIC_ID","TASK_ID","PLAN_REVIEW","WORK_REVIEW","COMPLETION_REVIEW","BRANCH_MODE","BRANCH_MODE_EFFECTIVE","REQUIRE_PLAN_REVIEW","REVIEW_RECEIPT_PATH","RALPH_ITERATION"]
+keys = ["EPIC_ID","TASK_ID","PLAN_REVIEW","WORK_REVIEW","COMPLETION_REVIEW","PLAN_REVIEW_BACKEND","WORK_REVIEW_BACKEND","COMPLETION_REVIEW_BACKEND","BRANCH_MODE","BRANCH_MODE_EFFECTIVE","REQUIRE_PLAN_REVIEW","REVIEW_RECEIPT_PATH","RALPH_ITERATION"]
 for k in keys:
     text = text.replace("{{%s}}" % k, os.environ.get(k, ""))
 print(text)
@@ -818,8 +832,8 @@ maybe_close_epics() {
     [[ "$status" == "done" ]] && continue
     all_done="$(epic_all_tasks_done "$json")"
     if [[ "$all_done" == "1" ]]; then
-      # Gate on completion review if enabled
-      if [[ "$COMPLETION_REVIEW" != "none" ]]; then
+      # Gate on completion review if enabled (bare backend check — spec form OK)
+      if [[ "$COMPLETION_REVIEW_BACKEND" != "none" ]]; then
         review_status="$(json_get completion_review_status "$json")"
         if [[ "$review_status" != "ship" ]]; then
           # Don't close - selector will return completion_review status
@@ -917,7 +931,7 @@ while (( iter <= MAX_ITERATIONS )); do
   selector_args=("$FLOWCTL" next --json)
   [[ -n "$EPICS_FILE" ]] && selector_args+=(--epics-file "$EPICS_FILE")
   [[ "$REQUIRE_PLAN_REVIEW" == "1" ]] && selector_args+=(--require-plan-review)
-  [[ "$COMPLETION_REVIEW" != "none" ]] && selector_args+=(--require-completion-review)
+  [[ "$COMPLETION_REVIEW_BACKEND" != "none" ]] && selector_args+=(--require-completion-review)
 
   selector_json="$("${selector_args[@]}")"
   status="$(json_get status "$selector_json")"
@@ -944,15 +958,18 @@ while (( iter <= MAX_ITERATIONS )); do
   if [[ "$status" == "plan" ]]; then
     export EPIC_ID="$epic_id"
     export PLAN_REVIEW
+    export PLAN_REVIEW_BACKEND  # bare backend name (extracted from spec)
     export REQUIRE_PLAN_REVIEW
-    export FLOW_REVIEW_BACKEND="$PLAN_REVIEW"  # Skills read this
-    if [[ "$PLAN_REVIEW" != "none" ]]; then
+    # FLOW_REVIEW_BACKEND carries the FULL spec through to flowctl, which
+    # resolves model + effort via BackendSpec.parse / resolve.
+    export FLOW_REVIEW_BACKEND="$PLAN_REVIEW"
+    if [[ "$PLAN_REVIEW_BACKEND" != "none" ]]; then
       export REVIEW_RECEIPT_PATH="$RECEIPTS_DIR/plan-${epic_id}.json"
     else
       unset REVIEW_RECEIPT_PATH
     fi
-    log "plan epic=$epic_id review=$PLAN_REVIEW receipt=${REVIEW_RECEIPT_PATH:-} require=$REQUIRE_PLAN_REVIEW"
-    ui_plan_review "$PLAN_REVIEW" "$epic_id"
+    log "plan epic=$epic_id review=$PLAN_REVIEW (backend=$PLAN_REVIEW_BACKEND) receipt=${REVIEW_RECEIPT_PATH:-} require=$REQUIRE_PLAN_REVIEW"
+    ui_plan_review "$PLAN_REVIEW_BACKEND" "$epic_id"
     prompt="$(render_template "$SCRIPT_DIR/prompt_plan.md")"
   elif [[ "$status" == "work" ]]; then
     epic_id="${task_id%%.*}"
@@ -963,26 +980,28 @@ while (( iter <= MAX_ITERATIONS )); do
     fi
     export BRANCH_MODE_EFFECTIVE
     export WORK_REVIEW
-    export FLOW_REVIEW_BACKEND="$WORK_REVIEW"  # Skills read this
-    if [[ "$WORK_REVIEW" != "none" ]]; then
+    export WORK_REVIEW_BACKEND  # bare backend name (extracted from spec)
+    export FLOW_REVIEW_BACKEND="$WORK_REVIEW"  # full spec
+    if [[ "$WORK_REVIEW_BACKEND" != "none" ]]; then
       export REVIEW_RECEIPT_PATH="$RECEIPTS_DIR/impl-${task_id}.json"
     else
       unset REVIEW_RECEIPT_PATH
     fi
-    log "work task=$task_id review=$WORK_REVIEW receipt=${REVIEW_RECEIPT_PATH:-} branch=$BRANCH_MODE_EFFECTIVE"
-    ui_impl_review "$WORK_REVIEW" "$task_id"
+    log "work task=$task_id review=$WORK_REVIEW (backend=$WORK_REVIEW_BACKEND) receipt=${REVIEW_RECEIPT_PATH:-} branch=$BRANCH_MODE_EFFECTIVE"
+    ui_impl_review "$WORK_REVIEW_BACKEND" "$task_id"
     prompt="$(render_template "$SCRIPT_DIR/prompt_work.md")"
   elif [[ "$status" == "completion_review" ]]; then
     export EPIC_ID="$epic_id"
     export COMPLETION_REVIEW
-    export FLOW_REVIEW_BACKEND="$COMPLETION_REVIEW"  # Skills read this
-    if [[ "$COMPLETION_REVIEW" != "none" ]]; then
+    export COMPLETION_REVIEW_BACKEND  # bare backend name (extracted from spec)
+    export FLOW_REVIEW_BACKEND="$COMPLETION_REVIEW"  # full spec
+    if [[ "$COMPLETION_REVIEW_BACKEND" != "none" ]]; then
       export REVIEW_RECEIPT_PATH="$RECEIPTS_DIR/completion-${epic_id}.json"
     else
       unset REVIEW_RECEIPT_PATH
     fi
-    log "completion_review epic=$epic_id review=$COMPLETION_REVIEW receipt=${REVIEW_RECEIPT_PATH:-}"
-    ui_completion_review "$COMPLETION_REVIEW" "$epic_id"
+    log "completion_review epic=$epic_id review=$COMPLETION_REVIEW (backend=$COMPLETION_REVIEW_BACKEND) receipt=${REVIEW_RECEIPT_PATH:-}"
+    ui_completion_review "$COMPLETION_REVIEW_BACKEND" "$epic_id"
     prompt="$(render_template "$SCRIPT_DIR/prompt_completion.md")"
   else
     fail "invalid selector status: $status"
@@ -1079,7 +1098,8 @@ Violations break automation and leave the user with incomplete work. Be precise,
   plan_review_status=""
   task_status=""
   impl_receipt_ok="1"
-  if [[ "$status" == "plan" && ( "$PLAN_REVIEW" == "rp" || "$PLAN_REVIEW" == "codex" || "$PLAN_REVIEW" == "copilot" ) ]]; then
+  # Gate on BARE backend name (spec form like codex:gpt-5.4:xhigh resolves to codex).
+  if [[ "$status" == "plan" && ( "$PLAN_REVIEW_BACKEND" == "rp" || "$PLAN_REVIEW_BACKEND" == "codex" || "$PLAN_REVIEW_BACKEND" == "copilot" ) ]]; then
     if ! verify_receipt "$REVIEW_RECEIPT_PATH" "plan_review" "$epic_id"; then
       echo "ralph: missing plan review receipt; forcing retry" >> "$iter_log"
       log "missing plan receipt; forcing retry"
@@ -1093,7 +1113,7 @@ Violations break automation and leave the user with incomplete work. Be precise,
   fi
   completion_review_status=""
   completion_receipt_ok="1"
-  if [[ "$status" == "completion_review" && ( "$COMPLETION_REVIEW" == "rp" || "$COMPLETION_REVIEW" == "codex" || "$COMPLETION_REVIEW" == "copilot" ) ]]; then
+  if [[ "$status" == "completion_review" && ( "$COMPLETION_REVIEW_BACKEND" == "rp" || "$COMPLETION_REVIEW_BACKEND" == "codex" || "$COMPLETION_REVIEW_BACKEND" == "copilot" ) ]]; then
     if ! verify_receipt "$REVIEW_RECEIPT_PATH" "completion_review" "$epic_id"; then
       echo "ralph: missing completion review receipt; forcing retry" >> "$iter_log"
       log "missing completion receipt; forcing retry"
@@ -1116,7 +1136,7 @@ Violations break automation and leave the user with incomplete work. Be precise,
     fi
   fi
   receipt_verdict=""
-  if [[ "$status" == "work" && ( "$WORK_REVIEW" == "rp" || "$WORK_REVIEW" == "codex" || "$WORK_REVIEW" == "copilot" ) ]]; then
+  if [[ "$status" == "work" && ( "$WORK_REVIEW_BACKEND" == "rp" || "$WORK_REVIEW_BACKEND" == "codex" || "$WORK_REVIEW_BACKEND" == "copilot" ) ]]; then
     if ! verify_receipt "$REVIEW_RECEIPT_PATH" "impl_review" "$task_id"; then
       echo "ralph: missing impl review receipt; forcing retry" >> "$iter_log"
       log "missing impl receipt; forcing retry"

--- a/plugins/flow-next/codex/skills/flow-next-setup/workflow.md
+++ b/plugins/flow-next/codex/skills/flow-next-setup/workflow.md
@@ -187,7 +187,7 @@ Current configuration:
 - Memory: <enabled|disabled> (change with: flowctl config set memory.enabled <true|false>)
 - Plan-Sync: <enabled|disabled> (change with: flowctl config set planSync.enabled <true|false>)
 - Plan-Sync cross-epic: <enabled|disabled> (change with: flowctl config set planSync.crossEpic <true|false>)
-- Review backend: <codex|rp|copilot|none> (change with: flowctl config set review.backend <codex|rp|copilot|none>)
+- Review backend: <current value, bare or spec form> (change with: flowctl config set review.backend <codex|rp|copilot|none OR spec form like codex:gpt-5.4:xhigh>)
 - GitHub scout: <enabled|disabled> (change with: flowctl config set scouts.github <true|false>)
 ```
 
@@ -265,6 +265,8 @@ Available questions (include only if corresponding config is unset):
   "multiSelect": false
 }
 ```
+
+Stored value is a bare backend name by default. Power users can also write a full spec like `codex:gpt-5.4:high` or `copilot:claude-opus-4.5:xhigh` via `flowctl config set review.backend <spec>` after setup — the review commands accept both forms.
 
 **Docs question** (always include — adjust default based on platform):
 

--- a/plugins/flow-next/scripts/flowctl.py
+++ b/plugins/flow-next/scripts/flowctl.py
@@ -21,6 +21,7 @@ import unicodedata
 import uuid
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, ContextManager, Optional
@@ -1689,6 +1690,212 @@ def is_sandbox_failure(exit_code: int, stdout: str, stderr: str) -> bool:
             continue
 
     return False
+
+
+# --- Backend Spec Parser (unified model + effort grammar, fn-28) ---
+#
+# Spec grammar: ``backend[:model[:effort]]`` — colon-delimited, three parts max,
+# trailing parts optional. Examples:
+#   - ``rp``                              backend only (RP uses window/session, not per-call model)
+#   - ``codex``                           backend only, defaults from registry
+#   - ``codex:gpt-5.4``                   backend + model, default effort
+#   - ``codex:gpt-5.4:xhigh``             full spec
+#   - ``copilot:claude-opus-4.5:xhigh``   copilot with its own effort set
+#
+# ``BACKEND_REGISTRY`` is a static dict (no plugin discovery). When the registry
+# has ``models`` or ``efforts`` set to ``None``, that backend rejects the
+# corresponding spec field (e.g. ``rp:opus`` is invalid — RP doesn't accept a
+# model). Every validation error lists the valid set sorted alphabetically so
+# users get a deterministic, copy-pasteable hint.
+#
+# Codex ``minimal`` effort caveat: passes codex config validation but the server
+# returns 400 when the ``web_search`` tool is enabled. flowctl reviews do not
+# enable web_search, so ``minimal`` is safe here — documented for the day we do.
+
+BACKEND_REGISTRY: dict[str, dict[str, Any]] = {
+    "rp": {
+        # RepoPrompt picks model via window/session config, not per-call.
+        "models": None,
+        "efforts": None,
+    },
+    "codex": {
+        "models": {
+            "gpt-5.4",
+            "gpt-5.2",
+            "gpt-5",
+            "gpt-5-mini",
+            "gpt-5-codex",
+        },
+        # ``none`` / ``minimal`` accepted at CLI layer; ``minimal`` is gated by
+        # server-side web_search check (not applicable to our reviews).
+        "efforts": {"none", "minimal", "low", "medium", "high", "xhigh"},
+        "default_model": "gpt-5.4",
+        "default_effort": "high",
+    },
+    "copilot": {
+        # Verified via ``copilot --help`` + live probe (fn-27 §Model Catalog).
+        "models": {
+            "claude-sonnet-4.5",
+            "claude-haiku-4.5",
+            "claude-opus-4.5",
+            "claude-sonnet-4",
+            "gpt-5.2",
+            "gpt-5.2-codex",
+            "gpt-5-mini",
+            "gpt-4.1",
+        },
+        # Copilot exposes ``xhigh`` in addition to standard tiers. No ``none`` /
+        # ``minimal`` — Claude-family models reject ``--effort`` entirely, which
+        # ``run_copilot_exec`` handles by dropping the flag when model starts
+        # with ``claude-``.
+        "efforts": {"low", "medium", "high", "xhigh"},
+        "default_model": "gpt-5.2",
+        "default_effort": "high",
+    },
+    "none": {
+        # Explicit opt-out. Parser still validates it so ``--review=none`` can
+        # be stored as a spec without special-casing upstream.
+        "models": None,
+        "efforts": None,
+    },
+}
+
+
+@dataclass(frozen=True)
+class BackendSpec:
+    """Parsed review-backend spec: ``backend[:model[:effort]]``.
+
+    Fields are ``None`` when unspecified. Use ``.resolve()`` to fill missing
+    fields from ``FLOW_<BACKEND>_MODEL`` / ``FLOW_<BACKEND>_EFFORT`` env vars
+    then registry defaults (env only fills fields that the spec left blank —
+    explicit spec values always win).
+    """
+
+    backend: str
+    model: Optional[str] = None
+    effort: Optional[str] = None
+
+    @classmethod
+    def parse(cls, spec: str) -> "BackendSpec":
+        """Parse ``backend[:model[:effort]]``. Raises ``ValueError`` on invalid.
+
+        Validation:
+          - empty / whitespace-only → ``Empty backend spec``
+          - more than 3 colon-separated parts → explicit ValueError
+          - unknown backend → lists valid backends
+          - model on backend that doesn't accept one (rp/none) → ValueError
+          - unknown model → lists valid models for that backend
+          - effort on backend that doesn't accept one → ValueError
+          - unknown effort → lists valid efforts for that backend
+
+        Backend names are case-sensitive and lowercase. Model and effort are
+        matched exactly against the registry (no case-folding) so users see
+        consistent spec strings everywhere.
+        """
+        if spec is None or not str(spec).strip():
+            raise ValueError("Empty backend spec")
+        raw = str(spec).strip()
+        parts = raw.split(":")
+        if len(parts) > 3:
+            raise ValueError(
+                f"Too many ':' separators in spec: {raw!r} "
+                f"(expected backend[:model[:effort]], max 3 parts)"
+            )
+        backend = parts[0].strip()
+        if not backend:
+            raise ValueError(f"Empty backend in spec: {raw!r}")
+        if backend not in BACKEND_REGISTRY:
+            valid = sorted(BACKEND_REGISTRY.keys())
+            raise ValueError(
+                f"Unknown backend: {backend!r}. Valid: {valid}"
+            )
+        reg = BACKEND_REGISTRY[backend]
+
+        model: Optional[str] = None
+        if len(parts) > 1:
+            m = parts[1].strip()
+            model = m if m else None
+        effort: Optional[str] = None
+        if len(parts) > 2:
+            e = parts[2].strip()
+            effort = e if e else None
+
+        if model is not None:
+            if reg["models"] is None:
+                raise ValueError(
+                    f"Backend {backend!r} does not accept a model "
+                    f"(got {model!r})"
+                )
+            if model not in reg["models"]:
+                raise ValueError(
+                    f"Unknown model for {backend}: {model!r}. "
+                    f"Valid: {sorted(reg['models'])}"
+                )
+        if effort is not None:
+            if reg["efforts"] is None:
+                raise ValueError(
+                    f"Backend {backend!r} does not accept an effort "
+                    f"(got {effort!r})"
+                )
+            if effort not in reg["efforts"]:
+                raise ValueError(
+                    f"Unknown effort for {backend}: {effort!r}. "
+                    f"Valid: {sorted(reg['efforts'])}"
+                )
+        return cls(backend=backend, model=model, effort=effort)
+
+    def resolve(self) -> "BackendSpec":
+        """Fill missing fields from env vars then registry defaults.
+
+        Precedence (per field, most specific wins):
+          1. explicit value on this spec
+          2. ``FLOW_<BACKEND>_MODEL`` / ``FLOW_<BACKEND>_EFFORT`` env var
+          3. registry ``default_model`` / ``default_effort``
+
+        Backends with ``models is None`` (rp, none) always resolve ``model`` to
+        ``None`` — env vars are ignored for fields the backend doesn't accept.
+        Same for ``effort``. This prevents a stray ``FLOW_RP_MODEL`` from
+        leaking into an RP spec.
+        """
+        reg = BACKEND_REGISTRY[self.backend]
+        env_model_key = f"FLOW_{self.backend.upper()}_MODEL"
+        env_effort_key = f"FLOW_{self.backend.upper()}_EFFORT"
+
+        if reg["models"] is None:
+            model = None
+        else:
+            model = (
+                self.model
+                or os.environ.get(env_model_key)
+                or reg.get("default_model")
+            )
+
+        if reg["efforts"] is None:
+            effort = None
+        else:
+            effort = (
+                self.effort
+                or os.environ.get(env_effort_key)
+                or reg.get("default_effort")
+            )
+
+        return BackendSpec(self.backend, model, effort)
+
+    def __str__(self) -> str:
+        """Serialize back to ``backend[:model[:effort]]``.
+
+        Trailing ``None`` parts are dropped so ``str(BackendSpec("codex"))``
+        round-trips to ``"codex"`` (not ``"codex::"``). If only ``effort`` is
+        set (no model) we still emit ``backend::effort`` — that's a legal spec
+        shape and keeps the round-trip honest.
+        """
+        if self.model is None and self.effort is None:
+            return self.backend
+        if self.effort is None:
+            return f"{self.backend}:{self.model}"
+        # effort set; model may be None
+        model_part = self.model if self.model is not None else ""
+        return f"{self.backend}:{model_part}:{self.effort}"
 
 
 # --- Copilot Backend Helpers ---

--- a/plugins/flow-next/scripts/flowctl.py
+++ b/plugins/flow-next/scripts/flowctl.py
@@ -3191,28 +3191,65 @@ def cmd_config_set(args: argparse.Namespace) -> None:
 
 
 def cmd_review_backend(args: argparse.Namespace) -> None:
-    """Get review backend for skill conditionals. Returns ASK if not configured."""
+    """Get review backend for skill conditionals. Returns ASK if not configured.
+
+    Accepts spec-form values (``codex:gpt-5.4:high``) from ``FLOW_REVIEW_BACKEND``
+    and ``.flow/config.json`` ``review.backend``. JSON mode returns the full
+    resolved spec plus model + effort fields so skills / Ralph can route model
+    choice. Text mode still prints just the bare backend name for back-compat
+    with skill greps (``BACKEND=$(flowctl review-backend)``).
+    """
     # Priority: FLOW_REVIEW_BACKEND env > config > ASK
+    spec: Optional[BackendSpec] = None
+    source = "none"
+
     env_val = os.environ.get("FLOW_REVIEW_BACKEND", "").strip()
-    if env_val and env_val in ("rp", "codex", "copilot", "none"):
-        backend = env_val
-        source = "env"
-    elif ensure_flow_exists():
+    if env_val:
+        # Lenient parse handles spec-form and legacy bare values; degrades on
+        # bad input rather than silently falling to ASK (previous behavior
+        # quietly dropped ``codex:gpt-5.2``).
+        parsed = parse_backend_spec_lenient(env_val, warn=False)
+        if parsed is not None:
+            spec = parsed.resolve()
+            source = "env"
+
+    if spec is None and ensure_flow_exists():
         cfg_val = get_config("review.backend")
-        if cfg_val and cfg_val in ("rp", "codex", "copilot", "none"):
-            backend = cfg_val
-            source = "config"
-        else:
-            backend = "ASK"
-            source = "none"
-    else:
+        if cfg_val:
+            parsed = parse_backend_spec_lenient(str(cfg_val), warn=False)
+            if parsed is not None:
+                spec = parsed.resolve()
+                source = "config"
+
+    if spec is None:
         backend = "ASK"
-        source = "none"
+        if args.json:
+            json_output(
+                {
+                    "backend": backend,
+                    "spec": backend,
+                    "source": source,
+                    "model": None,
+                    "effort": None,
+                }
+            )
+        else:
+            print(backend)
+        return
 
     if args.json:
-        json_output({"backend": backend, "source": source})
+        json_output(
+            {
+                "backend": spec.backend,
+                "spec": str(spec),
+                "source": source,
+                "model": spec.model,
+                "effort": spec.effort,
+            }
+        )
     else:
-        print(backend)
+        # Text mode: bare backend name only (skills grep this output).
+        print(spec.backend)
 
 
 MEMORY_TEMPLATES = {

--- a/plugins/flow-next/scripts/flowctl.py
+++ b/plugins/flow-next/scripts/flowctl.py
@@ -1761,6 +1761,11 @@ BACKEND_REGISTRY: dict[str, dict[str, Any]] = {
 }
 
 
+# Sorted list of backend names. Handy for argparse ``choices=`` and for any
+# call-site that needs the valid set without touching registry internals.
+VALID_BACKENDS: list[str] = sorted(BACKEND_REGISTRY.keys())
+
+
 @dataclass(frozen=True)
 class BackendSpec:
     """Parsed review-backend spec: ``backend[:model[:effort]]``.
@@ -1896,6 +1901,47 @@ class BackendSpec:
         # effort set; model may be None
         model_part = self.model if self.model is not None else ""
         return f"{self.backend}:{model_part}:{self.effort}"
+
+
+def parse_backend_spec_lenient(
+    raw: str, *, warn: bool = True
+) -> Optional[BackendSpec]:
+    """Parse a stored spec, degrading to bare backend on validation failure.
+
+    Used at read time (show-backend, runtime resolution) so pre-epic stored
+    values like ``codex:gpt-5.4-high`` (no colon between model and effort) do
+    not crash. On ValueError we:
+
+      1. Try the first colon-separated part as a bare backend name.
+      2. If that is a known backend, emit a stderr warning (when ``warn``) and
+         return ``BackendSpec(backend=<first>)``.
+      3. Otherwise return ``None`` — caller decides how to surface it.
+
+    Returns ``None`` for empty / whitespace-only input (no warning — that is
+    just "unset").
+    """
+    if raw is None or not str(raw).strip():
+        return None
+    try:
+        return BackendSpec.parse(raw)
+    except ValueError as e:
+        # Try bare-backend fallback: first ':'-separated part.
+        first = str(raw).strip().split(":", 1)[0].strip()
+        if first in BACKEND_REGISTRY:
+            if warn:
+                print(
+                    f'warning: spec {str(raw)!r} failed validation: {e}. '
+                    f'Treating as bare backend {first!r}.',
+                    file=sys.stderr,
+                )
+            return BackendSpec(backend=first)
+        if warn:
+            print(
+                f'warning: spec {str(raw)!r} failed validation: {e}. '
+                f'No recognizable backend prefix; ignoring.',
+                file=sys.stderr,
+            )
+        return None
 
 
 # --- Copilot Backend Helpers ---
@@ -4440,7 +4486,23 @@ def cmd_epic_set_backend(args: argparse.Namespace) -> None:
         load_json_or_exit(epic_path, f"Epic {args.id}", use_json=args.json)
     )
 
-    # Update fields (empty string means clear)
+    # Validate each non-empty spec up front — reject bad specs before we touch
+    # disk. Empty string is a clear-signal and skips validation.
+    for field, value in (
+        ("--impl", args.impl),
+        ("--review", args.review),
+        ("--sync", args.sync),
+    ):
+        if value:
+            try:
+                BackendSpec.parse(value)
+            except ValueError as e:
+                error_exit(
+                    f"Invalid spec for {field}: {e}", use_json=args.json
+                )
+
+    # Update fields (empty string means clear). Store raw strings as typed —
+    # no normalization — so users see back exactly what they set.
     updated = []
     if args.impl is not None:
         epic_data["default_impl"] = args.impl if args.impl else None
@@ -4498,7 +4560,22 @@ def cmd_task_set_backend(args: argparse.Namespace) -> None:
 
     task_data = load_json_or_exit(task_path, f"Task {task_id}", use_json=args.json)
 
-    # Update fields (empty string means clear)
+    # Validate each non-empty spec up front — reject bad specs before we touch
+    # disk. Empty string is a clear-signal and skips validation.
+    for field, value in (
+        ("--impl", args.impl),
+        ("--review", args.review),
+        ("--sync", args.sync),
+    ):
+        if value:
+            try:
+                BackendSpec.parse(value)
+            except ValueError as e:
+                error_exit(
+                    f"Invalid spec for {field}: {e}", use_json=args.json
+                )
+
+    # Update fields (empty string means clear). Store raw strings as typed.
     updated = []
     if args.impl is not None:
         task_data["impl"] = args.impl if args.impl else None
@@ -4560,9 +4637,9 @@ def cmd_task_show_backend(args: argparse.Namespace) -> None:
                 load_json_or_exit(epic_path, f"Epic {epic_id}", use_json=args.json)
             )
 
-    # Compute effective values with source tracking
+    # Compute effective values with source tracking.
     def resolve_spec(task_key: str, epic_key: str) -> tuple:
-        """Return (spec, source) tuple."""
+        """Return (raw_spec, source) tuple for a given field."""
         task_val = task_data.get(task_key)
         if task_val:
             return (task_val, "task")
@@ -4572,29 +4649,136 @@ def cmd_task_show_backend(args: argparse.Namespace) -> None:
                 return (epic_val, "epic")
         return (None, None)
 
-    impl_spec, impl_source = resolve_spec("impl", "default_impl")
-    review_spec, review_source = resolve_spec("review", "default_review")
-    sync_spec, sync_source = resolve_spec("sync", "default_sync")
+    def resolve_field(raw: Optional[str], spec_source: Optional[str]) -> dict:
+        """Build the richer JSON shape: raw + resolved + per-field sources.
+
+        ``raw`` is what's stored (possibly invalid legacy data). ``spec_source``
+        is where it came from ("task" / "epic" / None when unset).
+
+        Per-field sources ("model_source" / "effort_source") distinguish
+        between an explicit spec value ("spec"), env-var fill
+        ("env:FLOW_<BACKEND>_<FIELD>"), registry default
+        ("registry_default"), or n/a when the backend rejects the field.
+
+        Returns a dict with keys: ``raw``, ``source``, ``resolved``,
+        ``model_source``, ``effort_source``. On legacy-data parse failure we
+        degrade to bare backend (warning already went to stderr from
+        parse_backend_spec_lenient) so callers don't crash on old values.
+        """
+        if raw is None:
+            return {
+                "raw": None,
+                "source": None,
+                "resolved": None,
+                "model_source": None,
+                "effort_source": None,
+            }
+
+        parsed = parse_backend_spec_lenient(raw, warn=True)
+        if parsed is None:
+            # Unrecognizable — surface what we have without a resolved form.
+            return {
+                "raw": raw,
+                "source": spec_source,
+                "resolved": None,
+                "model_source": None,
+                "effort_source": None,
+            }
+
+        resolved = parsed.resolve()
+        reg = BACKEND_REGISTRY[parsed.backend]
+        env_model_key = f"FLOW_{parsed.backend.upper()}_MODEL"
+        env_effort_key = f"FLOW_{parsed.backend.upper()}_EFFORT"
+
+        # Derive per-field source to mirror resolve()'s precedence.
+        if reg["models"] is None:
+            model_source: Optional[str] = None
+        elif parsed.model is not None:
+            model_source = "spec"
+        elif os.environ.get(env_model_key):
+            model_source = f"env:{env_model_key}"
+        else:
+            model_source = "registry_default"
+
+        if reg["efforts"] is None:
+            effort_source: Optional[str] = None
+        elif parsed.effort is not None:
+            effort_source = "spec"
+        elif os.environ.get(env_effort_key):
+            effort_source = f"env:{env_effort_key}"
+        else:
+            effort_source = "registry_default"
+
+        return {
+            "raw": raw,
+            "source": spec_source,
+            "resolved": {
+                "backend": resolved.backend,
+                "model": resolved.model,
+                "effort": resolved.effort,
+                "str": str(resolved),
+            },
+            "model_source": model_source,
+            "effort_source": effort_source,
+        }
+
+    impl_raw, impl_source = resolve_spec("impl", "default_impl")
+    review_raw, review_source = resolve_spec("review", "default_review")
+    sync_raw, sync_source = resolve_spec("sync", "default_sync")
+
+    impl_field = resolve_field(impl_raw, impl_source)
+    review_field = resolve_field(review_raw, review_source)
+    sync_field = resolve_field(sync_raw, sync_source)
 
     if args.json:
         json_output(
             {
                 "id": task_id,
                 "epic": epic_id,
-                "impl": {"spec": impl_spec, "source": impl_source},
-                "review": {"spec": review_spec, "source": review_source},
-                "sync": {"spec": sync_spec, "source": sync_source},
+                "impl": impl_field,
+                "review": review_field,
+                "sync": sync_field,
             }
         )
     else:
-        def fmt(spec, source):
-            if spec:
-                return f"{spec} ({source})"
-            return "null"
+        def _short_src(src: Optional[str]) -> Optional[str]:
+            """Compact a per-field source tag for non-JSON display.
 
-        print(f"impl: {fmt(impl_spec, impl_source)}")
-        print(f"review: {fmt(review_spec, review_source)}")
-        print(f"sync: {fmt(sync_spec, sync_source)}")
+            ``env:FLOW_CODEX_EFFORT`` → ``env`` (keeps line short; JSON output
+            still has the full key for anyone who cares).
+            """
+            if src is None:
+                return None
+            if src.startswith("env:"):
+                return "env"
+            if src == "registry_default":
+                return "registry"
+            return src
+
+        def fmt(field: dict) -> str:
+            raw = field["raw"]
+            if raw is None:
+                return "null"
+            src = field["source"] or "unknown"
+            resolved = field["resolved"]
+            if resolved is None:
+                return f"{raw} ({src}) [unresolved - invalid spec]"
+            # Use str(resolved) so empty-model slot round-trips honestly
+            # (e.g. codex::high stays codex::high, not codex:high).
+            resolved_str = resolved["str"]
+            annotations = []
+            ms = field.get("model_source")
+            if ms and ms != "spec":
+                annotations.append(f"model: {_short_src(ms)}")
+            es = field.get("effort_source")
+            if es and es != "spec":
+                annotations.append(f"effort: {_short_src(es)}")
+            suffix = f" ({', '.join(annotations)})" if annotations else ""
+            return f"{raw} ({src}) -> {resolved_str}{suffix}"
+
+        print(f"impl: {fmt(impl_field)}")
+        print(f"review: {fmt(review_field)}")
+        print(f"sync: {fmt(sync_field)}")
 
 
 def cmd_task_set_description(args: argparse.Namespace) -> None:

--- a/plugins/flow-next/scripts/flowctl.py
+++ b/plugins/flow-next/scripts/flowctl.py
@@ -1536,12 +1536,18 @@ def run_codex_exec(
     prompt: str,
     session_id: Optional[str] = None,
     sandbox: str = "read-only",
-    model: Optional[str] = None,
+    spec: Optional["BackendSpec"] = None,
 ) -> tuple[str, Optional[str], int, str]:
     """Run codex exec and return (stdout, thread_id, exit_code, stderr).
 
     If session_id provided, tries to resume. Falls back to new session if resume fails.
-    Model: FLOW_CODEX_MODEL env > parameter > default (gpt-5.4 + high reasoning).
+
+    ``spec``: a resolved ``BackendSpec`` (backend=codex) whose ``model`` and
+    ``effort`` are used verbatim. The spec is assumed to be already resolved
+    by ``resolve_review_spec()`` or ``.resolve()`` so env-var fills live
+    upstream — this function just reads ``spec.model`` / ``spec.effort``.
+    When ``spec`` is ``None`` (defensive path for non-review callers), fall
+    back to bare-codex resolution (env + registry defaults).
 
     Note: Prompt is passed via stdin (using '-') to avoid Windows command-line
     length limits (~8191 chars) and special character escaping issues. (GH-35)
@@ -1552,8 +1558,14 @@ def run_codex_exec(
         - stderr contains error output from the process
     """
     codex = require_codex()
-    # Model priority: env > parameter > default (gpt-5.4 + high reasoning = GPT 5.4 High)
-    effective_model = os.environ.get("FLOW_CODEX_MODEL") or model or "gpt-5.4"
+    # Resolve spec so model+effort are populated. Defensive: older call sites
+    # (or tests) may pass spec=None; treat that as bare-codex resolution.
+    if spec is None:
+        spec = BackendSpec("codex").resolve()
+    elif spec.model is None or spec.effort is None:
+        spec = spec.resolve()
+    effective_model = spec.model or "gpt-5.4"
+    effective_effort = spec.effort or "high"
 
     if session_id:
         # Try resume first - use stdin for prompt (model already set in original session)
@@ -1577,7 +1589,7 @@ def run_codex_exec(
             # Resume failed - fall through to new session
             pass
 
-    # New session with model + high reasoning effort
+    # New session with model + reasoning effort from resolved spec
     # --skip-git-repo-check: safe with read-only sandbox, allows reviews from /tmp etc (GH-33)
     # Use '-' to read prompt from stdin - avoids Windows CLI length limits (GH-35)
     cmd = [
@@ -1586,7 +1598,7 @@ def run_codex_exec(
         "--model",
         effective_model,
         "-c",
-        'model_reasoning_effort="high"',
+        f'model_reasoning_effort="{effective_effort}"',
         "--sandbox",
         sandbox,
         "--skip-git-repo-check",
@@ -1944,6 +1956,98 @@ def parse_backend_spec_lenient(
         return None
 
 
+def resolve_review_spec(
+    backend_hint: str, task_id: Optional[str] = None
+) -> BackendSpec:
+    """Resolve a fully-filled ``BackendSpec`` for a review invocation.
+
+    ``backend_hint`` is the command-level backend name (``"codex"`` or
+    ``"copilot"``) — what the user typed when running ``flowctl codex
+    impl-review`` vs ``flowctl copilot impl-review``. It anchors the fallback
+    when no per-task / per-epic / env / config spec is found.
+
+    Precedence (first hit wins, then ``.resolve()`` fills missing fields):
+      1. Per-task ``review`` field (stored spec; may be legacy → lenient parse)
+      2. Per-epic ``default_review`` field (stored spec; lenient parse)
+      3. ``FLOW_REVIEW_BACKEND`` env var (lenient parse — user-typed at shell,
+         but we tolerate stale values)
+      4. ``.flow/config.json`` ``review.backend`` (lenient parse)
+      5. Bare ``backend_hint`` — caller's CLI subcommand name
+
+    The resolved spec's backend is **not** forced to ``backend_hint`` when a
+    per-task / per-epic / env spec picked a different backend. Example: task
+    has ``review: "copilot:gpt-5.2"`` and user runs ``flowctl codex
+    impl-review`` — we return a copilot spec. The caller (cmd_codex_*_review)
+    decides whether to warn or honor it. Current call sites ignore the
+    mismatch and pass the spec straight to ``run_codex_exec`` /
+    ``run_copilot_exec``; the command name already pins the execution path.
+
+    This helper does NOT read ``--spec`` argv — cmd functions call
+    ``BackendSpec.parse(args.spec)`` directly when set (strict parse, since
+    the user just typed it).
+    """
+    # 1 + 2: per-task / per-epic stored specs
+    if task_id is not None and is_task_id(task_id) and ensure_flow_exists():
+        flow_dir = get_flow_dir()
+        task_path = flow_dir / TASKS_DIR / f"{task_id}.json"
+        if task_path.exists():
+            try:
+                task_data = normalize_task(
+                    json.loads(task_path.read_text(encoding="utf-8"))
+                )
+                task_review = task_data.get("review")
+                if task_review:
+                    parsed = parse_backend_spec_lenient(task_review, warn=True)
+                    if parsed is not None:
+                        return parsed.resolve()
+                # Epic fallback
+                epic_id = task_data.get("epic")
+                if epic_id:
+                    epic_path = flow_dir / EPICS_DIR / f"{epic_id}.json"
+                    if epic_path.exists():
+                        try:
+                            epic_data = normalize_epic(
+                                json.loads(
+                                    epic_path.read_text(encoding="utf-8")
+                                )
+                            )
+                            epic_review = epic_data.get("default_review")
+                            if epic_review:
+                                parsed = parse_backend_spec_lenient(
+                                    epic_review, warn=True
+                                )
+                                if parsed is not None:
+                                    return parsed.resolve()
+                        except (json.JSONDecodeError, OSError):
+                            pass
+            except (json.JSONDecodeError, OSError):
+                pass
+
+    # 3: FLOW_REVIEW_BACKEND env (spec-form or bare backend)
+    env_val = os.environ.get("FLOW_REVIEW_BACKEND", "").strip()
+    if env_val:
+        parsed = parse_backend_spec_lenient(env_val, warn=True)
+        if parsed is not None:
+            return parsed.resolve()
+
+    # 4: .flow/config.json review.backend
+    if ensure_flow_exists():
+        cfg_val = get_config("review.backend")
+        if cfg_val:
+            parsed = parse_backend_spec_lenient(str(cfg_val), warn=True)
+            if parsed is not None:
+                return parsed.resolve()
+
+    # 5: fall back to bare backend_hint and resolve defaults
+    if backend_hint not in BACKEND_REGISTRY:
+        # Defensive — caller always passes a known backend, but don't crash.
+        raise ValueError(
+            f"Unknown backend_hint: {backend_hint!r}. "
+            f"Valid: {sorted(BACKEND_REGISTRY.keys())}"
+        )
+    return BackendSpec(backend_hint).resolve()
+
+
 # --- Copilot Backend Helpers ---
 
 
@@ -1986,8 +2090,7 @@ def run_copilot_exec(
     prompt: str,
     session_id: str,
     repo_root: Path,
-    model: Optional[str] = None,
-    effort: Optional[str] = None,
+    spec: Optional["BackendSpec"] = None,
 ) -> tuple[str, str, int, str]:
     """Run copilot -p and return (stdout, session_id, exit_code, stderr).
 
@@ -2003,9 +2106,16 @@ def run_copilot_exec(
       syntax). The temp file is removed in ``finally`` so KeyboardInterrupt,
       TimeoutExpired, and non-zero exits all clean up.
 
-    Config cascade (env > parameter > default):
-    - Model:  FLOW_COPILOT_MODEL  > ``model``  > ``claude-opus-4.5``
-    - Effort: FLOW_COPILOT_EFFORT > ``effort`` > ``high``
+    ``spec``: a resolved ``BackendSpec`` (backend=copilot) whose ``model`` and
+    ``effort`` are used verbatim. Env-var fills happen upstream in
+    ``resolve_review_spec()`` / ``BackendSpec.resolve()``; this function
+    reads ``spec.model`` / ``spec.effort`` directly. When ``spec`` is
+    ``None`` (defensive / non-review callers), fall back to bare-copilot
+    resolution (env + registry defaults).
+
+    Claude-model effort skip: the ``--effort`` flag is passed unless
+    ``effective_model`` starts with ``claude-`` (Copilot rejects
+    reasoning-effort on Claude-family models).
 
     Returns:
         tuple: (stdout, session_id, exit_code, stderr)
@@ -2014,12 +2124,12 @@ def run_copilot_exec(
     """
     copilot = require_copilot()
 
-    effective_model = (
-        os.environ.get("FLOW_COPILOT_MODEL") or model or "gpt-5.2"
-    )
-    effective_effort = (
-        os.environ.get("FLOW_COPILOT_EFFORT") or effort or "high"
-    )
+    if spec is None:
+        spec = BackendSpec("copilot").resolve()
+    elif spec.model is None or spec.effort is None:
+        spec = spec.resolve()
+    effective_model = spec.model or "gpt-5.2"
+    effective_effort = spec.effort or "high"
 
     # For large prompts, stage to disk then read back. Copilot has no @file
     # syntax for -p, so we always end up with the prompt in argv — but the
@@ -6792,9 +6902,12 @@ def cmd_codex_impl_review(args: argparse.Namespace) -> None:
     except ValueError as e:
         error_exit(str(e), use_json=args.json, code=2)
 
+    # Resolve review spec (--spec overrides task/epic/env/config resolution)
+    resolved_spec = _resolve_codex_review_spec(args, task_id)
+
     # Run codex
     output, thread_id, exit_code, stderr = run_codex_exec(
-        prompt, session_id=session_id, sandbox=sandbox
+        prompt, session_id=session_id, sandbox=sandbox, spec=resolved_spec
     )
 
     # Check for sandbox failures (clear stale receipt and exit)
@@ -6852,6 +6965,9 @@ def cmd_codex_impl_review(args: argparse.Namespace) -> None:
             "base": base_branch,
             "verdict": verdict,
             "session_id": thread_id,
+            "model": resolved_spec.model,
+            "effort": resolved_spec.effort,
+            "spec": str(resolved_spec),
             "timestamp": now_iso(),
             "review": output,  # Full review feedback for fix loop
         }
@@ -6877,6 +6993,9 @@ def cmd_codex_impl_review(args: argparse.Namespace) -> None:
                 "verdict": verdict,
                 "session_id": thread_id,
                 "mode": "codex",
+                "model": resolved_spec.model,
+                "effort": resolved_spec.effort,
+                "spec": str(resolved_spec),
                 "standalone": standalone,
                 "review": output,  # Full review feedback for fix loop
             }
@@ -6884,6 +7003,30 @@ def cmd_codex_impl_review(args: argparse.Namespace) -> None:
     else:
         print(output)
         print(f"\nVERDICT={verdict or 'UNKNOWN'}")
+
+
+def _resolve_codex_review_spec(
+    args: argparse.Namespace, task_id: Optional[str]
+) -> BackendSpec:
+    """Resolve ``BackendSpec`` for a codex review command.
+
+    Precedence:
+      1. ``--spec`` argv (strict parse — user just typed it, surface errors)
+      2. ``resolve_review_spec("codex", task_id)`` — task/epic/env/config/defaults
+
+    The resolved spec's backend is whatever the source said (task spec might
+    request ``copilot:gpt-5.2`` from a codex command); the codex command
+    still executes via codex CLI because the subcommand name pins the path.
+    Model/effort from the spec are still honored (codex accepts whatever
+    model string you pass; misconfigured ones fail at codex-CLI layer).
+    """
+    spec_arg = getattr(args, "spec", None)
+    if spec_arg:
+        try:
+            return BackendSpec.parse(spec_arg).resolve()
+        except ValueError as e:
+            error_exit(f"Invalid --spec: {e}", use_json=args.json, code=2)
+    return resolve_review_spec("codex", task_id)
 
 
 def cmd_codex_plan_review(args: argparse.Namespace) -> None:
@@ -7008,9 +7151,12 @@ def cmd_codex_plan_review(args: argparse.Namespace) -> None:
     except ValueError as e:
         error_exit(str(e), use_json=args.json, code=2)
 
+    # Resolve review spec — plan reviews are epic-scoped (no task_id context)
+    resolved_spec = _resolve_codex_review_spec(args, None)
+
     # Run codex
     output, thread_id, exit_code, stderr = run_codex_exec(
-        prompt, session_id=session_id, sandbox=sandbox
+        prompt, session_id=session_id, sandbox=sandbox, spec=resolved_spec
     )
 
     # Check for sandbox failures (clear stale receipt and exit)
@@ -7064,6 +7210,9 @@ def cmd_codex_plan_review(args: argparse.Namespace) -> None:
             "mode": "codex",
             "verdict": verdict,
             "session_id": thread_id,
+            "model": resolved_spec.model,
+            "effort": resolved_spec.effort,
+            "spec": str(resolved_spec),
             "timestamp": now_iso(),
             "review": output,  # Full review feedback for fix loop
         }
@@ -7087,6 +7236,9 @@ def cmd_codex_plan_review(args: argparse.Namespace) -> None:
                 "verdict": verdict,
                 "session_id": thread_id,
                 "mode": "codex",
+                "model": resolved_spec.model,
+                "effort": resolved_spec.effort,
+                "spec": str(resolved_spec),
                 "review": output,  # Full review feedback for fix loop
             }
         )
@@ -7362,9 +7514,12 @@ def cmd_codex_completion_review(args: argparse.Namespace) -> None:
     except ValueError as e:
         error_exit(str(e), use_json=args.json, code=2)
 
+    # Resolve review spec — completion reviews are epic-scoped
+    resolved_spec = _resolve_codex_review_spec(args, None)
+
     # Run codex
     output, thread_id, exit_code, stderr = run_codex_exec(
-        prompt, session_id=session_id, sandbox=sandbox
+        prompt, session_id=session_id, sandbox=sandbox, spec=resolved_spec
     )
 
     # Check for sandbox failures
@@ -7419,6 +7574,9 @@ def cmd_codex_completion_review(args: argparse.Namespace) -> None:
             "base": base_branch,
             "verdict": verdict,
             "session_id": session_id_to_write,
+            "model": resolved_spec.model,
+            "effort": resolved_spec.effort,
+            "spec": str(resolved_spec),
             "timestamp": now_iso(),
             "review": output,  # Full review feedback for fix loop
         }
@@ -7443,6 +7601,9 @@ def cmd_codex_completion_review(args: argparse.Namespace) -> None:
                 "verdict": verdict,
                 "session_id": session_id_to_write,
                 "mode": "codex",
+                "model": resolved_spec.model,
+                "effort": resolved_spec.effort,
+                "spec": str(resolved_spec),
                 "review": output,
             }
         )
@@ -7454,17 +7615,26 @@ def cmd_codex_completion_review(args: argparse.Namespace) -> None:
 # --- Copilot Review Commands ---
 
 
-def _resolve_copilot_model_effort(
-    model_arg: Optional[str] = None, effort_arg: Optional[str] = None
-) -> tuple[str, str]:
-    """Resolve effective copilot model + effort using env > arg > default.
+def _resolve_copilot_review_spec(
+    args: argparse.Namespace, task_id: Optional[str]
+) -> BackendSpec:
+    """Resolve ``BackendSpec`` for a copilot review command.
 
-    Matches the cascade inside ``run_copilot_exec`` so the receipt reflects
-    the exact values sent to copilot.
+    Precedence:
+      1. ``--spec`` argv (strict parse — user just typed it, surface errors)
+      2. ``resolve_review_spec("copilot", task_id)`` — task/epic/env/config/defaults
+
+    Caller uses ``resolved.model`` / ``resolved.effort`` for receipts and
+    passes the spec to ``run_copilot_exec`` which honors ``spec.model`` /
+    ``spec.effort`` and still skips ``--effort`` for ``claude-*`` models.
     """
-    model = os.environ.get("FLOW_COPILOT_MODEL") or model_arg or "gpt-5.2"
-    effort = os.environ.get("FLOW_COPILOT_EFFORT") or effort_arg or "high"
-    return model, effort
+    spec_arg = getattr(args, "spec", None)
+    if spec_arg:
+        try:
+            return BackendSpec.parse(spec_arg).resolve()
+        except ValueError as e:
+            error_exit(f"Invalid --spec: {e}", use_json=args.json, code=2)
+    return resolve_review_spec("copilot", task_id)
 
 
 def cmd_copilot_impl_review(args: argparse.Namespace) -> None:
@@ -7595,13 +7765,15 @@ def cmd_copilot_impl_review(args: argparse.Namespace) -> None:
             )
             prompt = rereview_preamble + prompt
 
-    # Resolve model + effort for receipt (matches run_copilot_exec cascade)
-    effective_model, effective_effort = _resolve_copilot_model_effort()
+    # Resolve review spec (task/epic/env/config/defaults or --spec override)
+    resolved_spec = _resolve_copilot_review_spec(args, task_id)
+    effective_model = resolved_spec.model or "gpt-5.2"
+    effective_effort = resolved_spec.effort or "high"
 
     # Run copilot
     repo_root = get_repo_root()
     output, returned_session_id, exit_code, stderr = run_copilot_exec(
-        prompt, session_id=session_id, repo_root=repo_root
+        prompt, session_id=session_id, repo_root=repo_root, spec=resolved_spec
     )
 
     # Handle failures (no sandbox branch — copilot has no sandbox)
@@ -7642,6 +7814,7 @@ def cmd_copilot_impl_review(args: argparse.Namespace) -> None:
             "session_id": returned_session_id,
             "model": effective_model,
             "effort": effective_effort,
+            "spec": str(resolved_spec),
             "timestamp": now_iso(),
             "review": output,
         }
@@ -7667,6 +7840,7 @@ def cmd_copilot_impl_review(args: argparse.Namespace) -> None:
                 "mode": "copilot",
                 "model": effective_model,
                 "effort": effective_effort,
+                "spec": str(resolved_spec),
                 "standalone": standalone,
                 "review": output,
             }
@@ -7778,10 +7952,13 @@ def cmd_copilot_plan_review(args: argparse.Namespace) -> None:
         rereview_preamble = build_rereview_preamble(spec_files, "plan", files_embedded)
         prompt = rereview_preamble + prompt
 
-    effective_model, effective_effort = _resolve_copilot_model_effort()
+    # Resolve review spec — plan reviews are epic-scoped (no task_id context)
+    resolved_spec = _resolve_copilot_review_spec(args, None)
+    effective_model = resolved_spec.model or "gpt-5.2"
+    effective_effort = resolved_spec.effort or "high"
 
     output, returned_session_id, exit_code, stderr = run_copilot_exec(
-        prompt, session_id=session_id, repo_root=repo_root
+        prompt, session_id=session_id, repo_root=repo_root, spec=resolved_spec
     )
 
     if exit_code != 0:
@@ -7817,6 +7994,7 @@ def cmd_copilot_plan_review(args: argparse.Namespace) -> None:
             "session_id": returned_session_id,
             "model": effective_model,
             "effort": effective_effort,
+            "spec": str(resolved_spec),
             "timestamp": now_iso(),
             "review": output,
         }
@@ -7840,6 +8018,7 @@ def cmd_copilot_plan_review(args: argparse.Namespace) -> None:
                 "mode": "copilot",
                 "model": effective_model,
                 "effort": effective_effort,
+                "spec": str(resolved_spec),
                 "review": output,
             }
         )
@@ -7959,11 +8138,14 @@ def cmd_copilot_completion_review(args: argparse.Namespace) -> None:
             )
             prompt = rereview_preamble + prompt
 
-    effective_model, effective_effort = _resolve_copilot_model_effort()
+    # Resolve review spec — completion reviews are epic-scoped
+    resolved_spec = _resolve_copilot_review_spec(args, None)
+    effective_model = resolved_spec.model or "gpt-5.2"
+    effective_effort = resolved_spec.effort or "high"
 
     repo_root = get_repo_root()
     output, returned_session_id, exit_code, stderr = run_copilot_exec(
-        prompt, session_id=session_id, repo_root=repo_root
+        prompt, session_id=session_id, repo_root=repo_root, spec=resolved_spec
     )
 
     if exit_code != 0:
@@ -8003,6 +8185,7 @@ def cmd_copilot_completion_review(args: argparse.Namespace) -> None:
             "session_id": session_id_to_write,
             "model": effective_model,
             "effort": effective_effort,
+            "spec": str(resolved_spec),
             "timestamp": now_iso(),
             "review": output,
         }
@@ -8027,6 +8210,7 @@ def cmd_copilot_completion_review(args: argparse.Namespace) -> None:
                 "mode": "copilot",
                 "model": effective_model,
                 "effort": effective_effort,
+                "spec": str(resolved_spec),
                 "review": output,
             }
         )
@@ -8984,6 +9168,11 @@ def main() -> None:
         default="auto",
         help="Sandbox mode (auto: danger-full-access on Windows, read-only on Unix)",
     )
+    p_codex_impl.add_argument(
+        "--spec",
+        help="Backend spec override (e.g. 'codex:gpt-5.2:medium'). "
+        "Overrides task/epic/env/config resolution. Strict parse.",
+    )
     p_codex_impl.set_defaults(func=cmd_codex_impl_review)
 
     p_codex_plan = codex_sub.add_parser("plan-review", help="Plan review")
@@ -9004,6 +9193,11 @@ def main() -> None:
         default="auto",
         help="Sandbox mode (auto: danger-full-access on Windows, read-only on Unix)",
     )
+    p_codex_plan.add_argument(
+        "--spec",
+        help="Backend spec override (e.g. 'codex:gpt-5.2:medium'). "
+        "Overrides env/config resolution. Strict parse.",
+    )
     p_codex_plan.set_defaults(func=cmd_codex_plan_review)
 
     p_codex_completion = codex_sub.add_parser(
@@ -9022,6 +9216,11 @@ def main() -> None:
         choices=["read-only", "workspace-write", "danger-full-access", "auto"],
         default="auto",
         help="Sandbox mode (auto: danger-full-access on Windows, read-only on Unix)",
+    )
+    p_codex_completion.add_argument(
+        "--spec",
+        help="Backend spec override (e.g. 'codex:gpt-5.2:medium'). "
+        "Overrides env/config resolution. Strict parse.",
     )
     p_codex_completion.set_defaults(func=cmd_codex_completion_review)
 
@@ -9058,6 +9257,11 @@ def main() -> None:
         "--receipt", help="Receipt file path for session continuity"
     )
     p_copilot_impl.add_argument("--json", action="store_true", help="JSON output")
+    p_copilot_impl.add_argument(
+        "--spec",
+        help="Backend spec override (e.g. 'copilot:claude-opus-4.5:xhigh'). "
+        "Overrides task/epic/env/config resolution. Strict parse.",
+    )
     p_copilot_impl.set_defaults(func=cmd_copilot_impl_review)
 
     p_copilot_plan = copilot_sub.add_parser("plan-review", help="Plan review")
@@ -9072,6 +9276,11 @@ def main() -> None:
         "--receipt", help="Receipt file path for session continuity"
     )
     p_copilot_plan.add_argument("--json", action="store_true", help="JSON output")
+    p_copilot_plan.add_argument(
+        "--spec",
+        help="Backend spec override (e.g. 'copilot:claude-opus-4.5:xhigh'). "
+        "Overrides env/config resolution. Strict parse.",
+    )
     p_copilot_plan.set_defaults(func=cmd_copilot_plan_review)
 
     p_copilot_completion = copilot_sub.add_parser(
@@ -9087,6 +9296,11 @@ def main() -> None:
         "--receipt", help="Receipt file path for session continuity"
     )
     p_copilot_completion.add_argument("--json", action="store_true", help="JSON output")
+    p_copilot_completion.add_argument(
+        "--spec",
+        help="Backend spec override (e.g. 'copilot:claude-opus-4.5:xhigh'). "
+        "Overrides env/config resolution. Strict parse.",
+    )
     p_copilot_completion.set_defaults(func=cmd_copilot_completion_review)
 
     args = parser.parse_args()

--- a/plugins/flow-next/scripts/smoke_test.sh
+++ b/plugins/flow-next/scripts/smoke_test.sh
@@ -1184,6 +1184,111 @@ else
   FAIL=$((FAIL + 1))
 fi
 
+echo -e "${YELLOW}--- backend spec validation (fn-28.2) ---${NC}"
+# Fresh epic + task for backend spec tests
+BSPEC_EPIC_JSON="$(scripts/flowctl epic create --title "Backend spec test" --json)"
+BSPEC_EPIC="$(echo "$BSPEC_EPIC_JSON" | "$PYTHON_BIN" -c 'import json,sys; print(json.load(sys.stdin)["id"])')"
+scripts/flowctl task create --epic "$BSPEC_EPIC" --title "Backend task" --json >/dev/null
+BSPEC_TASK="${BSPEC_EPIC}.1"
+
+# Test 1: valid full spec accepted
+if scripts/flowctl task set-backend "$BSPEC_TASK" --review "codex:gpt-5.4:xhigh" --json >/dev/null 2>&1; then
+  echo -e "${GREEN}✓${NC} set-backend accepts valid codex:gpt-5.4:xhigh spec"
+  PASS=$((PASS + 1))
+else
+  echo -e "${RED}✗${NC} set-backend rejected valid codex:gpt-5.4:xhigh spec"
+  FAIL=$((FAIL + 1))
+fi
+
+# Test 2: invalid model rejected
+invalid_out="$(scripts/flowctl task set-backend "$BSPEC_TASK" --review "codex:gpt-99" --json 2>&1 || true)"
+if echo "$invalid_out" | grep -q '"success": false' && echo "$invalid_out" | grep -q "Unknown model for codex"; then
+  echo -e "${GREEN}✓${NC} set-backend rejects unknown codex model with helpful error"
+  PASS=$((PASS + 1))
+else
+  echo -e "${RED}✗${NC} set-backend didn't reject unknown codex model cleanly: $invalid_out"
+  FAIL=$((FAIL + 1))
+fi
+
+# Test 3: rp with model rejected
+rp_out="$(scripts/flowctl task set-backend "$BSPEC_TASK" --review "rp:claude-opus" --json 2>&1 || true)"
+if echo "$rp_out" | grep -q '"success": false' && echo "$rp_out" | grep -q "does not accept a model"; then
+  echo -e "${GREEN}✓${NC} set-backend rejects rp:model spec"
+  PASS=$((PASS + 1))
+else
+  echo -e "${RED}✗${NC} set-backend didn't reject rp:model: $rp_out"
+  FAIL=$((FAIL + 1))
+fi
+
+# Test 4: copilot xhigh accepted
+if scripts/flowctl task set-backend "$BSPEC_TASK" --review "copilot:claude-opus-4.5:xhigh" --json >/dev/null 2>&1; then
+  echo -e "${GREEN}✓${NC} set-backend accepts copilot:claude-opus-4.5:xhigh"
+  PASS=$((PASS + 1))
+else
+  echo -e "${RED}✗${NC} set-backend rejected valid copilot xhigh spec"
+  FAIL=$((FAIL + 1))
+fi
+
+# Test 5: show-backend json has raw + resolved + sources
+show_out="$(scripts/flowctl task show-backend "$BSPEC_TASK" --json)"
+raw_val="$(echo "$show_out" | "$PYTHON_BIN" -c 'import json,sys; print(json.load(sys.stdin)["review"]["raw"])')"
+resolved_str="$(echo "$show_out" | "$PYTHON_BIN" -c 'import json,sys; print(json.load(sys.stdin)["review"]["resolved"]["str"])')"
+effort_src="$(echo "$show_out" | "$PYTHON_BIN" -c 'import json,sys; print(json.load(sys.stdin)["review"]["effort_source"])')"
+if [[ "$raw_val" == "copilot:claude-opus-4.5:xhigh" && "$resolved_str" == "copilot:claude-opus-4.5:xhigh" && "$effort_src" == "spec" ]]; then
+  echo -e "${GREEN}✓${NC} show-backend emits raw + resolved + source fields"
+  PASS=$((PASS + 1))
+else
+  echo -e "${RED}✗${NC} show-backend output wrong: raw=$raw_val resolved=$resolved_str effort_src=$effort_src"
+  FAIL=$((FAIL + 1))
+fi
+
+# Test 6: legacy stored value (codex:gpt-5.4-high dash form) falls back with warning
+# Directly patch the task JSON to simulate pre-epic stored data.
+"$PYTHON_BIN" -c "
+import json
+p = '.flow/tasks/${BSPEC_TASK}.json'
+d = json.load(open(p))
+d['review'] = 'codex:gpt-5.4-high'
+json.dump(d, open(p, 'w'))
+"
+legacy_stdout="$(scripts/flowctl task show-backend "$BSPEC_TASK" --json 2>/tmp/legacy_stderr_$$.txt)"
+legacy_stderr="$(cat /tmp/legacy_stderr_$$.txt)"
+legacy_backend="$(echo "$legacy_stdout" | "$PYTHON_BIN" -c 'import json,sys; print(json.load(sys.stdin)["review"]["resolved"]["backend"])')"
+legacy_raw="$(echo "$legacy_stdout" | "$PYTHON_BIN" -c 'import json,sys; print(json.load(sys.stdin)["review"]["raw"])')"
+trash /tmp/legacy_stderr_$$.txt 2>/dev/null || rm -f /tmp/legacy_stderr_$$.txt
+if [[ "$legacy_backend" == "codex" && "$legacy_raw" == "codex:gpt-5.4-high" ]] && echo "$legacy_stderr" | grep -qi "warning:"; then
+  echo -e "${GREEN}✓${NC} legacy spec codex:gpt-5.4-high falls back to bare codex with stderr warning"
+  PASS=$((PASS + 1))
+else
+  echo -e "${RED}✗${NC} legacy fallback broken: backend=$legacy_backend raw=$legacy_raw stderr=$legacy_stderr"
+  FAIL=$((FAIL + 1))
+fi
+
+# Test 7: empty-string clears field without validation
+if scripts/flowctl task set-backend "$BSPEC_TASK" --review "" --json >/dev/null 2>&1; then
+  cleared="$(scripts/flowctl task show-backend "$BSPEC_TASK" --json | "$PYTHON_BIN" -c 'import json,sys; print(json.load(sys.stdin)["review"]["raw"])')"
+  if [[ "$cleared" == "None" ]]; then
+    echo -e "${GREEN}✓${NC} empty string clears backend spec"
+    PASS=$((PASS + 1))
+  else
+    echo -e "${RED}✗${NC} empty string didn't clear: raw=$cleared"
+    FAIL=$((FAIL + 1))
+  fi
+else
+  echo -e "${RED}✗${NC} empty string rejected by validator (should bypass)"
+  FAIL=$((FAIL + 1))
+fi
+
+# Test 8: epic set-backend also validates
+epic_invalid="$(scripts/flowctl epic set-backend "$BSPEC_EPIC" --impl "bogus:foo" --json 2>&1 || true)"
+if echo "$epic_invalid" | grep -q '"success": false' && echo "$epic_invalid" | grep -q "Unknown backend"; then
+  echo -e "${GREEN}✓${NC} epic set-backend rejects unknown backend"
+  PASS=$((PASS + 1))
+else
+  echo -e "${RED}✗${NC} epic set-backend didn't reject unknown backend: $epic_invalid"
+  FAIL=$((FAIL + 1))
+fi
+
 echo ""
 echo -e "${YELLOW}=== Results ===${NC}"
 echo -e "Passed: ${GREEN}$PASS${NC}"

--- a/plugins/flow-next/skills/flow-next-epic-review/SKILL.md
+++ b/plugins/flow-next/skills/flow-next-epic-review/SKILL.md
@@ -22,8 +22,8 @@ FLOWCTL="${DROID_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT}}/scripts/flowctl"
 
 **Priority** (first match wins):
 1. `--review=rp|codex|copilot|none` argument
-2. `FLOW_REVIEW_BACKEND` env var (`rp`, `codex`, `copilot`, `none`)
-3. `.flow/config.json` → `review.backend`
+2. `FLOW_REVIEW_BACKEND` env var — bare backend (`rp`, `codex`, `copilot`, `none`) OR spec form (`codex:gpt-5.4:xhigh`, `copilot:claude-opus-4.5`)
+3. `.flow/config.json` → `review.backend` (same bare / spec forms)
 4. **Error** - no auto-detection
 
 ### Parse from arguments first
@@ -53,8 +53,10 @@ echo "Review backend: $BACKEND (override: --review=rp|codex|copilot|none)"
 ### Backend at a glance
 
 - **rp** — RepoPrompt (macOS GUI); builder auto-selects context. Primary backend.
-- **codex** — Codex CLI (cross-platform); uses OpenAI models (default `gpt-5.4`). `FLOW_CODEX_MODEL` / `FLOW_CODEX_EFFORT` env vars.
-- **copilot** — GitHub Copilot CLI (cross-platform); supports Claude Opus/Sonnet/Haiku 4.5 and GPT-5.2 families via a Copilot subscription. `FLOW_COPILOT_MODEL` / `FLOW_COPILOT_EFFORT` env vars (no CLI flags).
+- **codex** — Codex CLI (cross-platform); uses OpenAI models (default `gpt-5.4`). `FLOW_CODEX_MODEL` / `FLOW_CODEX_EFFORT` env vars, or `--spec codex:gpt-5.4:xhigh`.
+- **copilot** — GitHub Copilot CLI (cross-platform); supports Claude Opus/Sonnet/Haiku 4.5 and GPT-5.2 families via a Copilot subscription. `FLOW_COPILOT_MODEL` / `FLOW_COPILOT_EFFORT` env vars, or `--spec copilot:claude-opus-4.5:xhigh`.
+
+**Spec grammar:** `backend[:model[:effort]]` — `FLOW_REVIEW_BACKEND` and `.flow/config.json review.backend` both accept this. Examples: `codex`, `codex:gpt-5.2`, `copilot:claude-opus-4.5:xhigh`. Per-epic `default_review` (set via `flowctl epic set-backend`) overrides env.
 
 ## Critical Rules
 
@@ -73,7 +75,7 @@ echo "Review backend: $BACKEND (override: --review=rp|codex|copilot|none)"
 **For copilot backend:**
 1. Use `$FLOWCTL copilot completion-review` exclusively
 2. Pass `--receipt` for session continuity on re-reviews (session only resumes when prior receipt has `mode == "copilot"`)
-3. Model + effort are env-only: `FLOW_COPILOT_MODEL`, `FLOW_COPILOT_EFFORT` (no CLI flags)
+3. Model + effort resolved via (first match wins): `--spec backend:model:effort` flag, per-epic `default_review`, `FLOW_REVIEW_BACKEND` spec, `FLOW_COPILOT_MODEL` / `FLOW_COPILOT_EFFORT` env vars, registry defaults
 4. Parse verdict from command output
 
 **For all backends:**
@@ -129,8 +131,10 @@ On NEEDS_WORK: fix code, commit, re-run (receipt enables session continuity).
 ```bash
 RECEIPT_PATH="${REVIEW_RECEIPT_PATH:-/tmp/completion-review-receipt.json}"
 
-# Optional: override model + effort via env (no CLI flags)
-# FLOW_COPILOT_MODEL=gpt-5.2 FLOW_COPILOT_EFFORT=high \
+# Override model + effort (pick one):
+#   --spec copilot:claude-opus-4.5:xhigh   (preferred)
+#   FLOW_REVIEW_BACKEND=copilot:claude-opus-4.5:xhigh
+#   FLOW_COPILOT_MODEL=gpt-5.2 FLOW_COPILOT_EFFORT=high
 
 $FLOWCTL copilot completion-review "$EPIC_ID" --receipt "$RECEIPT_PATH"
 # Output includes VERDICT=SHIP|NEEDS_WORK

--- a/plugins/flow-next/skills/flow-next-epic-review/workflow.md
+++ b/plugins/flow-next/skills/flow-next-epic-review/workflow.md
@@ -22,6 +22,8 @@ FLOWCTL="${DROID_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT}}/scripts/flowctl"
 REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 
 # Priority: --review flag > env > config (flag parsed in SKILL.md)
+# Text output is bare backend name for back-compat grep. --json returns full
+# resolved spec (backend, spec, model, effort, source).
 BACKEND=$($FLOWCTL review-backend)
 
 if [[ "$BACKEND" == "ASK" ]]; then
@@ -32,6 +34,17 @@ fi
 
 echo "Review backend: $BACKEND"
 ```
+
+**Spec-form env var (optional):** `FLOW_REVIEW_BACKEND` accepts bare or full spec:
+
+```bash
+FLOW_REVIEW_BACKEND=codex:gpt-5.4:xhigh $FLOWCTL codex completion-review "$EPIC_ID" --receipt "$RECEIPT_PATH"
+FLOW_REVIEW_BACKEND=copilot:claude-opus-4.5 $FLOWCTL copilot completion-review "$EPIC_ID" --receipt "$RECEIPT_PATH"
+# Or pass spec directly:
+$FLOWCTL codex completion-review "$EPIC_ID" --spec "codex:gpt-5.4:xhigh" --receipt "$RECEIPT_PATH"
+```
+
+Per-epic `default_review` (set via `flowctl epic set-backend`) overrides env.
 
 **If backend is "none"**: Skip review, inform user, and exit cleanly (no error).
 
@@ -92,9 +105,11 @@ $FLOWCTL show "$EPIC_ID" --json
 ```bash
 RECEIPT_PATH="${REVIEW_RECEIPT_PATH:-/tmp/completion-review-receipt.json}"
 
-# Runtime config via env vars (no CLI flags for model/effort):
-#   FLOW_COPILOT_MODEL   (default gpt-5.2)
-#   FLOW_COPILOT_EFFORT  (default high)
+# Runtime config:
+#   --spec <spec>           full spec (backend:model:effort), highest priority
+#   FLOW_REVIEW_BACKEND     spec-form ok: copilot:claude-opus-4.5:xhigh
+#   FLOW_COPILOT_MODEL      fills missing model only (default gpt-5.2)
+#   FLOW_COPILOT_EFFORT     fills missing effort only (default high)
 
 $FLOWCTL copilot completion-review "$EPIC_ID" --receipt "$RECEIPT_PATH"
 ```
@@ -113,7 +128,9 @@ If `VERDICT=NEEDS_WORK`:
 ### Step 4: Receipt
 
 Receipt is written automatically by `flowctl copilot completion-review` when `--receipt` provided.
-Format: `{"type":"completion_review","id":"<epic-id>","mode":"copilot","verdict":"<verdict>","session_id":"<uuid>","model":"<model>","effort":"<effort>","timestamp":"..."}`
+Format: `{"type":"completion_review","id":"<epic-id>","mode":"copilot","verdict":"<verdict>","session_id":"<uuid>","model":"<model>","effort":"<effort>","spec":"copilot:<model>:<effort>","timestamp":"..."}`
+
+The `spec` field is the canonical round-trippable form (added in fn-28.3). `model` + `effort` remain for backward compatibility.
 
 Session resume guard: re-review only resumes the copilot session when the existing receipt at `$RECEIPT_PATH` has `mode == "copilot"`. Cross-backend switches start a fresh session.
 
@@ -424,6 +441,6 @@ If verdict is NEEDS_WORK:
 
 **Copilot backend only:**
 - **Direct copilot calls** - Must use `flowctl copilot` wrappers
-- **Inventing `--model`/`--effort` CLI flags** - Those are env-only (`FLOW_COPILOT_MODEL`, `FLOW_COPILOT_EFFORT`)
+- **Inventing `--model`/`--effort` CLI flags** - Use `--spec` for a full backend:model:effort value, or `FLOW_COPILOT_MODEL` / `FLOW_COPILOT_EFFORT` env vars to fill individual fields
 - **Using `--continue`** - Conflicts with parallel usage; session resume uses `--resume=<uuid>` under the hood via `--receipt`
 - **Assuming cross-backend session continuity** - Resume only works when prior receipt has `mode == "copilot"`

--- a/plugins/flow-next/skills/flow-next-impl-review/SKILL.md
+++ b/plugins/flow-next/skills/flow-next-impl-review/SKILL.md
@@ -22,8 +22,8 @@ FLOWCTL="${DROID_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT}}/scripts/flowctl"
 
 **Priority** (first match wins):
 1. `--review=rp|codex|copilot|export|none` argument
-2. `FLOW_REVIEW_BACKEND` env var (`rp`, `codex`, `copilot`, `none`)
-3. `.flow/config.json` → `review.backend`
+2. `FLOW_REVIEW_BACKEND` env var — bare backend (`rp`, `codex`, `copilot`, `none`) OR spec form (`codex:gpt-5.4:xhigh`, `copilot:claude-opus-4.5`)
+3. `.flow/config.json` → `review.backend` (same bare / spec forms)
 4. **Error** - no auto-detection
 
 ### Parse from arguments first
@@ -54,8 +54,10 @@ echo "Review backend: $BACKEND (override: --review=rp|codex|copilot|none)"
 ### Backend at a glance
 
 - **rp** — RepoPrompt (macOS GUI); builder auto-selects context. Primary backend.
-- **codex** — Codex CLI (cross-platform); uses OpenAI models (default `gpt-5.4`). `FLOW_CODEX_MODEL` / `FLOW_CODEX_EFFORT` env vars.
-- **copilot** — GitHub Copilot CLI (cross-platform); supports Claude Opus/Sonnet/Haiku 4.5 and GPT-5.2 families via a Copilot subscription. `FLOW_COPILOT_MODEL` / `FLOW_COPILOT_EFFORT` env vars (no CLI flags).
+- **codex** — Codex CLI (cross-platform); uses OpenAI models (default `gpt-5.4`). `FLOW_CODEX_MODEL` / `FLOW_CODEX_EFFORT` env vars, or `--spec codex:gpt-5.4:xhigh`.
+- **copilot** — GitHub Copilot CLI (cross-platform); supports Claude Opus/Sonnet/Haiku 4.5 and GPT-5.2 families via a Copilot subscription. `FLOW_COPILOT_MODEL` / `FLOW_COPILOT_EFFORT` env vars, or `--spec copilot:claude-opus-4.5:xhigh`.
+
+**Spec grammar:** `backend[:model[:effort]]` — `FLOW_REVIEW_BACKEND` and `.flow/config.json review.backend` both accept this. Examples: `codex`, `codex:gpt-5.2`, `copilot:claude-opus-4.5:xhigh`. Per-task `review` (set via `flowctl task set-backend`) overrides env.
 
 ## Critical Rules
 
@@ -74,7 +76,7 @@ echo "Review backend: $BACKEND (override: --review=rp|codex|copilot|none)"
 **For copilot backend:**
 1. Use `$FLOWCTL copilot impl-review` exclusively
 2. Pass `--receipt` for session continuity on re-reviews (session only resumes when prior receipt has `mode == "copilot"`)
-3. Model + effort are env-only: `FLOW_COPILOT_MODEL`, `FLOW_COPILOT_EFFORT` (no CLI flags)
+3. Model + effort resolved via (first match wins): `--spec backend:model:effort` flag, per-task `review`, `FLOW_REVIEW_BACKEND` spec, `FLOW_COPILOT_MODEL` / `FLOW_COPILOT_EFFORT` env vars, registry defaults
 4. Parse verdict from command output
 
 **For all backends:**
@@ -142,8 +144,10 @@ On NEEDS_WORK: fix code, commit, re-run (receipt enables session continuity).
 ```bash
 RECEIPT_PATH="${REVIEW_RECEIPT_PATH:-/tmp/impl-review-receipt.json}"
 
-# Optional: override model + effort via env (no CLI flags)
-# FLOW_COPILOT_MODEL=gpt-5.2 FLOW_COPILOT_EFFORT=high \
+# Override model + effort (pick one):
+#   --spec copilot:claude-opus-4.5:xhigh   (preferred, explicit)
+#   FLOW_REVIEW_BACKEND=copilot:claude-opus-4.5:xhigh  (env, cascades through `review-backend`)
+#   FLOW_COPILOT_MODEL=gpt-5.2 FLOW_COPILOT_EFFORT=high  (env per-field; fills only missing)
 
 if [[ -n "$BASE_COMMIT" ]]; then
   $FLOWCTL copilot impl-review "$TASK_ID" --base "$BASE_COMMIT" --receipt "$RECEIPT_PATH"

--- a/plugins/flow-next/skills/flow-next-impl-review/workflow.md
+++ b/plugins/flow-next/skills/flow-next-impl-review/workflow.md
@@ -18,6 +18,9 @@ FLOWCTL="${DROID_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT}}/scripts/flowctl"
 REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 
 # Priority: --review flag > env > config (flag parsed in SKILL.md)
+# Text output is bare backend name for back-compat grep. The same command in
+# --json mode returns {backend, spec, model, effort, source} — use that if you
+# need the model / effort resolved from a spec-form env value.
 BACKEND=$($FLOWCTL review-backend)
 
 if [[ "$BACKEND" == "ASK" ]]; then
@@ -28,6 +31,22 @@ fi
 
 echo "Review backend: $BACKEND (override: --review=rp|codex|copilot|none)"
 ```
+
+**Spec-form env var (optional):** `FLOW_REVIEW_BACKEND` accepts bare or full spec:
+
+```bash
+# Bare backend (back-compat)
+FLOW_REVIEW_BACKEND=codex $FLOWCTL codex impl-review "$TASK_ID" --receipt "$RECEIPT_PATH"
+
+# Full spec — model + effort resolved automatically
+FLOW_REVIEW_BACKEND=codex:gpt-5.4:xhigh $FLOWCTL codex impl-review "$TASK_ID" --receipt "$RECEIPT_PATH"
+FLOW_REVIEW_BACKEND=copilot:claude-opus-4.5 $FLOWCTL copilot impl-review "$TASK_ID" --receipt "$RECEIPT_PATH"
+
+# Or pass spec directly (preferred for one-offs, avoids env pollution):
+$FLOWCTL codex impl-review "$TASK_ID" --spec "codex:gpt-5.4:xhigh" --receipt "$RECEIPT_PATH"
+```
+
+Per-task `review` (set via `flowctl task set-backend`) overrides env.
 
 **If backend is "none"**: Skip review, inform user, and exit cleanly (no error).
 
@@ -108,9 +127,12 @@ git log ${DIFF_BASE}..HEAD --oneline
 ```bash
 RECEIPT_PATH="${REVIEW_RECEIPT_PATH:-/tmp/impl-review-receipt.json}"
 
-# Runtime config via env vars (no CLI flags for model/effort):
-#   FLOW_COPILOT_MODEL   (default gpt-5.2)
-#   FLOW_COPILOT_EFFORT  (default high; values: low|medium|high|xhigh)
+# Runtime config:
+#   --spec <spec>           full spec (backend:model:effort), highest priority
+#   FLOW_REVIEW_BACKEND     env (spec-form ok: copilot:claude-opus-4.5:xhigh)
+#   FLOW_COPILOT_MODEL      env (fills missing model only; default gpt-5.2)
+#   FLOW_COPILOT_EFFORT     env (fills missing effort only; default high)
+#   per-task stored review  via `flowctl task set-backend` (highest if set)
 
 $FLOWCTL copilot impl-review "$TASK_ID" --base "$DIFF_BASE" --receipt "$RECEIPT_PATH"
 ```
@@ -129,7 +151,9 @@ If `VERDICT=NEEDS_WORK`:
 ### Step 4: Receipt
 
 Receipt is written automatically by `flowctl copilot impl-review` when `--receipt` provided.
-Format: `{"type":"impl_review","id":"<id>","mode":"copilot","verdict":"<verdict>","session_id":"<uuid>","model":"<model>","effort":"<effort>","timestamp":"..."}`
+Format: `{"type":"impl_review","id":"<id>","mode":"copilot","verdict":"<verdict>","session_id":"<uuid>","model":"<model>","effort":"<effort>","spec":"copilot:<model>:<effort>","timestamp":"..."}`
+
+The `spec` field is the canonical round-trippable form (added in fn-28.3). `model` + `effort` remain for backward compatibility.
 
 Session resume guard: re-review only resumes the copilot session when the existing receipt at `$RECEIPT_PATH` has `mode == "copilot"`. A cross-backend switch (e.g., codex receipt at the same path) starts a fresh session.
 
@@ -403,6 +427,6 @@ If verdict is NEEDS_WORK:
 
 **Copilot backend only:**
 - **Direct copilot calls** - Must use `flowctl copilot` wrappers
-- **Inventing `--model`/`--effort` CLI flags** - Those are env-only (`FLOW_COPILOT_MODEL`, `FLOW_COPILOT_EFFORT`)
+- **Inventing `--model`/`--effort` CLI flags** - Use `--spec` for a full backend:model:effort value, or `FLOW_COPILOT_MODEL` / `FLOW_COPILOT_EFFORT` env vars to fill individual fields
 - **Using `--continue`** - Conflicts with parallel usage; session resume uses `--resume=<uuid>` under the hood via `--receipt`
 - **Assuming cross-backend session continuity** - Resume only works when prior receipt has `mode == "copilot"`

--- a/plugins/flow-next/skills/flow-next-plan-review/SKILL.md
+++ b/plugins/flow-next/skills/flow-next-plan-review/SKILL.md
@@ -22,8 +22,8 @@ FLOWCTL="${DROID_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT}}/scripts/flowctl"
 
 **Priority** (first match wins):
 1. `--review=rp|codex|copilot|export|none` argument
-2. `FLOW_REVIEW_BACKEND` env var (`rp`, `codex`, `copilot`, `none`)
-3. `.flow/config.json` → `review.backend`
+2. `FLOW_REVIEW_BACKEND` env var — bare backend (`rp`, `codex`, `copilot`, `none`) OR spec form (`codex:gpt-5.4:xhigh`, `copilot:claude-opus-4.5`)
+3. `.flow/config.json` → `review.backend` (same bare / spec forms)
 4. **Error** - no auto-detection
 
 ### Parse from arguments first
@@ -55,8 +55,10 @@ echo "Review backend: $BACKEND (override: --review=rp|codex|copilot|none)"
 ### Backend at a glance
 
 - **rp** — RepoPrompt (macOS GUI); builder auto-selects context. Primary backend.
-- **codex** — Codex CLI (cross-platform); uses OpenAI models (default `gpt-5.4`). `FLOW_CODEX_MODEL` / `FLOW_CODEX_EFFORT` env vars.
-- **copilot** — GitHub Copilot CLI (cross-platform); supports Claude Opus/Sonnet/Haiku 4.5 and GPT-5.2 families via a Copilot subscription. `FLOW_COPILOT_MODEL` / `FLOW_COPILOT_EFFORT` env vars (no CLI flags).
+- **codex** — Codex CLI (cross-platform); uses OpenAI models (default `gpt-5.4`). `FLOW_CODEX_MODEL` / `FLOW_CODEX_EFFORT` env vars, or `--spec codex:gpt-5.4:xhigh`.
+- **copilot** — GitHub Copilot CLI (cross-platform); supports Claude Opus/Sonnet/Haiku 4.5 and GPT-5.2 families via a Copilot subscription. `FLOW_COPILOT_MODEL` / `FLOW_COPILOT_EFFORT` env vars, or `--spec copilot:claude-opus-4.5:xhigh`.
+
+**Spec grammar:** `backend[:model[:effort]]` — `FLOW_REVIEW_BACKEND` and `.flow/config.json review.backend` both accept this. Examples: `codex`, `codex:gpt-5.2`, `copilot:claude-opus-4.5:xhigh`. Per-epic `default_review` (set via `flowctl epic set-backend`) overrides env.
 
 ## Critical Rules
 
@@ -75,7 +77,7 @@ echo "Review backend: $BACKEND (override: --review=rp|codex|copilot|none)"
 **For copilot backend:**
 1. Use `$FLOWCTL copilot plan-review` exclusively
 2. Pass `--receipt` for session continuity on re-reviews (session only resumes when prior receipt has `mode == "copilot"`)
-3. Model + effort are env-only: `FLOW_COPILOT_MODEL`, `FLOW_COPILOT_EFFORT` (no CLI flags)
+3. Model + effort resolved via (first match wins): `--spec backend:model:effort` flag, per-epic `default_review`, `FLOW_REVIEW_BACKEND` spec, `FLOW_COPILOT_MODEL` / `FLOW_COPILOT_EFFORT` env vars, registry defaults
 4. Parse verdict from command output
 
 **For all backends:**
@@ -145,8 +147,10 @@ $FLOWCTL checkpoint save --epic "$EPIC_ID" --json
 # Epic/task specs are auto-included; pass files the plan will CREATE or MODIFY
 CODE_FILES="src/main.py,src/config.py"
 
-# Optional: override model + effort via env (no CLI flags)
-# FLOW_COPILOT_MODEL=gpt-5.2 FLOW_COPILOT_EFFORT=high \
+# Override model + effort (pick one):
+#   --spec copilot:claude-opus-4.5:xhigh   (preferred)
+#   FLOW_REVIEW_BACKEND=copilot:claude-opus-4.5:xhigh
+#   FLOW_COPILOT_MODEL=gpt-5.2 FLOW_COPILOT_EFFORT=high
 
 $FLOWCTL copilot plan-review "$EPIC_ID" --files "$CODE_FILES" --receipt "$RECEIPT_PATH"
 # Output includes VERDICT=SHIP|NEEDS_WORK|MAJOR_RETHINK

--- a/plugins/flow-next/skills/flow-next-plan-review/workflow.md
+++ b/plugins/flow-next/skills/flow-next-plan-review/workflow.md
@@ -18,6 +18,8 @@ FLOWCTL="${DROID_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT}}/scripts/flowctl"
 REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 
 # Priority: --review flag > env > config (flag parsed in SKILL.md)
+# Text output is bare backend name for back-compat grep. --json returns full
+# resolved spec (backend, spec, model, effort, source).
 BACKEND=$($FLOWCTL review-backend)
 
 if [[ "$BACKEND" == "ASK" ]]; then
@@ -28,6 +30,17 @@ fi
 
 echo "Review backend: $BACKEND (override: --review=rp|codex|copilot|none)"
 ```
+
+**Spec-form env var (optional):** `FLOW_REVIEW_BACKEND` accepts bare or full spec:
+
+```bash
+FLOW_REVIEW_BACKEND=codex:gpt-5.4:xhigh $FLOWCTL codex plan-review "$EPIC_ID" --receipt "$RECEIPT_PATH"
+FLOW_REVIEW_BACKEND=copilot:claude-opus-4.5 $FLOWCTL copilot plan-review "$EPIC_ID" --receipt "$RECEIPT_PATH"
+# Or pass spec directly:
+$FLOWCTL codex plan-review "$EPIC_ID" --spec "codex:gpt-5.4:xhigh" --receipt "$RECEIPT_PATH"
+```
+
+Per-epic `default_review` (set via `flowctl epic set-backend`) overrides env.
 
 **If backend is "none"**: Skip review, inform user, and exit cleanly (no error).
 
@@ -107,9 +120,11 @@ RECEIPT_PATH="${REVIEW_RECEIPT_PATH:-/tmp/plan-review-receipt.json}"
 # Epic/task specs are auto-included; pass files the plan will CREATE or MODIFY
 CODE_FILES="src/main.py,src/config.py"  # Customize per epic
 
-# Runtime config via env vars (no CLI flags for model/effort):
-#   FLOW_COPILOT_MODEL   (default gpt-5.2)
-#   FLOW_COPILOT_EFFORT  (default high)
+# Runtime config:
+#   --spec <spec>           full spec (backend:model:effort), highest priority
+#   FLOW_REVIEW_BACKEND     spec-form ok: copilot:claude-opus-4.5:xhigh
+#   FLOW_COPILOT_MODEL      fills missing model only (default gpt-5.2)
+#   FLOW_COPILOT_EFFORT     fills missing effort only (default high)
 
 $FLOWCTL copilot plan-review "$EPIC_ID" --files "$CODE_FILES" --receipt "$RECEIPT_PATH"
 ```
@@ -136,7 +151,9 @@ If `VERDICT=NEEDS_WORK`:
 ### Step 4: Receipt
 
 Receipt is written automatically by `flowctl copilot plan-review` when `--receipt` provided.
-Format: `{"type":"plan_review","id":"<epic-id>","mode":"copilot","verdict":"<verdict>","session_id":"<uuid>","model":"<model>","effort":"<effort>","timestamp":"..."}`
+Format: `{"type":"plan_review","id":"<epic-id>","mode":"copilot","verdict":"<verdict>","session_id":"<uuid>","model":"<model>","effort":"<effort>","spec":"copilot:<model>:<effort>","timestamp":"..."}`
+
+The `spec` field is the canonical round-trippable form (added in fn-28.3). `model` + `effort` remain for backward compatibility.
 
 Session resume guard: re-review only resumes the copilot session when the existing receipt at `$RECEIPT_PATH` has `mode == "copilot"`. Cross-backend switches start a fresh session.
 
@@ -429,6 +446,6 @@ If verdict is NEEDS_WORK:
 
 **Copilot backend only:**
 - **Direct copilot calls** - Must use `flowctl copilot` wrappers
-- **Inventing `--model`/`--effort` CLI flags** - Those are env-only (`FLOW_COPILOT_MODEL`, `FLOW_COPILOT_EFFORT`)
+- **Inventing `--model`/`--effort` CLI flags** - Use `--spec` for a full backend:model:effort value, or `FLOW_COPILOT_MODEL` / `FLOW_COPILOT_EFFORT` env vars to fill individual fields
 - **Using `--continue`** - Conflicts with parallel usage; session resume uses `--resume=<uuid>` under the hood via `--receipt`
 - **Assuming cross-backend session continuity** - Resume only works when prior receipt has `mode == "copilot"`

--- a/plugins/flow-next/skills/flow-next-ralph-init/templates/config.env
+++ b/plugins/flow-next/skills/flow-next-ralph-init/templates/config.env
@@ -5,15 +5,21 @@ EPICS=
 
 # Plan gate
 REQUIRE_PLAN_REVIEW=0
-# PLAN_REVIEW options: rp (RepoPrompt, macOS), codex (cross-platform), copilot (cross-platform), none
+# PLAN_REVIEW: bare backend or full spec.
+#   Bare: rp (macOS), codex, copilot, none
+#   Spec: backend[:model[:effort]] — e.g. codex:gpt-5.4:xhigh, copilot:claude-opus-4.5:xhigh
+# The bare-backend name is extracted via ${PLAN_REVIEW%%:*} for gating; the full
+# spec flows through FLOW_REVIEW_BACKEND to flowctl which resolves model + effort.
 PLAN_REVIEW={{PLAN_REVIEW}}
 
 # Work gate
-# WORK_REVIEW options: rp (RepoPrompt, macOS), codex (cross-platform), copilot (cross-platform), none
+# WORK_REVIEW: bare backend or full spec (same grammar as PLAN_REVIEW).
+#   e.g. WORK_REVIEW=codex:gpt-5.4:xhigh   or   WORK_REVIEW=copilot:claude-haiku-4.5
 WORK_REVIEW={{WORK_REVIEW}}
 
 # Epic completion gate (runs when all tasks done, before epic closes)
-# COMPLETION_REVIEW options: rp (RepoPrompt, macOS), codex (cross-platform), copilot (cross-platform), none
+# COMPLETION_REVIEW: bare backend or full spec (same grammar).
+#   e.g. COMPLETION_REVIEW=codex:gpt-5.4:xhigh   or   COMPLETION_REVIEW=copilot:claude-opus-4.5
 COMPLETION_REVIEW={{COMPLETION_REVIEW}}
 
 # Codex sandbox mode (only used when PLAN_REVIEW or WORK_REVIEW is codex)
@@ -25,10 +31,10 @@ CODEX_SANDBOX=auto
 # 500KB default (~70% of Codex 200k token context). Set to 0 for unlimited.
 FLOW_CODEX_EMBED_MAX_BYTES=500000
 
-# Copilot runtime config (only used when PLAN/WORK/COMPLETION_REVIEW is copilot).
-# Env-only — no CLI flags. Resolved via env > arg > default cascade in
-# flowctl's _resolve_copilot_model_effort() and stamped into every receipt
-# (model + effort fields), so reviews are reproducible.
+# Copilot runtime config (only used when PLAN/WORK/COMPLETION_REVIEW resolves to copilot).
+# These env vars fill MISSING fields only — a full spec (e.g. WORK_REVIEW=copilot:claude-opus-4.5:xhigh
+# or --spec copilot:claude-opus-4.5:xhigh) always wins. Receipts stamp model,
+# effort, and spec fields so reviews are reproducible.
 # Model catalog: claude-sonnet-4.5, claude-haiku-4.5, claude-opus-4.5,
 #                claude-sonnet-4, gpt-5.2 (default), gpt-5.2-codex, gpt-5-mini, gpt-4.1
 FLOW_COPILOT_MODEL=gpt-5.2

--- a/plugins/flow-next/skills/flow-next-ralph-init/templates/prompt_completion.md
+++ b/plugins/flow-next/skills/flow-next-ralph-init/templates/prompt_completion.md
@@ -2,7 +2,10 @@ You are running one Ralph epic completion review iteration.
 
 Inputs:
 - EPIC_ID={{EPIC_ID}}
-- COMPLETION_REVIEW={{COMPLETION_REVIEW}}
+- COMPLETION_REVIEW={{COMPLETION_REVIEW}}                  (may be spec form, e.g. `codex:gpt-5.4:xhigh`)
+- COMPLETION_REVIEW_BACKEND={{COMPLETION_REVIEW_BACKEND}}  (bare backend name — use this for branching)
+
+The full spec is also exported as `FLOW_REVIEW_BACKEND` for flowctl to resolve model + effort.
 
 Steps:
 1) Re-anchor:
@@ -17,18 +20,25 @@ Steps:
    ```
 
 Ralph mode rules (must follow):
-- If COMPLETION_REVIEW=rp: use `flowctl rp` wrappers (setup-review, select-add, prompt-get, chat-send).
-- If COMPLETION_REVIEW=codex: use `flowctl codex` wrappers (completion-review with --receipt).
-- If COMPLETION_REVIEW=copilot: use `flowctl copilot` wrappers (completion-review with --receipt). Never call `copilot` directly; never pass `--continue`.
+- Branch on COMPLETION_REVIEW_BACKEND (bare name), NOT the full spec.
+  Spec form (e.g. `codex:gpt-5.4:xhigh`) carries model + effort; the backend
+  name picks the wrapper and the full spec flows through `FLOW_REVIEW_BACKEND`.
+- If COMPLETION_REVIEW_BACKEND=rp: use `flowctl rp` wrappers (setup-review, select-add, prompt-get, chat-send).
+- If COMPLETION_REVIEW_BACKEND=codex: use `flowctl codex` wrappers (completion-review with --receipt).
+- If COMPLETION_REVIEW_BACKEND=copilot: use `flowctl copilot` wrappers (completion-review with --receipt). Never call `copilot` directly; never pass `--continue`.
 - Write receipt via bash heredoc (no Write tool) if `REVIEW_RECEIPT_PATH` set.
 - If any rule is violated, output `<promise>RETRY</promise>` and stop.
 
-3) Completion review gate:
-   - If COMPLETION_REVIEW=rp: run `/flow-next:epic-review {{EPIC_ID}} --review=rp`
-   - If COMPLETION_REVIEW=codex: run `/flow-next:epic-review {{EPIC_ID}} --review=codex`
-   - If COMPLETION_REVIEW=copilot: run `/flow-next:epic-review {{EPIC_ID}} --review=copilot`
-   - If COMPLETION_REVIEW=none: set ship and stop:
+3) Completion review gate (branch on bare backend; full spec is already in env):
+   - If COMPLETION_REVIEW_BACKEND=rp: run `/flow-next:epic-review {{EPIC_ID}} --review=rp`
+   - If COMPLETION_REVIEW_BACKEND=codex: run `/flow-next:epic-review {{EPIC_ID}} --review=codex`
+   - If COMPLETION_REVIEW_BACKEND=copilot: run `/flow-next:epic-review {{EPIC_ID}} --review=copilot`
+   - If COMPLETION_REVIEW_BACKEND=none: set ship and stop:
      `scripts/ralph/flowctl epic set-completion-review-status {{EPIC_ID}} --status ship --json`
+
+   Note: when COMPLETION_REVIEW is spec form (e.g. `codex:gpt-5.4:xhigh`), the
+   /flow-next:epic-review skill picks up the spec from `FLOW_REVIEW_BACKEND`
+   automatically — no extra flag needed.
 
 4) The skill will loop internally until `<verdict>SHIP</verdict>`:
    - First review uses `--new-chat`

--- a/plugins/flow-next/skills/flow-next-ralph-init/templates/prompt_plan.md
+++ b/plugins/flow-next/skills/flow-next-ralph-init/templates/prompt_plan.md
@@ -2,8 +2,11 @@ You are running one Ralph plan gate iteration.
 
 Inputs:
 - EPIC_ID={{EPIC_ID}}
-- PLAN_REVIEW={{PLAN_REVIEW}}
+- PLAN_REVIEW={{PLAN_REVIEW}}                  (may be spec form, e.g. `codex:gpt-5.4:xhigh`)
+- PLAN_REVIEW_BACKEND={{PLAN_REVIEW_BACKEND}}  (bare backend name — use this for branching)
 - REQUIRE_PLAN_REVIEW={{REQUIRE_PLAN_REVIEW}}
+
+The full spec is also exported as `FLOW_REVIEW_BACKEND` for flowctl to resolve model + effort.
 
 Steps:
 1) Re-anchor:
@@ -18,21 +21,28 @@ Steps:
    ```
 
 Ralph mode rules (must follow):
-- If PLAN_REVIEW=rp: use `flowctl rp` wrappers (setup-review, select-add, prompt-get, chat-send).
-- If PLAN_REVIEW=codex: use `flowctl codex` wrappers (plan-review with --receipt).
-- If PLAN_REVIEW=copilot: use `flowctl copilot` wrappers (plan-review with --receipt). Never call `copilot` directly; never pass `--continue`.
+- Branch on PLAN_REVIEW_BACKEND (bare name), NOT the full PLAN_REVIEW spec.
+  Spec form (e.g. `codex:gpt-5.4:xhigh`) carries model + effort; the backend
+  name picks the wrapper and the full spec flows through `FLOW_REVIEW_BACKEND`.
+- If PLAN_REVIEW_BACKEND=rp: use `flowctl rp` wrappers (setup-review, select-add, prompt-get, chat-send).
+- If PLAN_REVIEW_BACKEND=codex: use `flowctl codex` wrappers (plan-review with --receipt).
+- If PLAN_REVIEW_BACKEND=copilot: use `flowctl copilot` wrappers (plan-review with --receipt). Never call `copilot` directly; never pass `--continue`.
 - Write receipt via bash heredoc (no Write tool) if `REVIEW_RECEIPT_PATH` set.
 - If any rule is violated, output `<promise>RETRY</promise>` and stop.
 
-3) Plan review gate:
-   - If PLAN_REVIEW=rp: run `/flow-next:plan-review {{EPIC_ID}} --review=rp`
-   - If PLAN_REVIEW=codex: run `/flow-next:plan-review {{EPIC_ID}} --review=codex`
-   - If PLAN_REVIEW=copilot: run `/flow-next:plan-review {{EPIC_ID}} --review=copilot`
-   - If PLAN_REVIEW=export: run `/flow-next:plan-review {{EPIC_ID}} --review=export`
-   - If PLAN_REVIEW=none:
+3) Plan review gate (branch on bare backend; full spec is already in env):
+   - If PLAN_REVIEW_BACKEND=rp: run `/flow-next:plan-review {{EPIC_ID}} --review=rp`
+   - If PLAN_REVIEW_BACKEND=codex: run `/flow-next:plan-review {{EPIC_ID}} --review=codex`
+   - If PLAN_REVIEW_BACKEND=copilot: run `/flow-next:plan-review {{EPIC_ID}} --review=copilot`
+   - If PLAN_REVIEW_BACKEND=export: run `/flow-next:plan-review {{EPIC_ID}} --review=export`
+   - If PLAN_REVIEW_BACKEND=none:
      - If REQUIRE_PLAN_REVIEW=1: output `<promise>RETRY</promise>` and stop.
      - Else: set ship and stop:
        `scripts/ralph/flowctl epic set-plan-review-status {{EPIC_ID}} --status ship --json`
+
+   Note: when PLAN_REVIEW is spec form (e.g. `codex:gpt-5.4:xhigh`), the
+   /flow-next:plan-review skill picks up the spec from `FLOW_REVIEW_BACKEND`
+   automatically — no extra flag needed.
 
 4) The skill will loop internally until `<verdict>SHIP</verdict>`:
    - First review uses `--new-chat`

--- a/plugins/flow-next/skills/flow-next-ralph-init/templates/prompt_work.md
+++ b/plugins/flow-next/skills/flow-next-ralph-init/templates/prompt_work.md
@@ -3,14 +3,22 @@ You are running one Ralph work iteration.
 Inputs:
 - TASK_ID={{TASK_ID}}
 - BRANCH_MODE={{BRANCH_MODE_EFFECTIVE}}
-- WORK_REVIEW={{WORK_REVIEW}}
+- WORK_REVIEW={{WORK_REVIEW}}                  (may be spec form, e.g. `codex:gpt-5.4:xhigh`)
+- WORK_REVIEW_BACKEND={{WORK_REVIEW_BACKEND}}  (bare backend name — use this for `--review`)
+
+The full spec is also exported as `FLOW_REVIEW_BACKEND` for flowctl to resolve model + effort.
 
 ## Steps (execute ALL in order)
 
 **Step 1: Execute task**
 ```
-/flow-next:work {{TASK_ID}} --branch={{BRANCH_MODE_EFFECTIVE}} --review={{WORK_REVIEW}}
+/flow-next:work {{TASK_ID}} --branch={{BRANCH_MODE_EFFECTIVE}} --review={{WORK_REVIEW_BACKEND}}
 ```
+`--review` takes the bare backend name (`rp`, `codex`, `copilot`, `none`). If
+WORK_REVIEW was spec form (e.g. `copilot:claude-opus-4.5:xhigh`), the exported
+`FLOW_REVIEW_BACKEND` carries the full spec through to flowctl which resolves
+model + effort automatically.
+
 When `--review=rp`, the worker subagent invokes `/flow-next:impl-review` internally.
 When `--review=codex`, the worker uses `flowctl codex impl-review` for review.
 When `--review=copilot`, the worker uses `flowctl copilot impl-review` for review.
@@ -24,7 +32,7 @@ scripts/ralph/flowctl show {{TASK_ID}} --json
 ```
 If status != `done`, output `<promise>RETRY</promise>` and stop.
 
-**Step 3: Write impl receipt** (MANDATORY if WORK_REVIEW=rp, codex, or copilot)
+**Step 3: Write impl receipt** (MANDATORY if WORK_REVIEW_BACKEND=rp, codex, or copilot)
 For rp mode:
 ```bash
 mkdir -p "$(dirname '{{REVIEW_RECEIPT_PATH}}')"

--- a/plugins/flow-next/skills/flow-next-ralph-init/templates/ralph.sh
+++ b/plugins/flow-next/skills/flow-next-ralph-init/templates/ralph.sh
@@ -224,16 +224,24 @@ ui_config() {
   ui "${C_DIM}   Branch:${C_RESET} ${C_BOLD}$git_branch${C_RESET}"
   ui "${C_DIM}   Progress:${C_RESET} Epic ${epics_done}/${epics_total} ${C_DIM}•${C_RESET} Task ${tasks_done}/${tasks_total}"
 
+  # Show the full spec (so Ralph operators see the model / effort they picked);
+  # map the bare-backend name to a pretty label.
   local plan_display="$PLAN_REVIEW" work_display="$WORK_REVIEW" completion_display="$COMPLETION_REVIEW"
-  [[ "$PLAN_REVIEW" == "rp" ]] && plan_display="RepoPrompt"
-  [[ "$PLAN_REVIEW" == "codex" ]] && plan_display="Codex"
-  [[ "$PLAN_REVIEW" == "copilot" ]] && plan_display="Copilot"
-  [[ "$WORK_REVIEW" == "rp" ]] && work_display="RepoPrompt"
-  [[ "$WORK_REVIEW" == "codex" ]] && work_display="Codex"
-  [[ "$WORK_REVIEW" == "copilot" ]] && work_display="Copilot"
-  [[ "$COMPLETION_REVIEW" == "rp" ]] && completion_display="RepoPrompt"
-  [[ "$COMPLETION_REVIEW" == "codex" ]] && completion_display="Codex"
-  [[ "$COMPLETION_REVIEW" == "copilot" ]] && completion_display="Copilot"
+  case "$PLAN_REVIEW_BACKEND" in
+    rp) plan_display="RepoPrompt${PLAN_REVIEW#rp}" ;;
+    codex) plan_display="Codex${PLAN_REVIEW#codex}" ;;
+    copilot) plan_display="Copilot${PLAN_REVIEW#copilot}" ;;
+  esac
+  case "$WORK_REVIEW_BACKEND" in
+    rp) work_display="RepoPrompt${WORK_REVIEW#rp}" ;;
+    codex) work_display="Codex${WORK_REVIEW#codex}" ;;
+    copilot) work_display="Copilot${WORK_REVIEW#copilot}" ;;
+  esac
+  case "$COMPLETION_REVIEW_BACKEND" in
+    rp) completion_display="RepoPrompt${COMPLETION_REVIEW#rp}" ;;
+    codex) completion_display="Codex${COMPLETION_REVIEW#codex}" ;;
+    copilot) completion_display="Copilot${COMPLETION_REVIEW#copilot}" ;;
+  esac
   ui "${C_DIM}   Reviews:${C_RESET} Plan=$plan_display ${C_DIM}•${C_RESET} Work=$work_display ${C_DIM}•${C_RESET} Completion=$completion_display"
   [[ -n "${EPICS:-}" ]] && ui "${C_DIM}   Scope:${C_RESET} $EPICS"
   ui ""
@@ -398,6 +406,12 @@ BRANCH_MODE="${BRANCH_MODE:-new}"
 PLAN_REVIEW="${PLAN_REVIEW:-none}"
 WORK_REVIEW="${WORK_REVIEW:-none}"
 COMPLETION_REVIEW="${COMPLETION_REVIEW:-none}"
+# Derive bare backend names from possible spec form (backend[:model[:effort]]).
+# Equality checks / UI labels / gating use BARE; full spec is exported via
+# FLOW_REVIEW_BACKEND so flowctl resolves model + effort.
+PLAN_REVIEW_BACKEND="${PLAN_REVIEW%%:*}"
+WORK_REVIEW_BACKEND="${WORK_REVIEW%%:*}"
+COMPLETION_REVIEW_BACKEND="${COMPLETION_REVIEW%%:*}"
 CODEX_SANDBOX="${CODEX_SANDBOX:-auto}"  # Codex sandbox mode; flowctl reads this env var
 REQUIRE_PLAN_REVIEW="${REQUIRE_PLAN_REVIEW:-0}"
 YOLO="${YOLO:-0}"
@@ -515,7 +529,7 @@ render_template() {
 import os, sys
 path = sys.argv[1]
 text = open(path, encoding="utf-8").read()
-keys = ["EPIC_ID","TASK_ID","PLAN_REVIEW","WORK_REVIEW","COMPLETION_REVIEW","BRANCH_MODE","BRANCH_MODE_EFFECTIVE","REQUIRE_PLAN_REVIEW","REVIEW_RECEIPT_PATH","RALPH_ITERATION"]
+keys = ["EPIC_ID","TASK_ID","PLAN_REVIEW","WORK_REVIEW","COMPLETION_REVIEW","PLAN_REVIEW_BACKEND","WORK_REVIEW_BACKEND","COMPLETION_REVIEW_BACKEND","BRANCH_MODE","BRANCH_MODE_EFFECTIVE","REQUIRE_PLAN_REVIEW","REVIEW_RECEIPT_PATH","RALPH_ITERATION"]
 for k in keys:
     text = text.replace("{{%s}}" % k, os.environ.get(k, ""))
 print(text)
@@ -818,8 +832,8 @@ maybe_close_epics() {
     [[ "$status" == "done" ]] && continue
     all_done="$(epic_all_tasks_done "$json")"
     if [[ "$all_done" == "1" ]]; then
-      # Gate on completion review if enabled
-      if [[ "$COMPLETION_REVIEW" != "none" ]]; then
+      # Gate on completion review if enabled (bare backend check — spec form OK)
+      if [[ "$COMPLETION_REVIEW_BACKEND" != "none" ]]; then
         review_status="$(json_get completion_review_status "$json")"
         if [[ "$review_status" != "ship" ]]; then
           # Don't close - selector will return completion_review status
@@ -917,7 +931,7 @@ while (( iter <= MAX_ITERATIONS )); do
   selector_args=("$FLOWCTL" next --json)
   [[ -n "$EPICS_FILE" ]] && selector_args+=(--epics-file "$EPICS_FILE")
   [[ "$REQUIRE_PLAN_REVIEW" == "1" ]] && selector_args+=(--require-plan-review)
-  [[ "$COMPLETION_REVIEW" != "none" ]] && selector_args+=(--require-completion-review)
+  [[ "$COMPLETION_REVIEW_BACKEND" != "none" ]] && selector_args+=(--require-completion-review)
 
   selector_json="$("${selector_args[@]}")"
   status="$(json_get status "$selector_json")"
@@ -944,15 +958,18 @@ while (( iter <= MAX_ITERATIONS )); do
   if [[ "$status" == "plan" ]]; then
     export EPIC_ID="$epic_id"
     export PLAN_REVIEW
+    export PLAN_REVIEW_BACKEND  # bare backend name (extracted from spec)
     export REQUIRE_PLAN_REVIEW
-    export FLOW_REVIEW_BACKEND="$PLAN_REVIEW"  # Skills read this
-    if [[ "$PLAN_REVIEW" != "none" ]]; then
+    # FLOW_REVIEW_BACKEND carries the FULL spec through to flowctl, which
+    # resolves model + effort via BackendSpec.parse / resolve.
+    export FLOW_REVIEW_BACKEND="$PLAN_REVIEW"
+    if [[ "$PLAN_REVIEW_BACKEND" != "none" ]]; then
       export REVIEW_RECEIPT_PATH="$RECEIPTS_DIR/plan-${epic_id}.json"
     else
       unset REVIEW_RECEIPT_PATH
     fi
-    log "plan epic=$epic_id review=$PLAN_REVIEW receipt=${REVIEW_RECEIPT_PATH:-} require=$REQUIRE_PLAN_REVIEW"
-    ui_plan_review "$PLAN_REVIEW" "$epic_id"
+    log "plan epic=$epic_id review=$PLAN_REVIEW (backend=$PLAN_REVIEW_BACKEND) receipt=${REVIEW_RECEIPT_PATH:-} require=$REQUIRE_PLAN_REVIEW"
+    ui_plan_review "$PLAN_REVIEW_BACKEND" "$epic_id"
     prompt="$(render_template "$SCRIPT_DIR/prompt_plan.md")"
   elif [[ "$status" == "work" ]]; then
     epic_id="${task_id%%.*}"
@@ -963,26 +980,28 @@ while (( iter <= MAX_ITERATIONS )); do
     fi
     export BRANCH_MODE_EFFECTIVE
     export WORK_REVIEW
-    export FLOW_REVIEW_BACKEND="$WORK_REVIEW"  # Skills read this
-    if [[ "$WORK_REVIEW" != "none" ]]; then
+    export WORK_REVIEW_BACKEND  # bare backend name (extracted from spec)
+    export FLOW_REVIEW_BACKEND="$WORK_REVIEW"  # full spec
+    if [[ "$WORK_REVIEW_BACKEND" != "none" ]]; then
       export REVIEW_RECEIPT_PATH="$RECEIPTS_DIR/impl-${task_id}.json"
     else
       unset REVIEW_RECEIPT_PATH
     fi
-    log "work task=$task_id review=$WORK_REVIEW receipt=${REVIEW_RECEIPT_PATH:-} branch=$BRANCH_MODE_EFFECTIVE"
-    ui_impl_review "$WORK_REVIEW" "$task_id"
+    log "work task=$task_id review=$WORK_REVIEW (backend=$WORK_REVIEW_BACKEND) receipt=${REVIEW_RECEIPT_PATH:-} branch=$BRANCH_MODE_EFFECTIVE"
+    ui_impl_review "$WORK_REVIEW_BACKEND" "$task_id"
     prompt="$(render_template "$SCRIPT_DIR/prompt_work.md")"
   elif [[ "$status" == "completion_review" ]]; then
     export EPIC_ID="$epic_id"
     export COMPLETION_REVIEW
-    export FLOW_REVIEW_BACKEND="$COMPLETION_REVIEW"  # Skills read this
-    if [[ "$COMPLETION_REVIEW" != "none" ]]; then
+    export COMPLETION_REVIEW_BACKEND  # bare backend name (extracted from spec)
+    export FLOW_REVIEW_BACKEND="$COMPLETION_REVIEW"  # full spec
+    if [[ "$COMPLETION_REVIEW_BACKEND" != "none" ]]; then
       export REVIEW_RECEIPT_PATH="$RECEIPTS_DIR/completion-${epic_id}.json"
     else
       unset REVIEW_RECEIPT_PATH
     fi
-    log "completion_review epic=$epic_id review=$COMPLETION_REVIEW receipt=${REVIEW_RECEIPT_PATH:-}"
-    ui_completion_review "$COMPLETION_REVIEW" "$epic_id"
+    log "completion_review epic=$epic_id review=$COMPLETION_REVIEW (backend=$COMPLETION_REVIEW_BACKEND) receipt=${REVIEW_RECEIPT_PATH:-}"
+    ui_completion_review "$COMPLETION_REVIEW_BACKEND" "$epic_id"
     prompt="$(render_template "$SCRIPT_DIR/prompt_completion.md")"
   else
     fail "invalid selector status: $status"
@@ -1079,7 +1098,8 @@ Violations break automation and leave the user with incomplete work. Be precise,
   plan_review_status=""
   task_status=""
   impl_receipt_ok="1"
-  if [[ "$status" == "plan" && ( "$PLAN_REVIEW" == "rp" || "$PLAN_REVIEW" == "codex" || "$PLAN_REVIEW" == "copilot" ) ]]; then
+  # Gate on BARE backend name (spec form like codex:gpt-5.4:xhigh resolves to codex).
+  if [[ "$status" == "plan" && ( "$PLAN_REVIEW_BACKEND" == "rp" || "$PLAN_REVIEW_BACKEND" == "codex" || "$PLAN_REVIEW_BACKEND" == "copilot" ) ]]; then
     if ! verify_receipt "$REVIEW_RECEIPT_PATH" "plan_review" "$epic_id"; then
       echo "ralph: missing plan review receipt; forcing retry" >> "$iter_log"
       log "missing plan receipt; forcing retry"
@@ -1093,7 +1113,7 @@ Violations break automation and leave the user with incomplete work. Be precise,
   fi
   completion_review_status=""
   completion_receipt_ok="1"
-  if [[ "$status" == "completion_review" && ( "$COMPLETION_REVIEW" == "rp" || "$COMPLETION_REVIEW" == "codex" || "$COMPLETION_REVIEW" == "copilot" ) ]]; then
+  if [[ "$status" == "completion_review" && ( "$COMPLETION_REVIEW_BACKEND" == "rp" || "$COMPLETION_REVIEW_BACKEND" == "codex" || "$COMPLETION_REVIEW_BACKEND" == "copilot" ) ]]; then
     if ! verify_receipt "$REVIEW_RECEIPT_PATH" "completion_review" "$epic_id"; then
       echo "ralph: missing completion review receipt; forcing retry" >> "$iter_log"
       log "missing completion receipt; forcing retry"
@@ -1116,7 +1136,7 @@ Violations break automation and leave the user with incomplete work. Be precise,
     fi
   fi
   receipt_verdict=""
-  if [[ "$status" == "work" && ( "$WORK_REVIEW" == "rp" || "$WORK_REVIEW" == "codex" || "$WORK_REVIEW" == "copilot" ) ]]; then
+  if [[ "$status" == "work" && ( "$WORK_REVIEW_BACKEND" == "rp" || "$WORK_REVIEW_BACKEND" == "codex" || "$WORK_REVIEW_BACKEND" == "copilot" ) ]]; then
     if ! verify_receipt "$REVIEW_RECEIPT_PATH" "impl_review" "$task_id"; then
       echo "ralph: missing impl review receipt; forcing retry" >> "$iter_log"
       log "missing impl receipt; forcing retry"

--- a/plugins/flow-next/skills/flow-next-setup/workflow.md
+++ b/plugins/flow-next/skills/flow-next-setup/workflow.md
@@ -187,7 +187,7 @@ Current configuration:
 - Memory: <enabled|disabled> (change with: flowctl config set memory.enabled <true|false>)
 - Plan-Sync: <enabled|disabled> (change with: flowctl config set planSync.enabled <true|false>)
 - Plan-Sync cross-epic: <enabled|disabled> (change with: flowctl config set planSync.crossEpic <true|false>)
-- Review backend: <codex|rp|copilot|none> (change with: flowctl config set review.backend <codex|rp|copilot|none>)
+- Review backend: <current value, bare or spec form> (change with: flowctl config set review.backend <codex|rp|copilot|none OR spec form like codex:gpt-5.4:xhigh>)
 - GitHub scout: <enabled|disabled> (change with: flowctl config set scouts.github <true|false>)
 ```
 
@@ -265,6 +265,8 @@ Available questions (include only if corresponding config is unset):
   "multiSelect": false
 }
 ```
+
+Stored value is a bare backend name by default. Power users can also write a full spec like `codex:gpt-5.4:high` or `copilot:claude-opus-4.5:xhigh` via `flowctl config set review.backend <spec>` after setup — the review commands accept both forms.
 
 **Docs question** (always include — adjust default based on platform):
 

--- a/plugins/flow-next/tests/test_backend_spec.py
+++ b/plugins/flow-next/tests/test_backend_spec.py
@@ -1350,5 +1350,189 @@ class TestPerTaskReviewSpecIntegration(unittest.TestCase):
             self.assertIn("Unknown model for codex", payload["error"])
 
 
+# --- cmd_review_backend (fn-28.4) ---
+
+
+class TestReviewBackendCmd(unittest.TestCase):
+    """``flowctl review-backend`` accepts spec-form FLOW_REVIEW_BACKEND and
+    config.json review.backend. Text mode still prints bare backend for
+    back-compat with skill greps; JSON mode returns full resolved spec."""
+
+    def setUp(self) -> None:
+        self._env_snapshot = os.environ.copy()
+        # Scrub any FLOW_* env so each test starts clean.
+        for key in list(os.environ.keys()):
+            if key.startswith("FLOW_"):
+                os.environ.pop(key, None)
+
+    def tearDown(self) -> None:
+        os.environ.clear()
+        os.environ.update(self._env_snapshot)
+
+    def _run_json(self) -> dict:
+        out = io.StringIO()
+        with redirect_stdout(out):
+            flowctl.cmd_review_backend(_ns(json=True))
+        return json.loads(out.getvalue())
+
+    def _run_text(self) -> str:
+        out = io.StringIO()
+        with redirect_stdout(out):
+            flowctl.cmd_review_backend(_ns(json=False))
+        return out.getvalue().strip()
+
+    # --- env spec form ---
+
+    def test_env_spec_returns_full_resolution(self) -> None:
+        os.environ["FLOW_REVIEW_BACKEND"] = "codex:gpt-5.2:medium"
+        with _flow_fixture():
+            payload = self._run_json()
+            self.assertEqual(payload["backend"], "codex")
+            self.assertEqual(payload["spec"], "codex:gpt-5.2:medium")
+            self.assertEqual(payload["model"], "gpt-5.2")
+            self.assertEqual(payload["effort"], "medium")
+            self.assertEqual(payload["source"], "env")
+
+    def test_env_spec_text_mode_prints_bare_backend(self) -> None:
+        # Back-compat contract: `BACKEND=$(flowctl review-backend)` in skills
+        # must still get `codex`, not `codex:gpt-5.4:xhigh`.
+        os.environ["FLOW_REVIEW_BACKEND"] = "codex:gpt-5.4:xhigh"
+        with _flow_fixture():
+            self.assertEqual(self._run_text(), "codex")
+
+    def test_env_copilot_spec_full_form(self) -> None:
+        os.environ["FLOW_REVIEW_BACKEND"] = "copilot:claude-opus-4.5:xhigh"
+        with _flow_fixture():
+            payload = self._run_json()
+            self.assertEqual(payload["backend"], "copilot")
+            self.assertEqual(payload["spec"], "copilot:claude-opus-4.5:xhigh")
+            self.assertEqual(payload["model"], "claude-opus-4.5")
+            self.assertEqual(payload["effort"], "xhigh")
+
+    # --- env bare form (back-compat) ---
+
+    def test_env_bare_codex_resolves_defaults(self) -> None:
+        os.environ["FLOW_REVIEW_BACKEND"] = "codex"
+        with _flow_fixture():
+            payload = self._run_json()
+            self.assertEqual(payload["backend"], "codex")
+            self.assertEqual(payload["spec"], "codex:gpt-5.4:high")
+            self.assertEqual(payload["model"], "gpt-5.4")
+            self.assertEqual(payload["effort"], "high")
+            self.assertEqual(payload["source"], "env")
+
+    def test_env_bare_rp_has_no_model_or_effort(self) -> None:
+        os.environ["FLOW_REVIEW_BACKEND"] = "rp"
+        with _flow_fixture():
+            payload = self._run_json()
+            self.assertEqual(payload["backend"], "rp")
+            self.assertEqual(payload["spec"], "rp")
+            self.assertIsNone(payload["model"])
+            self.assertIsNone(payload["effort"])
+
+    def test_env_bare_none_returns_none(self) -> None:
+        os.environ["FLOW_REVIEW_BACKEND"] = "none"
+        with _flow_fixture():
+            payload = self._run_json()
+            self.assertEqual(payload["backend"], "none")
+            self.assertEqual(payload["source"], "env")
+
+    # --- config.json source ---
+
+    def test_config_spec_form_resolves(self) -> None:
+        with _flow_fixture() as td:
+            (td / ".flow" / "config.json").write_text(
+                json.dumps({"review": {"backend": "copilot:claude-haiku-4.5"}})
+            )
+            payload = self._run_json()
+            self.assertEqual(payload["backend"], "copilot")
+            self.assertEqual(payload["spec"], "copilot:claude-haiku-4.5:high")
+            self.assertEqual(payload["model"], "claude-haiku-4.5")
+            self.assertEqual(payload["source"], "config")
+
+    def test_env_beats_config(self) -> None:
+        os.environ["FLOW_REVIEW_BACKEND"] = "codex:gpt-5.2"
+        with _flow_fixture() as td:
+            (td / ".flow" / "config.json").write_text(
+                json.dumps({"review": {"backend": "copilot"}})
+            )
+            payload = self._run_json()
+            self.assertEqual(payload["backend"], "codex")
+            self.assertEqual(payload["model"], "gpt-5.2")
+            self.assertEqual(payload["source"], "env")
+
+    # --- unset fallback ---
+
+    def test_unset_returns_ask(self) -> None:
+        with _flow_fixture():
+            payload = self._run_json()
+            self.assertEqual(payload["backend"], "ASK")
+            self.assertEqual(payload["spec"], "ASK")
+            self.assertIsNone(payload["model"])
+            self.assertIsNone(payload["effort"])
+            self.assertEqual(payload["source"], "none")
+
+    def test_unset_text_prints_ask(self) -> None:
+        with _flow_fixture():
+            self.assertEqual(self._run_text(), "ASK")
+
+    # --- legacy / invalid fallthrough ---
+
+    def test_invalid_spec_falls_back_to_bare_backend(self) -> None:
+        # Pre-fn-28 legacy stored value "codex:gpt-5.4-high" (no colon between
+        # model+effort). Lenient parse recovers the bare backend rather than
+        # silently returning ASK (pre-fn-28.4 behavior).
+        os.environ["FLOW_REVIEW_BACKEND"] = "codex:gpt-5.4-high"
+        with _flow_fixture():
+            payload = self._run_json()
+            self.assertEqual(payload["backend"], "codex")
+            # Full spec resolves to registry defaults since model was unparseable.
+            self.assertEqual(payload["spec"], "codex:gpt-5.4:high")
+            self.assertEqual(payload["source"], "env")
+
+    def test_garbage_env_returns_ask(self) -> None:
+        # Garbage with no recognizable backend prefix → fall through to ASK.
+        os.environ["FLOW_REVIEW_BACKEND"] = "not-a-backend"
+        with _flow_fixture():
+            payload = self._run_json()
+            self.assertEqual(payload["backend"], "ASK")
+
+    # --- spec-form config precedence vs env bare ---
+
+    def test_config_spec_beats_empty_env(self) -> None:
+        # Spec-form in config resolves even when env is empty string.
+        os.environ["FLOW_REVIEW_BACKEND"] = ""
+        with _flow_fixture() as td:
+            (td / ".flow" / "config.json").write_text(
+                json.dumps({"review": {"backend": "codex:gpt-5.2:low"}})
+            )
+            payload = self._run_json()
+            self.assertEqual(payload["backend"], "codex")
+            self.assertEqual(payload["spec"], "codex:gpt-5.2:low")
+            self.assertEqual(payload["effort"], "low")
+            self.assertEqual(payload["source"], "config")
+
+
+class TestRalphBareBackendExtraction(unittest.TestCase):
+    """Ralph's `${VAR%%:*}` pattern must extract bare backend for both bare
+    and spec forms. This is a smoke test against the pattern the Ralph shell
+    script uses — not the shell itself, but the equivalent pure-Python form.
+    If this pattern is ever changed in ralph.sh, update this test too.
+    """
+
+    def test_bare_backend_extraction_python_equivalent(self) -> None:
+        # Python equivalent of bash ${VAR%%:*}
+        def bare(v: str) -> str:
+            return v.split(":", 1)[0]
+
+        self.assertEqual(bare("codex"), "codex")
+        self.assertEqual(bare("codex:gpt-5.4:xhigh"), "codex")
+        self.assertEqual(bare("copilot:claude-opus-4.5"), "copilot")
+        self.assertEqual(bare("rp"), "rp")
+        self.assertEqual(bare("none"), "none")
+        # Degenerate: trailing colon still parses cleanly.
+        self.assertEqual(bare("codex:"), "codex")
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/plugins/flow-next/tests/test_backend_spec.py
+++ b/plugins/flow-next/tests/test_backend_spec.py
@@ -1,0 +1,414 @@
+"""Unit tests for BackendSpec parser + registry (fn-28 task 1).
+
+Run:
+    python3 -m unittest discover -s plugins/flow-next/tests -v
+
+Covers every valid form and every invalid-input branch listed in the task
+spec. If the grammar/validation/resolution semantics break here, the whole
+fn-28 plumbing chain will be wrong downstream.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+import unittest
+from pathlib import Path
+from typing import Any
+
+
+def _load_flowctl() -> Any:
+    """Load flowctl.py as a module without running it as a script.
+
+    Resolves relative to this file so the test works from any cwd (same
+    approach the smoke test uses).
+    """
+    here = Path(__file__).resolve()
+    flowctl_path = here.parent.parent / "scripts" / "flowctl.py"
+    if not flowctl_path.is_file():
+        raise RuntimeError(f"flowctl.py not found at {flowctl_path}")
+    spec = importlib.util.spec_from_file_location("flowctl_under_test", flowctl_path)
+    mod = importlib.util.module_from_spec(spec)
+    # Prevent argparse / CLI dispatch at import time — flowctl.py guards main()
+    # under ``if __name__ == "__main__"``, so importing is side-effect free.
+    assert spec.loader is not None
+    spec.loader.exec_module(mod)
+    return mod
+
+
+flowctl = _load_flowctl()
+BackendSpec = flowctl.BackendSpec
+BACKEND_REGISTRY = flowctl.BACKEND_REGISTRY
+
+
+# --- Registry shape ---
+
+
+class TestRegistryShape(unittest.TestCase):
+    """Registry contents are the contract downstream code depends on."""
+
+    def test_exactly_four_backends(self) -> None:
+        self.assertEqual(
+            sorted(BACKEND_REGISTRY.keys()),
+            ["codex", "copilot", "none", "rp"],
+        )
+
+    def test_rp_rejects_model_and_effort(self) -> None:
+        self.assertIsNone(BACKEND_REGISTRY["rp"]["models"])
+        self.assertIsNone(BACKEND_REGISTRY["rp"]["efforts"])
+
+    def test_none_rejects_model_and_effort(self) -> None:
+        self.assertIsNone(BACKEND_REGISTRY["none"]["models"])
+        self.assertIsNone(BACKEND_REGISTRY["none"]["efforts"])
+
+    def test_codex_effort_set(self) -> None:
+        self.assertEqual(
+            BACKEND_REGISTRY["codex"]["efforts"],
+            {"none", "minimal", "low", "medium", "high", "xhigh"},
+        )
+
+    def test_copilot_effort_set(self) -> None:
+        # Copilot rejects ``none`` and ``minimal`` (see fn-27 model catalog).
+        self.assertEqual(
+            BACKEND_REGISTRY["copilot"]["efforts"],
+            {"low", "medium", "high", "xhigh"},
+        )
+
+    def test_codex_defaults(self) -> None:
+        self.assertEqual(BACKEND_REGISTRY["codex"]["default_model"], "gpt-5.4")
+        self.assertEqual(BACKEND_REGISTRY["codex"]["default_effort"], "high")
+
+    def test_copilot_defaults(self) -> None:
+        # Matches fn-27 runtime default (commit f519faa).
+        self.assertEqual(BACKEND_REGISTRY["copilot"]["default_model"], "gpt-5.2")
+        self.assertEqual(BACKEND_REGISTRY["copilot"]["default_effort"], "high")
+
+    def test_copilot_model_catalog(self) -> None:
+        # Verified list from fn-27 §Model Catalog (copilot --help + live probe).
+        self.assertEqual(
+            BACKEND_REGISTRY["copilot"]["models"],
+            {
+                "claude-sonnet-4.5",
+                "claude-haiku-4.5",
+                "claude-opus-4.5",
+                "claude-sonnet-4",
+                "gpt-5.2",
+                "gpt-5.2-codex",
+                "gpt-5-mini",
+                "gpt-4.1",
+            },
+        )
+
+
+# --- Valid specs ---
+
+
+class TestParseValid(unittest.TestCase):
+    def test_bare_codex(self) -> None:
+        s = BackendSpec.parse("codex")
+        self.assertEqual(s, BackendSpec("codex", None, None))
+
+    def test_bare_rp(self) -> None:
+        s = BackendSpec.parse("rp")
+        self.assertEqual(s, BackendSpec("rp", None, None))
+
+    def test_bare_none(self) -> None:
+        s = BackendSpec.parse("none")
+        self.assertEqual(s, BackendSpec("none", None, None))
+
+    def test_bare_copilot(self) -> None:
+        s = BackendSpec.parse("copilot")
+        self.assertEqual(s, BackendSpec("copilot", None, None))
+
+    def test_codex_with_model(self) -> None:
+        s = BackendSpec.parse("codex:gpt-5.4")
+        self.assertEqual(s, BackendSpec("codex", "gpt-5.4", None))
+
+    def test_codex_full(self) -> None:
+        s = BackendSpec.parse("codex:gpt-5.4:xhigh")
+        self.assertEqual(s, BackendSpec("codex", "gpt-5.4", "xhigh"))
+
+    def test_copilot_full(self) -> None:
+        s = BackendSpec.parse("copilot:claude-opus-4.5:xhigh")
+        self.assertEqual(s, BackendSpec("copilot", "claude-opus-4.5", "xhigh"))
+
+    def test_copilot_model_only(self) -> None:
+        s = BackendSpec.parse("copilot:gpt-5.2")
+        self.assertEqual(s, BackendSpec("copilot", "gpt-5.2", None))
+
+    def test_codex_all_efforts(self) -> None:
+        for eff in ("none", "minimal", "low", "medium", "high", "xhigh"):
+            with self.subTest(effort=eff):
+                s = BackendSpec.parse(f"codex:gpt-5.4:{eff}")
+                self.assertEqual(s.effort, eff)
+
+    def test_leading_trailing_whitespace_tolerated(self) -> None:
+        # Per parser: outer strip + per-part strip — pasting from help text
+        # with trailing newlines shouldn't blow up.
+        self.assertEqual(
+            BackendSpec.parse("  codex:gpt-5.4:xhigh  "),
+            BackendSpec("codex", "gpt-5.4", "xhigh"),
+        )
+
+    def test_empty_middle_part_is_none(self) -> None:
+        # ``codex::high`` means "default model, effort=high". Weird but legal
+        # — the parser treats an empty part as unset so the round-trip works.
+        s = BackendSpec.parse("codex::high")
+        self.assertEqual(s, BackendSpec("codex", None, "high"))
+
+
+# --- Invalid specs ---
+
+
+class TestParseInvalid(unittest.TestCase):
+    def test_empty_string(self) -> None:
+        with self.assertRaisesRegex(ValueError, "Empty backend spec"):
+            BackendSpec.parse("")
+
+    def test_whitespace_only(self) -> None:
+        with self.assertRaisesRegex(ValueError, "Empty backend spec"):
+            BackendSpec.parse("   ")
+
+    def test_none_value(self) -> None:
+        # Defensive: ``None`` is not a string but downstream code may pass it.
+        with self.assertRaisesRegex(ValueError, "Empty backend spec"):
+            BackendSpec.parse(None)  # type: ignore[arg-type]
+
+    def test_unknown_backend(self) -> None:
+        with self.assertRaisesRegex(ValueError, "Unknown backend"):
+            BackendSpec.parse("foo")
+
+    def test_unknown_backend_lists_valid_set(self) -> None:
+        # Users need a copy-pasteable list — don't regress.
+        try:
+            BackendSpec.parse("foo")
+            self.fail("expected ValueError")
+        except ValueError as e:
+            msg = str(e)
+            for name in ("rp", "codex", "copilot", "none"):
+                self.assertIn(name, msg)
+
+    def test_too_many_colons(self) -> None:
+        with self.assertRaisesRegex(ValueError, "Too many ':' separators"):
+            BackendSpec.parse("codex:gpt-5.4:high:extra")
+
+    def test_way_too_many_colons(self) -> None:
+        with self.assertRaisesRegex(ValueError, "Too many ':' separators"):
+            BackendSpec.parse("copilot:::::")
+
+    def test_trailing_colon(self) -> None:
+        # ``codex:`` — model part is empty string; parser treats as None, so
+        # this parses as bare ``codex``. That's the same lenient rule as
+        # ``codex::high``. Confirm behavior is stable (not a crash).
+        s = BackendSpec.parse("codex:")
+        self.assertEqual(s, BackendSpec("codex", None, None))
+
+    def test_unknown_model_codex(self) -> None:
+        with self.assertRaisesRegex(ValueError, "Unknown model for codex"):
+            BackendSpec.parse("codex:gpt-99")
+
+    def test_unknown_model_lists_sorted_valid(self) -> None:
+        try:
+            BackendSpec.parse("codex:gpt-99")
+            self.fail("expected ValueError")
+        except ValueError as e:
+            msg = str(e)
+            # Spec says: sorted valid-list in message.
+            self.assertIn("'gpt-5-codex'", msg)
+            self.assertIn("'gpt-5.4'", msg)
+
+    def test_unknown_model_copilot(self) -> None:
+        # Effort-looking string in model slot must fail cleanly.
+        with self.assertRaisesRegex(ValueError, "Unknown model for copilot"):
+            BackendSpec.parse("copilot:xhigh-is-not-a-model")
+
+    def test_unknown_effort_codex(self) -> None:
+        with self.assertRaisesRegex(ValueError, "Unknown effort for codex"):
+            BackendSpec.parse("codex:gpt-5.4:bogus-effort")
+
+    def test_unknown_effort_lists_sorted_valid(self) -> None:
+        try:
+            BackendSpec.parse("codex:gpt-5.4:bogus")
+            self.fail("expected ValueError")
+        except ValueError as e:
+            self.assertIn("'high'", str(e))
+            self.assertIn("'xhigh'", str(e))
+
+    def test_copilot_rejects_codex_only_efforts(self) -> None:
+        # ``none`` and ``minimal`` are codex-only; copilot must reject.
+        with self.assertRaisesRegex(ValueError, "Unknown effort for copilot"):
+            BackendSpec.parse("copilot:gpt-5.2:minimal")
+        with self.assertRaisesRegex(ValueError, "Unknown effort for copilot"):
+            BackendSpec.parse("copilot:gpt-5.2:none")
+
+    def test_rp_rejects_model(self) -> None:
+        with self.assertRaisesRegex(ValueError, "does not accept a model"):
+            BackendSpec.parse("rp:opus")
+
+    def test_rp_rejects_effort(self) -> None:
+        # rp has no models either, so model check fires first. Force effort-only
+        # with empty model slot.
+        with self.assertRaisesRegex(ValueError, "does not accept an effort"):
+            BackendSpec.parse("rp::high")
+
+    def test_none_rejects_model(self) -> None:
+        with self.assertRaisesRegex(ValueError, "does not accept a model"):
+            BackendSpec.parse("none:gpt-5.4")
+
+    def test_none_rejects_effort(self) -> None:
+        with self.assertRaisesRegex(ValueError, "does not accept an effort"):
+            BackendSpec.parse("none::high")
+
+    def test_case_sensitive_backend_name(self) -> None:
+        # Backend names are lowercase per the registry. Uppercase must fail
+        # rather than silently lowercasing — that would hide typos.
+        with self.assertRaisesRegex(ValueError, "Unknown backend"):
+            BackendSpec.parse("Codex")
+        with self.assertRaisesRegex(ValueError, "Unknown backend"):
+            BackendSpec.parse("RP")
+
+    def test_case_sensitive_model(self) -> None:
+        # Registry models are lowercase; uppercase must fail.
+        with self.assertRaisesRegex(ValueError, "Unknown model"):
+            BackendSpec.parse("codex:GPT-5.4")
+
+    def test_case_sensitive_effort(self) -> None:
+        with self.assertRaisesRegex(ValueError, "Unknown effort"):
+            BackendSpec.parse("codex:gpt-5.4:HIGH")
+
+
+# --- resolve() precedence ---
+
+
+class TestResolve(unittest.TestCase):
+    """Per-field env-fill precedence: explicit > env > registry default."""
+
+    def setUp(self) -> None:
+        # Snapshot + scrub any FLOW_* env that could bleed between tests.
+        self._env_snapshot = os.environ.copy()
+        for key in list(os.environ.keys()):
+            if key.startswith("FLOW_CODEX_") or key.startswith("FLOW_COPILOT_") \
+               or key.startswith("FLOW_RP_") or key.startswith("FLOW_NONE_"):
+                os.environ.pop(key, None)
+
+    def tearDown(self) -> None:
+        os.environ.clear()
+        os.environ.update(self._env_snapshot)
+
+    def test_bare_codex_fills_both_defaults(self) -> None:
+        r = BackendSpec.parse("codex").resolve()
+        self.assertEqual(r, BackendSpec("codex", "gpt-5.4", "high"))
+
+    def test_bare_copilot_fills_both_defaults(self) -> None:
+        r = BackendSpec.parse("copilot").resolve()
+        self.assertEqual(r, BackendSpec("copilot", "gpt-5.2", "high"))
+
+    def test_env_fills_missing_model(self) -> None:
+        os.environ["FLOW_CODEX_MODEL"] = "gpt-5.2"
+        r = BackendSpec.parse("codex").resolve()
+        self.assertEqual(r.model, "gpt-5.2")
+        self.assertEqual(r.effort, "high")  # still registry default
+
+    def test_env_fills_missing_effort(self) -> None:
+        os.environ["FLOW_CODEX_EFFORT"] = "low"
+        r = BackendSpec.parse("codex:gpt-5.2").resolve()
+        self.assertEqual(r.model, "gpt-5.2")  # explicit wins
+        self.assertEqual(r.effort, "low")  # from env
+
+    def test_explicit_spec_wins_over_env(self) -> None:
+        # Critical: env only fills *missing* fields; explicit spec values are
+        # never overridden. This is the subtle contract called out in the epic
+        # risks section.
+        os.environ["FLOW_CODEX_MODEL"] = "gpt-5.2"
+        os.environ["FLOW_CODEX_EFFORT"] = "low"
+        r = BackendSpec.parse("codex:gpt-5.4:xhigh").resolve()
+        self.assertEqual(r, BackendSpec("codex", "gpt-5.4", "xhigh"))
+
+    def test_rp_resolve_returns_no_model_no_effort(self) -> None:
+        # rp has no model/effort concept — resolve must not leak env values in.
+        os.environ["FLOW_RP_MODEL"] = "bogus"
+        os.environ["FLOW_RP_EFFORT"] = "bogus"
+        r = BackendSpec.parse("rp").resolve()
+        self.assertEqual(r, BackendSpec("rp", None, None))
+
+    def test_none_resolve_returns_no_model_no_effort(self) -> None:
+        os.environ["FLOW_NONE_MODEL"] = "bogus"
+        r = BackendSpec.parse("none").resolve()
+        self.assertEqual(r, BackendSpec("none", None, None))
+
+    def test_copilot_env_override(self) -> None:
+        os.environ["FLOW_COPILOT_MODEL"] = "claude-opus-4.5"
+        os.environ["FLOW_COPILOT_EFFORT"] = "xhigh"
+        r = BackendSpec.parse("copilot").resolve()
+        self.assertEqual(r, BackendSpec("copilot", "claude-opus-4.5", "xhigh"))
+
+    def test_resolve_is_idempotent(self) -> None:
+        # Calling resolve twice must not change the result — downstream code
+        # may resolve defensively.
+        once = BackendSpec.parse("codex").resolve()
+        twice = once.resolve()
+        self.assertEqual(once, twice)
+
+
+# --- __str__ round-trip ---
+
+
+class TestStrRoundTrip(unittest.TestCase):
+    def test_full_spec_roundtrip(self) -> None:
+        self.assertEqual(
+            str(BackendSpec("codex", "gpt-5.4", "xhigh")),
+            "codex:gpt-5.4:xhigh",
+        )
+
+    def test_bare_backend_no_trailing_colons(self) -> None:
+        self.assertEqual(str(BackendSpec("codex")), "codex")
+        self.assertEqual(str(BackendSpec("rp")), "rp")
+        self.assertEqual(str(BackendSpec("none")), "none")
+
+    def test_model_only(self) -> None:
+        self.assertEqual(str(BackendSpec("codex", "gpt-5.4")), "codex:gpt-5.4")
+
+    def test_effort_only_keeps_empty_model_slot(self) -> None:
+        # Round-trip must preserve the spec: ``codex::high`` means "default
+        # model, effort=high". If __str__ dropped the empty slot, re-parsing
+        # would see ``codex:high`` → unknown model error.
+        s = BackendSpec("codex", None, "high")
+        self.assertEqual(str(s), "codex::high")
+        self.assertEqual(BackendSpec.parse(str(s)), s)
+
+    def test_parse_str_roundtrip_valid_specs(self) -> None:
+        for raw in (
+            "codex",
+            "rp",
+            "none",
+            "copilot",
+            "codex:gpt-5.4",
+            "codex:gpt-5.4:xhigh",
+            "copilot:claude-opus-4.5:xhigh",
+            "copilot:gpt-5.2:medium",
+        ):
+            with self.subTest(spec=raw):
+                self.assertEqual(str(BackendSpec.parse(raw)), raw)
+
+
+# --- Frozen dataclass guarantees ---
+
+
+class TestFrozen(unittest.TestCase):
+    def test_spec_is_hashable(self) -> None:
+        # Frozen dataclasses are hashable — downstream code may stick specs
+        # into sets / dict keys.
+        s = BackendSpec("codex", "gpt-5.4", "high")
+        self.assertEqual(hash(s), hash(BackendSpec("codex", "gpt-5.4", "high")))
+        seen = {s, s, BackendSpec("codex")}
+        self.assertEqual(len(seen), 2)
+
+    def test_spec_is_immutable(self) -> None:
+        s = BackendSpec("codex", "gpt-5.4", "high")
+        with self.assertRaises(Exception):  # FrozenInstanceError is a dataclass subclass
+            s.model = "gpt-5.2"  # type: ignore[misc]
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/plugins/flow-next/tests/test_backend_spec.py
+++ b/plugins/flow-next/tests/test_backend_spec.py
@@ -10,10 +10,15 @@ fn-28 plumbing chain will be wrong downstream.
 
 from __future__ import annotations
 
+import argparse
 import importlib.util
+import io
+import json
 import os
 import sys
+import tempfile
 import unittest
+from contextlib import contextmanager, redirect_stderr, redirect_stdout
 from pathlib import Path
 from typing import Any
 
@@ -408,6 +413,452 @@ class TestFrozen(unittest.TestCase):
         s = BackendSpec("codex", "gpt-5.4", "high")
         with self.assertRaises(Exception):  # FrozenInstanceError is a dataclass subclass
             s.model = "gpt-5.2"  # type: ignore[misc]
+
+
+# --- VALID_BACKENDS constant (fn-28.2) ---
+
+
+class TestValidBackends(unittest.TestCase):
+    """``VALID_BACKENDS`` mirrors registry keys sorted — downstream argparse
+    ``choices=`` and any "valid list" UI depends on this shape."""
+
+    def test_exists(self) -> None:
+        self.assertTrue(hasattr(flowctl, "VALID_BACKENDS"))
+
+    def test_matches_registry(self) -> None:
+        self.assertEqual(
+            flowctl.VALID_BACKENDS, sorted(BACKEND_REGISTRY.keys())
+        )
+
+    def test_is_sorted(self) -> None:
+        self.assertEqual(
+            list(flowctl.VALID_BACKENDS), sorted(flowctl.VALID_BACKENDS)
+        )
+
+
+# --- parse_backend_spec_lenient (legacy fallback — fn-28.2) ---
+
+
+class TestLenientParse(unittest.TestCase):
+    """Graceful fallback for stored legacy values. Runtime must never crash on
+    old data — warn and degrade to bare backend."""
+
+    def _capture_stderr(self, fn):
+        buf = io.StringIO()
+        with redirect_stderr(buf):
+            result = fn()
+        return result, buf.getvalue()
+
+    def test_empty_returns_none_no_warning(self) -> None:
+        result, err = self._capture_stderr(
+            lambda: flowctl.parse_backend_spec_lenient("")
+        )
+        self.assertIsNone(result)
+        self.assertEqual(err, "")
+
+    def test_whitespace_returns_none_no_warning(self) -> None:
+        result, err = self._capture_stderr(
+            lambda: flowctl.parse_backend_spec_lenient("   ")
+        )
+        self.assertIsNone(result)
+        self.assertEqual(err, "")
+
+    def test_none_returns_none_no_warning(self) -> None:
+        result, err = self._capture_stderr(
+            lambda: flowctl.parse_backend_spec_lenient(None)
+        )
+        self.assertIsNone(result)
+        self.assertEqual(err, "")
+
+    def test_valid_spec_roundtrips_no_warning(self) -> None:
+        result, err = self._capture_stderr(
+            lambda: flowctl.parse_backend_spec_lenient("codex:gpt-5.4:high")
+        )
+        self.assertEqual(result, BackendSpec("codex", "gpt-5.4", "high"))
+        self.assertEqual(err, "")
+
+    def test_legacy_dash_model_effort_falls_back_to_bare(self) -> None:
+        # Hot-path case called out in the task spec: pre-epic users stored
+        # ``codex:gpt-5.4-high`` (dash, not colon). Parser rejects as unknown
+        # model; lenient must degrade to bare backend + stderr warning.
+        result, err = self._capture_stderr(
+            lambda: flowctl.parse_backend_spec_lenient("codex:gpt-5.4-high")
+        )
+        self.assertEqual(result, BackendSpec("codex", None, None))
+        self.assertIn("warning:", err)
+        self.assertIn("codex:gpt-5.4-high", err)
+        self.assertIn("codex", err)
+
+    def test_legacy_bad_effort_falls_back_to_bare(self) -> None:
+        result, err = self._capture_stderr(
+            lambda: flowctl.parse_backend_spec_lenient("codex:gpt-5.4:bogus")
+        )
+        self.assertEqual(result, BackendSpec("codex", None, None))
+        self.assertIn("warning:", err)
+
+    def test_unknown_backend_returns_none(self) -> None:
+        # No recognizable backend prefix — caller gets None and stderr note.
+        result, err = self._capture_stderr(
+            lambda: flowctl.parse_backend_spec_lenient("bogus-prefix:foo:bar")
+        )
+        self.assertIsNone(result)
+        self.assertIn("No recognizable backend prefix", err)
+
+    def test_warn_false_suppresses_stderr(self) -> None:
+        result, err = self._capture_stderr(
+            lambda: flowctl.parse_backend_spec_lenient(
+                "codex:gpt-5.4-high", warn=False
+            )
+        )
+        self.assertEqual(result, BackendSpec("codex", None, None))
+        self.assertEqual(err, "")
+
+
+# --- Command integration tests (fn-28.2) ---
+
+
+@contextmanager
+def _flow_fixture():
+    """Spin up an isolated .flow dir under a temp cwd for command tests.
+
+    Yields the temp path. Restores cwd + clears the module-level cache so each
+    fixture test sees a fresh .flow/. Temp dir is cleaned via TemporaryDirectory.
+    """
+    old_cwd = os.getcwd()
+    with tempfile.TemporaryDirectory(prefix="flowctl-cmd-test-") as td:
+        os.chdir(td)
+        try:
+            # cmd_init requires git init — not strictly needed for set/show
+            # commands but mirrors real usage.
+            flow_dir = Path(td) / ".flow"
+            flow_dir.mkdir(parents=True, exist_ok=True)
+            (flow_dir / "epics").mkdir(exist_ok=True)
+            (flow_dir / "tasks").mkdir(exist_ok=True)
+            (flow_dir / "config.json").write_text("{}")
+            yield Path(td)
+        finally:
+            os.chdir(old_cwd)
+
+
+def _write_epic(flow_dir: Path, epic_id: str, **fields: Any) -> None:
+    data = {
+        "id": epic_id,
+        "title": "Test epic",
+        "status": "open",
+        "branch_name": epic_id,
+        "created_at": "2026-01-01T00:00:00Z",
+        "updated_at": "2026-01-01T00:00:00Z",
+        "next_task": 1,
+        "depends_on_epics": [],
+        "default_impl": None,
+        "default_review": None,
+        "default_sync": None,
+    }
+    data.update(fields)
+    (flow_dir / "epics" / f"{epic_id}.json").write_text(json.dumps(data))
+
+
+def _write_task(flow_dir: Path, task_id: str, epic_id: str, **fields: Any) -> None:
+    data = {
+        "id": task_id,
+        "epic": epic_id,
+        "title": "Test task",
+        "status": "todo",
+        "created_at": "2026-01-01T00:00:00Z",
+        "updated_at": "2026-01-01T00:00:00Z",
+        "depends_on": [],
+        "impl": None,
+        "review": None,
+        "sync": None,
+    }
+    data.update(fields)
+    (flow_dir / "tasks" / f"{task_id}.json").write_text(json.dumps(data))
+
+
+def _ns(**kwargs: Any) -> argparse.Namespace:
+    return argparse.Namespace(**kwargs)
+
+
+class TestSetBackendValidation(unittest.TestCase):
+    """``cmd_epic_set_backend`` / ``cmd_task_set_backend`` must reject bad
+    specs before writing to disk."""
+
+    def test_task_set_backend_valid_spec_stored_as_is(self) -> None:
+        with _flow_fixture() as td:
+            _write_epic(td / ".flow", "fn-9-e")
+            _write_task(td / ".flow", "fn-9-e.1", "fn-9-e")
+            out = io.StringIO()
+            with redirect_stdout(out):
+                flowctl.cmd_task_set_backend(
+                    _ns(
+                        id="fn-9-e.1",
+                        impl=None,
+                        review="codex:gpt-5.4:xhigh",
+                        sync=None,
+                        json=True,
+                    )
+                )
+            raw = json.loads(
+                (td / ".flow" / "tasks" / "fn-9-e.1.json").read_text()
+            )
+            # Store raw string exactly as typed (no normalization).
+            self.assertEqual(raw["review"], "codex:gpt-5.4:xhigh")
+
+    def test_task_set_backend_rejects_unknown_model(self) -> None:
+        with _flow_fixture() as td:
+            _write_epic(td / ".flow", "fn-9-e")
+            _write_task(td / ".flow", "fn-9-e.1", "fn-9-e")
+            out = io.StringIO()
+            with self.assertRaises(SystemExit) as cm, redirect_stdout(out):
+                flowctl.cmd_task_set_backend(
+                    _ns(
+                        id="fn-9-e.1",
+                        impl=None,
+                        review="codex:gpt-99",
+                        sync=None,
+                        json=True,
+                    )
+                )
+            self.assertEqual(cm.exception.code, 1)
+            payload = json.loads(out.getvalue())
+            self.assertFalse(payload["success"])
+            self.assertIn("--review", payload["error"])
+            self.assertIn("Unknown model for codex", payload["error"])
+
+    def test_task_set_backend_rejects_rp_with_model(self) -> None:
+        with _flow_fixture() as td:
+            _write_epic(td / ".flow", "fn-9-e")
+            _write_task(td / ".flow", "fn-9-e.1", "fn-9-e")
+            out = io.StringIO()
+            with self.assertRaises(SystemExit), redirect_stdout(out):
+                flowctl.cmd_task_set_backend(
+                    _ns(
+                        id="fn-9-e.1",
+                        impl=None,
+                        review="rp:claude-opus",
+                        sync=None,
+                        json=True,
+                    )
+                )
+            payload = json.loads(out.getvalue())
+            self.assertFalse(payload["success"])
+            self.assertIn("does not accept a model", payload["error"])
+
+    def test_task_set_backend_accepts_copilot_xhigh(self) -> None:
+        with _flow_fixture() as td:
+            _write_epic(td / ".flow", "fn-9-e")
+            _write_task(td / ".flow", "fn-9-e.1", "fn-9-e")
+            out = io.StringIO()
+            with redirect_stdout(out):
+                flowctl.cmd_task_set_backend(
+                    _ns(
+                        id="fn-9-e.1",
+                        impl=None,
+                        review="copilot:claude-opus-4.5:xhigh",
+                        sync=None,
+                        json=True,
+                    )
+                )
+            raw = json.loads(
+                (td / ".flow" / "tasks" / "fn-9-e.1.json").read_text()
+            )
+            self.assertEqual(raw["review"], "copilot:claude-opus-4.5:xhigh")
+
+    def test_task_set_backend_rejects_bad_spec_does_not_touch_disk(self) -> None:
+        with _flow_fixture() as td:
+            _write_epic(td / ".flow", "fn-9-e")
+            _write_task(
+                td / ".flow", "fn-9-e.1", "fn-9-e", review="codex"
+            )
+            before = (td / ".flow" / "tasks" / "fn-9-e.1.json").read_text()
+            with self.assertRaises(SystemExit), redirect_stdout(io.StringIO()):
+                flowctl.cmd_task_set_backend(
+                    _ns(
+                        id="fn-9-e.1",
+                        impl=None,
+                        review="codex:gpt-99",
+                        sync=None,
+                        json=True,
+                    )
+                )
+            after = (td / ".flow" / "tasks" / "fn-9-e.1.json").read_text()
+            self.assertEqual(
+                before, after, "disk must be untouched on validation failure"
+            )
+
+    def test_epic_set_backend_rejects_unknown_backend(self) -> None:
+        with _flow_fixture() as td:
+            _write_epic(td / ".flow", "fn-9-e")
+            out = io.StringIO()
+            with self.assertRaises(SystemExit), redirect_stdout(out):
+                flowctl.cmd_epic_set_backend(
+                    _ns(
+                        id="fn-9-e",
+                        impl="bogus:foo",
+                        review=None,
+                        sync=None,
+                        json=True,
+                    )
+                )
+            payload = json.loads(out.getvalue())
+            self.assertFalse(payload["success"])
+            self.assertIn("--impl", payload["error"])
+            self.assertIn("Unknown backend", payload["error"])
+
+    def test_epic_set_backend_clears_with_empty_string(self) -> None:
+        # Empty string means "clear" — must NOT validate (nothing to validate).
+        with _flow_fixture() as td:
+            _write_epic(
+                td / ".flow", "fn-9-e", default_review="codex:gpt-5.4"
+            )
+            out = io.StringIO()
+            with redirect_stdout(out):
+                flowctl.cmd_epic_set_backend(
+                    _ns(
+                        id="fn-9-e",
+                        impl=None,
+                        review="",
+                        sync=None,
+                        json=True,
+                    )
+                )
+            raw = json.loads(
+                (td / ".flow" / "epics" / "fn-9-e.json").read_text()
+            )
+            self.assertIsNone(raw["default_review"])
+
+
+class TestShowBackendResolution(unittest.TestCase):
+    """``cmd_task_show_backend`` emits raw + resolved + per-field sources and
+    degrades gracefully on legacy values."""
+
+    def setUp(self) -> None:
+        # Scrub env so registry defaults are deterministic.
+        self._env_snapshot = os.environ.copy()
+        for key in list(os.environ.keys()):
+            if key.startswith("FLOW_"):
+                os.environ.pop(key, None)
+
+    def tearDown(self) -> None:
+        os.environ.clear()
+        os.environ.update(self._env_snapshot)
+
+    def _show_json(self, task_id: str) -> dict:
+        out = io.StringIO()
+        with redirect_stdout(out):
+            flowctl.cmd_task_show_backend(_ns(id=task_id, json=True))
+        return json.loads(out.getvalue())
+
+    def test_null_when_no_spec_set(self) -> None:
+        with _flow_fixture() as td:
+            _write_epic(td / ".flow", "fn-9-e")
+            _write_task(td / ".flow", "fn-9-e.1", "fn-9-e")
+            result = self._show_json("fn-9-e.1")
+            self.assertIsNone(result["review"]["raw"])
+            self.assertIsNone(result["review"]["resolved"])
+            self.assertIsNone(result["review"]["source"])
+
+    def test_task_spec_full_fields(self) -> None:
+        # Valid spec → raw + source=task + resolved with per-field sources.
+        with _flow_fixture() as td:
+            _write_epic(td / ".flow", "fn-9-e")
+            _write_task(
+                td / ".flow",
+                "fn-9-e.1",
+                "fn-9-e",
+                review="codex:gpt-5.4:xhigh",
+            )
+            r = self._show_json("fn-9-e.1")["review"]
+            self.assertEqual(r["raw"], "codex:gpt-5.4:xhigh")
+            self.assertEqual(r["source"], "task")
+            self.assertEqual(
+                r["resolved"],
+                {
+                    "backend": "codex",
+                    "model": "gpt-5.4",
+                    "effort": "xhigh",
+                    "str": "codex:gpt-5.4:xhigh",
+                },
+            )
+            self.assertEqual(r["model_source"], "spec")
+            self.assertEqual(r["effort_source"], "spec")
+
+    def test_epic_default_shows_source_epic(self) -> None:
+        with _flow_fixture() as td:
+            _write_epic(
+                td / ".flow", "fn-9-e", default_review="codex"
+            )
+            _write_task(td / ".flow", "fn-9-e.1", "fn-9-e")
+            r = self._show_json("fn-9-e.1")["review"]
+            self.assertEqual(r["raw"], "codex")
+            self.assertEqual(r["source"], "epic")
+            self.assertEqual(r["resolved"]["backend"], "codex")
+            # bare backend → model/effort fill from registry defaults
+            self.assertEqual(r["model_source"], "registry_default")
+            self.assertEqual(r["effort_source"], "registry_default")
+
+    def test_env_fills_missing_effort_source_reported(self) -> None:
+        os.environ["FLOW_CODEX_EFFORT"] = "low"
+        with _flow_fixture() as td:
+            _write_epic(td / ".flow", "fn-9-e")
+            _write_task(
+                td / ".flow",
+                "fn-9-e.1",
+                "fn-9-e",
+                review="codex:gpt-5.2",
+            )
+            r = self._show_json("fn-9-e.1")["review"]
+            self.assertEqual(r["resolved"]["effort"], "low")
+            self.assertEqual(r["model_source"], "spec")
+            self.assertEqual(r["effort_source"], "env:FLOW_CODEX_EFFORT")
+
+    def test_effort_only_spec_roundtrips_in_str(self) -> None:
+        # `codex::high` stored directly must show `codex::high` in
+        # resolved.str — preserving empty-model slot honesty.
+        with _flow_fixture() as td:
+            _write_epic(td / ".flow", "fn-9-e")
+            _write_task(
+                td / ".flow",
+                "fn-9-e.1",
+                "fn-9-e",
+                review="codex::high",
+            )
+            r = self._show_json("fn-9-e.1")["review"]
+            self.assertEqual(r["raw"], "codex::high")
+            # resolve() fills in the model from registry default, so str
+            # becomes the full form. The important invariant is the resolved
+            # dict has both fields populated without raising.
+            self.assertEqual(r["resolved"]["model"], "gpt-5.4")
+            self.assertEqual(r["resolved"]["effort"], "high")
+            self.assertEqual(r["resolved"]["str"], "codex:gpt-5.4:high")
+
+    def test_legacy_value_falls_back_with_warning(self) -> None:
+        # The hot-path compat case: stored ``codex:gpt-5.4-high`` (dash) from
+        # before this epic existed. Must warn to stderr, not crash, and
+        # resolved must fall back to bare-backend defaults.
+        with _flow_fixture() as td:
+            _write_epic(td / ".flow", "fn-9-e")
+            _write_task(
+                td / ".flow",
+                "fn-9-e.1",
+                "fn-9-e",
+                review="codex:gpt-5.4-high",
+            )
+            out = io.StringIO()
+            err = io.StringIO()
+            with redirect_stdout(out), redirect_stderr(err):
+                flowctl.cmd_task_show_backend(
+                    _ns(id="fn-9-e.1", json=True)
+                )
+            r = json.loads(out.getvalue())["review"]
+            self.assertEqual(r["raw"], "codex:gpt-5.4-high")
+            self.assertEqual(r["source"], "task")
+            # Lenient fallback → bare codex → registry defaults fill.
+            self.assertEqual(r["resolved"]["backend"], "codex")
+            self.assertEqual(r["resolved"]["model"], "gpt-5.4")
+            self.assertEqual(r["resolved"]["effort"], "high")
+            self.assertIn("warning:", err.getvalue())
+            self.assertIn("codex:gpt-5.4-high", err.getvalue())
 
 
 if __name__ == "__main__":

--- a/plugins/flow-next/tests/test_backend_spec.py
+++ b/plugins/flow-next/tests/test_backend_spec.py
@@ -861,5 +861,494 @@ class TestShowBackendResolution(unittest.TestCase):
             self.assertIn("codex:gpt-5.4-high", err.getvalue())
 
 
+# --- run_codex_exec / run_copilot_exec honor spec.model + spec.effort (fn-28.3) ---
+
+
+class _FakeCompleted:
+    """Minimal stand-in for subprocess.CompletedProcess.
+
+    Captures the argv the caller would have passed to subprocess.run so tests
+    can assert on --model / --effort / -c model_reasoning_effort flags
+    without actually invoking codex or copilot.
+    """
+
+    def __init__(self, stdout: str = "", stderr: str = "", returncode: int = 0) -> None:
+        self.stdout = stdout
+        self.stderr = stderr
+        self.returncode = returncode
+
+
+@contextmanager
+def _stub_subprocess(module, captured: list, *, stdout: str = "", returncode: int = 0):
+    """Replace ``subprocess.run`` in the flowctl module with a capturing stub.
+
+    The stub records ``(cmd_argv, kwargs)`` to ``captured`` and returns a
+    ``_FakeCompleted`` whose stdout/returncode match the test's intent.
+    Any call into ``shutil.which`` is also stubbed to return a sentinel path
+    so ``require_codex`` / ``require_copilot`` don't error out on hosts that
+    don't have codex/copilot installed.
+    """
+    import subprocess as _subprocess
+
+    real_run = module.subprocess.run
+    real_which = module.shutil.which
+
+    def fake_run(cmd, **kwargs):
+        captured.append((list(cmd), kwargs))
+        return _FakeCompleted(stdout=stdout, returncode=returncode)
+
+    def fake_which(binary):
+        if binary in ("codex", "copilot"):
+            return f"/fake/bin/{binary}"
+        return real_which(binary)
+
+    module.subprocess.run = fake_run
+    module.shutil.which = fake_which
+    try:
+        yield
+    finally:
+        module.subprocess.run = real_run
+        module.shutil.which = real_which
+
+
+class TestRunCodexExecHonorsSpec(unittest.TestCase):
+    """``run_codex_exec`` must pull model + effort from the passed ``BackendSpec``
+    instead of the env-var / hardcoded defaults that lived there pre-fn-28.3."""
+
+    def setUp(self) -> None:
+        self._env_snapshot = os.environ.copy()
+        for key in list(os.environ.keys()):
+            if key.startswith("FLOW_"):
+                os.environ.pop(key, None)
+
+    def tearDown(self) -> None:
+        os.environ.clear()
+        os.environ.update(self._env_snapshot)
+
+    def test_spec_model_and_effort_flow_into_argv(self) -> None:
+        # BackendSpec("codex", "gpt-5.2", "medium") must produce:
+        #   --model gpt-5.2
+        #   -c model_reasoning_effort="medium"
+        # NOT the old hardcoded --model gpt-5.4 / effort="high".
+        captured: list = []
+        spec = BackendSpec("codex", "gpt-5.2", "medium")
+        with _stub_subprocess(flowctl, captured, stdout='{"type":"thread.started","thread_id":"t1"}'):
+            flowctl.run_codex_exec("prompt", sandbox="read-only", spec=spec)
+        self.assertEqual(len(captured), 1)
+        argv, _kwargs = captured[0]
+        self.assertIn("--model", argv)
+        self.assertEqual(argv[argv.index("--model") + 1], "gpt-5.2")
+        # -c flag carries the effort in the form model_reasoning_effort="<val>"
+        self.assertIn("-c", argv)
+        c_val = argv[argv.index("-c") + 1]
+        self.assertEqual(c_val, 'model_reasoning_effort="medium"')
+
+    def test_spec_none_falls_back_to_registry_defaults(self) -> None:
+        # Defensive path: spec=None must resolve via bare-codex defaults
+        # (gpt-5.4 / high). This keeps non-review callers safe.
+        captured: list = []
+        with _stub_subprocess(flowctl, captured, stdout='{"type":"thread.started","thread_id":"t1"}'):
+            flowctl.run_codex_exec("prompt", sandbox="read-only", spec=None)
+        argv, _ = captured[0]
+        self.assertEqual(argv[argv.index("--model") + 1], "gpt-5.4")
+        self.assertEqual(
+            argv[argv.index("-c") + 1],
+            'model_reasoning_effort="high"',
+        )
+
+    def test_partial_spec_gets_resolved(self) -> None:
+        # Spec with only backend set — should resolve() upstream. Effort env
+        # fills the gap.
+        os.environ["FLOW_CODEX_EFFORT"] = "low"
+        captured: list = []
+        spec = BackendSpec("codex")  # no model, no effort
+        with _stub_subprocess(flowctl, captured, stdout='{"type":"thread.started","thread_id":"t1"}'):
+            flowctl.run_codex_exec("prompt", sandbox="read-only", spec=spec)
+        argv, _ = captured[0]
+        # Registry default model (no env set) + env effort.
+        self.assertEqual(argv[argv.index("--model") + 1], "gpt-5.4")
+        self.assertEqual(
+            argv[argv.index("-c") + 1],
+            'model_reasoning_effort="low"',
+        )
+
+    def test_explicit_spec_wins_over_env(self) -> None:
+        # Env must NOT override an explicit spec value — that would defeat
+        # per-task model pinning.
+        os.environ["FLOW_CODEX_MODEL"] = "gpt-5"
+        os.environ["FLOW_CODEX_EFFORT"] = "low"
+        captured: list = []
+        spec = BackendSpec("codex", "gpt-5.2", "xhigh")
+        with _stub_subprocess(flowctl, captured, stdout='{"type":"thread.started","thread_id":"t1"}'):
+            flowctl.run_codex_exec("prompt", sandbox="read-only", spec=spec)
+        argv, _ = captured[0]
+        self.assertEqual(argv[argv.index("--model") + 1], "gpt-5.2")
+        self.assertEqual(
+            argv[argv.index("-c") + 1],
+            'model_reasoning_effort="xhigh"',
+        )
+
+
+class TestRunCopilotExecHonorsSpec(unittest.TestCase):
+    """``run_copilot_exec`` must honor the spec. The claude-* effort skip
+    is a live fn-27 bug fix and must remain intact."""
+
+    def setUp(self) -> None:
+        self._env_snapshot = os.environ.copy()
+        for key in list(os.environ.keys()):
+            if key.startswith("FLOW_"):
+                os.environ.pop(key, None)
+        self._tmp = tempfile.TemporaryDirectory(prefix="copilot-spec-test-")
+        self.repo_root = Path(self._tmp.name)
+
+    def tearDown(self) -> None:
+        os.environ.clear()
+        os.environ.update(self._env_snapshot)
+        self._tmp.cleanup()
+
+    def test_spec_model_and_effort_flow_into_argv(self) -> None:
+        captured: list = []
+        spec = BackendSpec("copilot", "gpt-5.2", "medium")
+        with _stub_subprocess(flowctl, captured, stdout="verdict"):
+            flowctl.run_copilot_exec(
+                "prompt", session_id="s1", repo_root=self.repo_root, spec=spec
+            )
+        argv, _ = captured[0]
+        self.assertIn("--model", argv)
+        self.assertEqual(argv[argv.index("--model") + 1], "gpt-5.2")
+        # gpt-5.2 accepts --effort (non-claude model).
+        self.assertIn("--effort", argv)
+        self.assertEqual(argv[argv.index("--effort") + 1], "medium")
+
+    def test_claude_model_skips_effort_flag(self) -> None:
+        # THE fn-27 live bug fix: Claude models reject --effort. Must stay.
+        captured: list = []
+        spec = BackendSpec("copilot", "claude-opus-4.5", "xhigh")
+        with _stub_subprocess(flowctl, captured, stdout="verdict"):
+            flowctl.run_copilot_exec(
+                "prompt", session_id="s1", repo_root=self.repo_root, spec=spec
+            )
+        argv, _ = captured[0]
+        self.assertEqual(argv[argv.index("--model") + 1], "claude-opus-4.5")
+        # --effort must NOT appear for claude-* — Copilot CLI rejects it.
+        self.assertNotIn("--effort", argv)
+
+    def test_claude_haiku_also_skips_effort(self) -> None:
+        # Every claude-* model, not just opus. Use .startswith("claude-").
+        captured: list = []
+        spec = BackendSpec("copilot", "claude-haiku-4.5", "low")
+        with _stub_subprocess(flowctl, captured, stdout="verdict"):
+            flowctl.run_copilot_exec(
+                "prompt", session_id="s1", repo_root=self.repo_root, spec=spec
+            )
+        argv, _ = captured[0]
+        self.assertEqual(argv[argv.index("--model") + 1], "claude-haiku-4.5")
+        self.assertNotIn("--effort", argv)
+
+    def test_gpt_model_keeps_effort(self) -> None:
+        # Sanity — non-claude must keep --effort.
+        captured: list = []
+        spec = BackendSpec("copilot", "gpt-4.1", "high")
+        with _stub_subprocess(flowctl, captured, stdout="verdict"):
+            flowctl.run_copilot_exec(
+                "prompt", session_id="s1", repo_root=self.repo_root, spec=spec
+            )
+        argv, _ = captured[0]
+        self.assertIn("--effort", argv)
+        self.assertEqual(argv[argv.index("--effort") + 1], "high")
+
+    def test_explicit_spec_wins_over_env(self) -> None:
+        os.environ["FLOW_COPILOT_MODEL"] = "gpt-4.1"
+        os.environ["FLOW_COPILOT_EFFORT"] = "low"
+        captured: list = []
+        spec = BackendSpec("copilot", "gpt-5.2", "xhigh")
+        with _stub_subprocess(flowctl, captured, stdout="verdict"):
+            flowctl.run_copilot_exec(
+                "prompt", session_id="s1", repo_root=self.repo_root, spec=spec
+            )
+        argv, _ = captured[0]
+        self.assertEqual(argv[argv.index("--model") + 1], "gpt-5.2")
+        self.assertEqual(argv[argv.index("--effort") + 1], "xhigh")
+
+
+# --- resolve_review_spec precedence (fn-28.3) ---
+
+
+class TestResolveReviewSpec(unittest.TestCase):
+    """The resolution helper is the single source of truth for which spec
+    flows into a review. Test each precedence rung."""
+
+    def setUp(self) -> None:
+        self._env_snapshot = os.environ.copy()
+        for key in list(os.environ.keys()):
+            if key.startswith("FLOW_"):
+                os.environ.pop(key, None)
+
+    def tearDown(self) -> None:
+        os.environ.clear()
+        os.environ.update(self._env_snapshot)
+
+    def test_task_review_spec_wins(self) -> None:
+        # Task fn-9-e.1 has review: "codex:gpt-5.2" — resolved spec must
+        # carry that model through even when an env model var is set.
+        os.environ["FLOW_CODEX_MODEL"] = "gpt-5"  # loses to task spec
+        with _flow_fixture() as td:
+            _write_epic(td / ".flow", "fn-9-e", default_review="codex:gpt-5.4")
+            _write_task(
+                td / ".flow", "fn-9-e.1", "fn-9-e", review="codex:gpt-5.2"
+            )
+            resolved = flowctl.resolve_review_spec("codex", "fn-9-e.1")
+            self.assertEqual(resolved.backend, "codex")
+            self.assertEqual(resolved.model, "gpt-5.2")
+
+    def test_epic_default_fills_when_task_unset(self) -> None:
+        with _flow_fixture() as td:
+            _write_epic(
+                td / ".flow", "fn-9-e", default_review="codex:gpt-5.2:medium"
+            )
+            _write_task(td / ".flow", "fn-9-e.1", "fn-9-e")  # no per-task spec
+            resolved = flowctl.resolve_review_spec("codex", "fn-9-e.1")
+            self.assertEqual(resolved.model, "gpt-5.2")
+            self.assertEqual(resolved.effort, "medium")
+
+    def test_env_review_backend_beats_config(self) -> None:
+        os.environ["FLOW_REVIEW_BACKEND"] = "codex:gpt-5.2"
+        with _flow_fixture() as td:
+            # Config says gpt-5 but env wins.
+            (td / ".flow" / "config.json").write_text(
+                json.dumps({"review": {"backend": "codex:gpt-5"}})
+            )
+            _write_epic(td / ".flow", "fn-9-e")
+            _write_task(td / ".flow", "fn-9-e.1", "fn-9-e")
+            resolved = flowctl.resolve_review_spec("codex", "fn-9-e.1")
+            self.assertEqual(resolved.model, "gpt-5.2")
+
+    def test_config_backend_when_nothing_else_set(self) -> None:
+        with _flow_fixture() as td:
+            (td / ".flow" / "config.json").write_text(
+                json.dumps({"review": {"backend": "copilot:gpt-5.2"}})
+            )
+            _write_epic(td / ".flow", "fn-9-e")
+            _write_task(td / ".flow", "fn-9-e.1", "fn-9-e")
+            resolved = flowctl.resolve_review_spec("codex", "fn-9-e.1")
+            # Config spec says copilot — resolved carries that forward. The
+            # codex command still executes via codex CLI; model name travels
+            # in spec.
+            self.assertEqual(resolved.backend, "copilot")
+            self.assertEqual(resolved.model, "gpt-5.2")
+
+    def test_backend_hint_fallback_when_nothing_set(self) -> None:
+        with _flow_fixture() as td:
+            _write_epic(td / ".flow", "fn-9-e")
+            _write_task(td / ".flow", "fn-9-e.1", "fn-9-e")
+            resolved = flowctl.resolve_review_spec("codex", "fn-9-e.1")
+            self.assertEqual(resolved.backend, "codex")
+            self.assertEqual(resolved.model, "gpt-5.4")  # registry default
+            self.assertEqual(resolved.effort, "high")
+
+    def test_no_task_id_still_resolves(self) -> None:
+        # Plan / completion reviews pass task_id=None — must still resolve.
+        with _flow_fixture():
+            resolved = flowctl.resolve_review_spec("copilot", None)
+            self.assertEqual(resolved.backend, "copilot")
+            self.assertEqual(resolved.model, "gpt-5.2")
+
+
+# --- Per-task review spec actually runs that model (fn-28.3 integration) ---
+
+
+class TestPerTaskReviewSpecIntegration(unittest.TestCase):
+    """End-to-end-ish: task with ``review: "codex:gpt-5.2"`` + `flowctl codex
+    impl-review fn-X` => subprocess argv contains ``--model gpt-5.2`` (not the
+    default gpt-5.4). Receipt stamps model+effort+spec from resolved spec."""
+
+    def setUp(self) -> None:
+        self._env_snapshot = os.environ.copy()
+        for key in list(os.environ.keys()):
+            if key.startswith("FLOW_"):
+                os.environ.pop(key, None)
+
+    def tearDown(self) -> None:
+        os.environ.clear()
+        os.environ.update(self._env_snapshot)
+
+    def _stub_review_side_effects(self, module):
+        """Stub out git/file-system heavy helpers so cmd_codex_impl_review
+        can run in-process without an actual git repo or codex binary.
+
+        Returns a context manager. Minimum set needed:
+          - get_repo_root → fixture dir
+          - get_changed_files → empty list (skip embed logic)
+          - gather_context_hints → ""
+          - build_review_prompt → returns "fake"
+          - parse_codex_verdict → SHIP
+        Plus ``subprocess.run`` / ``shutil.which`` from _stub_subprocess for
+        the run_codex_exec call.
+        """
+        @contextmanager
+        def _cm(fixture_dir: Path, captured: list):
+            saved = {
+                "get_repo_root": module.get_repo_root,
+                "get_changed_files": module.get_changed_files,
+                "gather_context_hints": module.gather_context_hints,
+                "get_embedded_file_contents": module.get_embedded_file_contents,
+                "build_review_prompt": module.build_review_prompt,
+                "parse_codex_verdict": module.parse_codex_verdict,
+                "resolve_codex_sandbox": module.resolve_codex_sandbox,
+                "is_sandbox_failure": module.is_sandbox_failure,
+                "subprocess_Popen": module.subprocess.Popen,
+            }
+
+            # Minimal git diff via Popen stub — return empty diff.
+            class _FakePopen:
+                def __init__(self, *args, **kwargs):
+                    self.stdout = io.BytesIO(b"")
+                    self.stderr = io.BytesIO(b"")
+
+                def wait(self):
+                    return 0
+
+            module.get_repo_root = lambda: fixture_dir
+            module.get_changed_files = lambda base: []
+            module.gather_context_hints = lambda base: ""
+            module.get_embedded_file_contents = (
+                lambda files, **kw: ("", {"budget_skipped": False, "truncated": False})
+            )
+            module.build_review_prompt = lambda *a, **kw: "fake-prompt"
+            module.parse_codex_verdict = lambda out: "SHIP"
+            module.resolve_codex_sandbox = lambda s: "read-only"
+            module.is_sandbox_failure = lambda *a, **kw: False
+            module.subprocess.Popen = _FakePopen
+
+            with _stub_subprocess(
+                module,
+                captured,
+                stdout='{"type":"thread.started","thread_id":"t-abc"}\n',
+            ):
+                try:
+                    yield
+                finally:
+                    for name, fn in saved.items():
+                        if name == "subprocess_Popen":
+                            module.subprocess.Popen = fn
+                        else:
+                            setattr(module, name, fn)
+
+        return _cm
+
+    def test_task_with_codex_gpt52_spec_runs_gpt52(self) -> None:
+        captured: list = []
+        with _flow_fixture() as td:
+            _write_epic(td / ".flow", "fn-9-e")
+            _write_task(
+                td / ".flow", "fn-9-e.1", "fn-9-e", review="codex:gpt-5.2"
+            )
+            # Task spec markdown needs to exist too (cmd reads .md file).
+            (td / ".flow" / "tasks" / "fn-9-e.1.md").write_text(
+                "# Fake task\n\nTest task spec content."
+            )
+            receipt_path = td / "receipt.json"
+            cm = self._stub_review_side_effects(flowctl)
+            with cm(td, captured):
+                args = _ns(
+                    task="fn-9-e.1",
+                    base="main",
+                    focus=None,
+                    receipt=str(receipt_path),
+                    json=True,
+                    sandbox="read-only",
+                    spec=None,
+                )
+                try:
+                    with redirect_stdout(io.StringIO()):
+                        flowctl.cmd_codex_impl_review(args)
+                except SystemExit:
+                    # json_output calls sys.exit(0) on success — fine.
+                    pass
+            # Find the codex exec argv (not the git diff Popen calls).
+            exec_calls = [
+                (argv, kw) for (argv, kw) in captured
+                if argv and argv[0].endswith("/codex")
+            ]
+            self.assertTrue(exec_calls, f"no codex exec calls captured: {captured}")
+            argv, _ = exec_calls[-1]
+            # Per-task spec `codex:gpt-5.2` (effort unset → registry default "high").
+            self.assertEqual(argv[argv.index("--model") + 1], "gpt-5.2")
+            self.assertEqual(
+                argv[argv.index("-c") + 1],
+                'model_reasoning_effort="high"',
+            )
+            # Receipt carries model + effort + canonical spec string.
+            receipt = json.loads(receipt_path.read_text())
+            self.assertEqual(receipt["model"], "gpt-5.2")
+            self.assertEqual(receipt["effort"], "high")
+            self.assertEqual(receipt["spec"], "codex:gpt-5.2:high")
+
+    def test_spec_cli_flag_overrides_task_spec(self) -> None:
+        # Task says codex:gpt-5.2 but --spec on argv says codex:gpt-5:low.
+        # --spec must win.
+        captured: list = []
+        with _flow_fixture() as td:
+            _write_epic(td / ".flow", "fn-9-e")
+            _write_task(
+                td / ".flow", "fn-9-e.1", "fn-9-e", review="codex:gpt-5.2"
+            )
+            (td / ".flow" / "tasks" / "fn-9-e.1.md").write_text("# Fake")
+            receipt_path = td / "receipt.json"
+            cm = self._stub_review_side_effects(flowctl)
+            with cm(td, captured):
+                args = _ns(
+                    task="fn-9-e.1",
+                    base="main",
+                    focus=None,
+                    receipt=str(receipt_path),
+                    json=True,
+                    sandbox="read-only",
+                    spec="codex:gpt-5:low",
+                )
+                try:
+                    with redirect_stdout(io.StringIO()):
+                        flowctl.cmd_codex_impl_review(args)
+                except SystemExit:
+                    pass
+            exec_calls = [
+                (argv, kw) for (argv, kw) in captured
+                if argv and argv[0].endswith("/codex")
+            ]
+            argv, _ = exec_calls[-1]
+            self.assertEqual(argv[argv.index("--model") + 1], "gpt-5")
+            self.assertEqual(
+                argv[argv.index("-c") + 1],
+                'model_reasoning_effort="low"',
+            )
+            receipt = json.loads(receipt_path.read_text())
+            self.assertEqual(receipt["model"], "gpt-5")
+            self.assertEqual(receipt["effort"], "low")
+            self.assertEqual(receipt["spec"], "codex:gpt-5:low")
+
+    def test_invalid_spec_cli_flag_rejected(self) -> None:
+        # --spec takes strict parse — bad specs must fail loudly.
+        with _flow_fixture() as td:
+            _write_epic(td / ".flow", "fn-9-e")
+            _write_task(td / ".flow", "fn-9-e.1", "fn-9-e")
+            (td / ".flow" / "tasks" / "fn-9-e.1.md").write_text("# Fake")
+            args = _ns(
+                task="fn-9-e.1",
+                base="main",
+                focus=None,
+                receipt=None,
+                json=True,
+                sandbox="read-only",
+                spec="codex:gpt-99",  # unknown model
+            )
+            out = io.StringIO()
+            with self.assertRaises(SystemExit), redirect_stdout(out):
+                flowctl.cmd_codex_impl_review(args)
+            payload = json.loads(out.getvalue())
+            self.assertFalse(payload["success"])
+            self.assertIn("Invalid --spec", payload["error"])
+            self.assertIn("Unknown model for codex", payload["error"])
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

- **Unified `backend[:model[:effort]]` spec vocabulary** across all review backends (RP, Codex, Copilot). Per-task and per-epic model+effort pinning now actually run — previously `--review=codex:gpt-5.4-high` was aspirational help text only, stored opaquely, never parsed.
- New **`BackendSpec` dataclass** + **`BACKEND_REGISTRY`** validating against the real model/effort catalogs. Codex: `{gpt-5.4, gpt-5.2, gpt-5, gpt-5-mini, gpt-5-codex}` × `{none, minimal, low, medium, high, xhigh}`. Copilot: full catalog × `{low, medium, high, xhigh}`.
- **`--spec` CLI flag** on all 6 review commands (`{codex,copilot} {impl,plan,completion}-review`). Overrides resolved default.
- **7-level resolution precedence**: `--spec` flag > per-task `review` > per-epic `default_review` > `FLOW_REVIEW_BACKEND` env > `.flow/config.json` > backend-specific env (`FLOW_CODEX_MODEL` etc.) > registry default. Backend-specific env vars fill *missing* fields only — task spec still wins for fields it sets.
- **Store-time validation**: `flowctl epic/task set-backend --review "codex:gpt-99"` rejects immediately with sorted valid-values hint. Legacy stored strings degrade gracefully to bare backend with stderr warning via `parse_backend_spec_lenient`.
- **`cmd_task_show_backend`** emits per-field source tracking: `{raw, source, resolved: {backend, model, effort, str}, model_source, effort_source}`.
- **Receipts** gain a `spec: str(resolved_spec)` field alongside `model` + `effort` for round-trip with `show-backend`.
- **Ralph**: `config.env` accepts spec form on `PLAN_REVIEW` / `WORK_REVIEW` / `COMPLETION_REVIEW`. `ralph.sh` derives bare backends via `${VAR%%:*}` for gate checks while exporting full spec via `FLOW_REVIEW_BACKEND` so flowctl resolves model+effort.
- Claude-* `--effort` skip (fn-27) **preserved and explicitly covered** by 5 new unit tests.
- Minor release (new feature surface): 0.30.0 → 0.31.0.

Epic `fn-28-unified-review-backend-spec-parser` closed; all 5 tasks done with re-anchored worker subagents. 112 unit tests + 67 smoke tests, all green.

## Test plan

- [x] `python3 -m unittest discover -s plugins/flow-next/tests` → **112/112 pass** (56 from .1 + 24 from .2 + 18 from .3 + 14 from .4)
- [x] `plugins/flow-next/scripts/smoke_test.sh` → **67/67 pass**
- [x] `FLOW_REVIEW_BACKEND=codex:gpt-5.4:xhigh flowctl review-backend --json` → `{backend: "codex", spec: "codex:gpt-5.4:xhigh", model: "gpt-5.4", effort: "xhigh", source: "env"}`
- [x] Text mode still prints just `codex` (skill grep back-compat)
- [x] Legacy fallback: `FLOW_REVIEW_BACKEND=codex:gpt-5.4-high` (dash form) degrades to bare `codex`, no crash
- [x] `flowctl epic set-backend --review "codex:gpt-99"` rejects with sorted valid-list
- [x] `flowctl copilot check` unchanged (authed: true, gpt-5-mini)
- [x] `flowctl codex check` unchanged (0.94.0)
- [x] Per-task integration: task with `review: "codex:gpt-5.2"` runs gpt-5.2 (not gpt-5.4 default); receipt stamps `model: "gpt-5.2"` + `spec: "codex:gpt-5.2:high"`
- [x] Claude-* `--effort` skip preserved (live verified: `claude-opus-4.5` + `effort=high` → verdict=SHIP)
- [x] GPT models still receive `--effort` (live verified: `gpt-5.2` + `effort=high` → verdict=SHIP)
- [x] Ralph `${VAR%%:*}` extraction works for both bare (`rp`) and spec-form (`codex:gpt-5.4:xhigh`) inputs
- [x] Manifest versions: marketplace / plugin / codex-plugin all `0.31.0`
- [x] `scripts/sync-codex.sh` ran; 7 codex skill files mention `--spec` (mirror complete)
- [x] Python + bash syntax clean on all touched files
- [x] `.flow/bin/flowctl.py` in sync with plugin source
- [x] Epic closed; no uncommitted changes

Release sequence post-merge:
1. `git tag flow-next-v0.31.0 && git push origin flow-next-v0.31.0` (triggers release + Discord notification)