### PR TITLE
feat(flow-next): review rigor bundle (R-IDs, confidence, classification, protected artifacts, triage-skip) — 0.32.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,13 +6,13 @@
   },
   "metadata": {
     "description": "Plan-first workflows for Claude Code and Factory Droid. Two plugins: flow-next (recommended, zero-dep, Ralph autonomous mode) and flow (Beads integration).",
-    "version": "0.32.0"
+    "version": "0.32.1"
   },
   "plugins": [
     {
       "name": "flow-next",
       "description": "Zero-dependency planning + execution with .flow/ task tracking and Ralph autonomous mode (multi-model review gates). Worker subagent per task for context isolation. Includes 20 subagents, 11 commands, 16 skills.",
-      "version": "0.32.0",
+      "version": "0.32.1",
       "author": {
         "name": "Gordon Mickel",
         "email": "gordon@mickel.tech",

--- a/.flow/bin/flowctl.py
+++ b/.flow/bin/flowctl.py
@@ -1647,6 +1647,52 @@ def parse_codex_verdict(output: str) -> Optional[str]:
     return match.group(1) if match else None
 
 
+def parse_suppressed_count(output: str) -> Optional[dict[str, int]]:
+    """Extract suppression-gate counts from review output (fn-29.3).
+
+    Looks for a line like:
+        Suppressed findings: 3 at anchor 50, 7 at anchor 25, 2 at anchor 0.
+
+    Returns a {anchor: count} dict (keys are stringified anchor ints so the
+    resulting JSON receipt field stays stable across json.dumps round-trips).
+    Returns None when no such line is present (nothing suppressed, or reviewer
+    skipped the summary). An empty dict is never returned — callers can treat
+    None as "no data".
+    """
+    if not output:
+        return None
+    # Accept "Suppressed findings:" anywhere in the text, case-insensitive.
+    # Tolerate bold markers and trailing punctuation.
+    line_match = re.search(
+        r"(?im)^[\s>*_`]*suppressed\s+findings[\s*_`]*:\s*(.+?)\s*$", output
+    )
+    if not line_match:
+        return None
+    payload = line_match.group(1).strip().rstrip(".")
+    if not payload or payload.lower() in {"none", "n/a", "0"}:
+        return None
+    counts: dict[str, int] = {}
+    # Match fragments like "3 at anchor 50" or "50: 3".
+    # Accept only the 5 canonical anchors to stay aligned with the rubric.
+    valid_anchors = {"0", "25", "50", "75", "100"}
+    for frag_match in re.finditer(
+        r"(\d+)\s*(?:at\s+anchor|@|:)\s*(\d+)|anchor\s*(\d+)[^\d]+(\d+)",
+        payload,
+        re.IGNORECASE,
+    ):
+        if frag_match.group(1) and frag_match.group(2):
+            count, anchor = frag_match.group(1), frag_match.group(2)
+        else:
+            anchor, count = frag_match.group(3), frag_match.group(4)
+        if anchor not in valid_anchors:
+            continue
+        try:
+            counts[anchor] = counts.get(anchor, 0) + int(count)
+        except ValueError:
+            continue
+    return counts or None
+
+
 def is_sandbox_failure(exit_code: int, stdout: str, stderr: str) -> bool:
     """Detect if codex failure is due to sandbox restrictions.
 
@@ -2194,6 +2240,40 @@ def run_copilot_exec(
                 pass
 
 
+# --- Confidence calibration (fn-29.3) ---
+#
+# Shared rubric + suppression gate injected into review prompts so rp, codex,
+# and copilot all emit the same discrete confidence anchors. Keep synchronized
+# with the RP workflow.md files and quality-auditor.md — if you change the
+# wording, update those copies too.
+
+CONFIDENCE_RUBRIC_BLOCK = """## Confidence calibration
+
+Rate each finding on exactly one of these 5 discrete anchors. Do not use interpolated values (no 33, 80, 90).
+
+| Anchor | Meaning |
+|--------|---------|
+| 100 | Verifiable from the code alone, zero interpretation. A definitive logic error (off-by-one in a tested algorithm, wrong return type, swapped arguments, clear type error). The bug is mechanical. |
+| 75 | Full execution path traced: "input X enters here, takes this branch, reaches line Z, produces wrong result." Reproducible from the code alone. A normal caller will hit it. |
+| 50 | Depends on conditions visible but not fully confirmable from this diff — e.g., whether a value can actually be null depends on callers not in the diff. Surfaces only as P0-escape or via soft-bucket routing. |
+| 25 | Requires runtime conditions with no direct evidence — specific timing, specific input shapes, specific external state. |
+| 0 | Speculative. Not worth filing. |
+
+## Suppression gate
+
+After all findings are collected:
+1. Suppress findings below anchor 75.
+2. **Exception:** P0 severity findings at anchor 50+ survive the gate. Critical-but-uncertain issues must not be silently dropped.
+3. Report the suppressed count by anchor in a `Suppressed findings` section of the review output.
+
+Example:
+
+> Suppressed findings: 3 at anchor 50, 7 at anchor 25, 2 at anchor 0.
+
+Each surviving finding carries a `Confidence: <N>` field alongside severity, file, and line.
+"""
+
+
 def build_review_prompt(
     review_type: str,
     spec_content: str,
@@ -2307,13 +2387,19 @@ Do NOT mark NEEDS_WORK for:
 
 You MAY mention these as "FYI" observations without affecting the verdict.
 
+"""
+            + CONFIDENCE_RUBRIC_BLOCK
+            + """
 ## Output Format
 
-For each issue found:
-- **Severity**: Critical / Major / Minor / Nitpick
+For each surviving finding:
+- **Severity**: Critical / Major / Minor / Nitpick (P0 / P1 / P2 / P3 accepted)
+- **Confidence**: 0 / 25 / 50 / 75 / 100 (one of the five discrete anchors)
 - **File:Line**: Exact location
 - **Problem**: What's wrong
 - **Suggestion**: How to fix
+
+After the findings list, emit a `Suppressed findings:` line tallying anchors dropped by the gate (omit when nothing was suppressed).
 
 Be critical. Find real issues.
 
@@ -6791,13 +6877,17 @@ Do NOT mark NEEDS_WORK for:
 
 You MAY mention these as "FYI" observations without affecting the verdict.
 
+{CONFIDENCE_RUBRIC_BLOCK}
 ## Output Format
 
-For each issue found:
-- **Severity**: Critical / Major / Minor / Nitpick
+For each surviving finding:
+- **Severity**: Critical / Major / Minor / Nitpick (P0 / P1 / P2 / P3 accepted)
+- **Confidence**: 0 / 25 / 50 / 75 / 100 (one of the five discrete anchors)
 - **File:Line**: Exact location
 - **Problem**: What's wrong
 - **Suggestion**: How to fix
+
+After the findings list, emit a `Suppressed findings:` line tallying anchors dropped by the gate (omit when nothing was suppressed).
 
 Be critical. Find real issues.
 
@@ -6994,6 +7084,9 @@ def cmd_codex_impl_review(args: argparse.Namespace) -> None:
     # Determine review id (task_id for task reviews, "branch" for standalone)
     review_id = task_id if task_id else "branch"
 
+    # Parse optional review-rigor signals from output (fn-29.3)
+    suppressed_count = parse_suppressed_count(output)
+
     # Write receipt if path provided (Ralph-compatible schema)
     if receipt_path:
         receipt_data = {
@@ -7018,25 +7111,30 @@ def cmd_codex_impl_review(args: argparse.Namespace) -> None:
                 pass
         if focus:
             receipt_data["focus"] = focus
+        if suppressed_count:
+            receipt_data["suppressed_count"] = suppressed_count
         Path(receipt_path).write_text(
             json.dumps(receipt_data, indent=2) + "\n", encoding="utf-8"
         )
 
     # Output
     if args.json:
+        json_payload = {
+            "type": "impl_review",
+            "id": review_id,
+            "verdict": verdict,
+            "session_id": thread_id,
+            "mode": "codex",
+            "model": resolved_spec.model,
+            "effort": resolved_spec.effort,
+            "spec": str(resolved_spec),
+            "standalone": standalone,
+            "review": output,  # Full review feedback for fix loop
+        }
+        if suppressed_count:
+            json_payload["suppressed_count"] = suppressed_count
         json_output(
-            {
-                "type": "impl_review",
-                "id": review_id,
-                "verdict": verdict,
-                "session_id": thread_id,
-                "mode": "codex",
-                "model": resolved_spec.model,
-                "effort": resolved_spec.effort,
-                "spec": str(resolved_spec),
-                "standalone": standalone,
-                "review": output,  # Full review feedback for fix loop
-            }
+            json_payload
         )
     else:
         print(output)
@@ -7373,6 +7471,9 @@ For EACH requirement from Phase 1:
 - Scope drift (task marked done without fully addressing spec intent)
 - Missing doc updates mentioned in spec
 
+"""
+        + CONFIDENCE_RUBRIC_BLOCK
+        + """
 ## Output Format
 
 ```
@@ -7390,8 +7491,10 @@ For EACH requirement from Phase 1:
 
 ## Gaps Found
 
-[For each GAP, describe what's missing and suggest fix]
+[For each GAP, describe what's missing and suggest fix. Include `Confidence: <0|25|50|75|100>`.]
 ```
+
+After the findings list, emit a `Suppressed findings:` line tallying anchors dropped by the gate (omit when nothing was suppressed).
 
 ## Verdict
 
@@ -7603,6 +7706,9 @@ def cmd_codex_completion_review(args: argparse.Namespace) -> None:
     # Preserve session_id for continuity (avoid clobbering on resumed sessions)
     session_id_to_write = thread_id or session_id
 
+    # Parse optional review-rigor signals from output (fn-29.3)
+    suppressed_count = parse_suppressed_count(output)
+
     # Write receipt if path provided (Ralph-compatible schema)
     if receipt_path:
         receipt_data = {
@@ -7625,26 +7731,29 @@ def cmd_codex_completion_review(args: argparse.Namespace) -> None:
                 receipt_data["iteration"] = int(ralph_iter)
             except ValueError:
                 pass
+        if suppressed_count:
+            receipt_data["suppressed_count"] = suppressed_count
         Path(receipt_path).write_text(
             json.dumps(receipt_data, indent=2) + "\n", encoding="utf-8"
         )
 
     # Output
     if args.json:
-        json_output(
-            {
-                "type": "completion_review",
-                "id": epic_id,
-                "base": base_branch,
-                "verdict": verdict,
-                "session_id": session_id_to_write,
-                "mode": "codex",
-                "model": resolved_spec.model,
-                "effort": resolved_spec.effort,
-                "spec": str(resolved_spec),
-                "review": output,
-            }
-        )
+        json_payload = {
+            "type": "completion_review",
+            "id": epic_id,
+            "base": base_branch,
+            "verdict": verdict,
+            "session_id": session_id_to_write,
+            "mode": "codex",
+            "model": resolved_spec.model,
+            "effort": resolved_spec.effort,
+            "spec": str(resolved_spec),
+            "review": output,
+        }
+        if suppressed_count:
+            json_payload["suppressed_count"] = suppressed_count
+        json_output(json_payload)
     else:
         print(output)
         print(f"\nVERDICT={verdict or 'UNKNOWN'}")
@@ -7842,6 +7951,9 @@ def cmd_copilot_impl_review(args: argparse.Namespace) -> None:
 
     review_id = task_id if task_id else "branch"
 
+    # Parse optional review-rigor signals from output (fn-29.3)
+    suppressed_count = parse_suppressed_count(output)
+
     if receipt_path:
         receipt_data = {
             "type": "impl_review",
@@ -7864,25 +7976,28 @@ def cmd_copilot_impl_review(args: argparse.Namespace) -> None:
                 pass
         if focus:
             receipt_data["focus"] = focus
+        if suppressed_count:
+            receipt_data["suppressed_count"] = suppressed_count
         Path(receipt_path).write_text(
             json.dumps(receipt_data, indent=2) + "\n", encoding="utf-8"
         )
 
     if args.json:
-        json_output(
-            {
-                "type": "impl_review",
-                "id": review_id,
-                "verdict": verdict,
-                "session_id": returned_session_id,
-                "mode": "copilot",
-                "model": effective_model,
-                "effort": effective_effort,
-                "spec": str(resolved_spec),
-                "standalone": standalone,
-                "review": output,
-            }
-        )
+        json_payload = {
+            "type": "impl_review",
+            "id": review_id,
+            "verdict": verdict,
+            "session_id": returned_session_id,
+            "mode": "copilot",
+            "model": effective_model,
+            "effort": effective_effort,
+            "spec": str(resolved_spec),
+            "standalone": standalone,
+            "review": output,
+        }
+        if suppressed_count:
+            json_payload["suppressed_count"] = suppressed_count
+        json_output(json_payload)
     else:
         print(output)
         print(f"\nVERDICT={verdict or 'UNKNOWN'}")
@@ -8213,6 +8328,9 @@ def cmd_copilot_completion_review(args: argparse.Namespace) -> None:
     # Preserve session_id for continuity (avoid clobbering on resumed sessions)
     session_id_to_write = returned_session_id or session_id
 
+    # Parse optional review-rigor signals from output (fn-29.3)
+    suppressed_count = parse_suppressed_count(output)
+
     if receipt_path:
         receipt_data = {
             "type": "completion_review",
@@ -8233,25 +8351,28 @@ def cmd_copilot_completion_review(args: argparse.Namespace) -> None:
                 receipt_data["iteration"] = int(ralph_iter)
             except ValueError:
                 pass
+        if suppressed_count:
+            receipt_data["suppressed_count"] = suppressed_count
         Path(receipt_path).write_text(
             json.dumps(receipt_data, indent=2) + "\n", encoding="utf-8"
         )
 
     if args.json:
-        json_output(
-            {
-                "type": "completion_review",
-                "id": epic_id,
-                "base": base_branch,
-                "verdict": verdict,
-                "session_id": session_id_to_write,
-                "mode": "copilot",
-                "model": effective_model,
-                "effort": effective_effort,
-                "spec": str(resolved_spec),
-                "review": output,
-            }
-        )
+        json_payload = {
+            "type": "completion_review",
+            "id": epic_id,
+            "base": base_branch,
+            "verdict": verdict,
+            "session_id": session_id_to_write,
+            "mode": "copilot",
+            "model": effective_model,
+            "effort": effective_effort,
+            "spec": str(resolved_spec),
+            "review": output,
+        }
+        if suppressed_count:
+            json_payload["suppressed_count"] = suppressed_count
+        json_output(json_payload)
     else:
         print(output)
         print(f"\nVERDICT={verdict or 'UNKNOWN'}")

--- a/.flow/bin/flowctl.py
+++ b/.flow/bin/flowctl.py
@@ -1762,6 +1762,95 @@ def parse_classification_counts(output: str) -> Optional[dict[str, int]]:
     return per_finding if saw_any else None
 
 
+def parse_unaddressed_rids(output: str) -> Optional[list[str]]:
+    """Extract unaddressed R-IDs from review output (fn-29.2).
+
+    Primary signal: a summary line the reviewer is asked to emit, e.g.
+        Unaddressed R-IDs: [R3, R5]
+        Unaddressed R-ID: R3
+        Unaddressed: [R3, R5]
+
+    Fallback: scan a `## Requirements coverage` markdown table for rows whose
+    Status column is `not-addressed` (or `not addressed`). Deferred R-IDs are
+    never returned. Returns a de-duplicated list preserving first-seen order.
+    Returns None when no R-ID coverage signal is present at all (legacy specs
+    without R-IDs, or reviewer skipped the block). Returns ``[]`` when the
+    reviewer explicitly reported zero unaddressed R-IDs (`Unaddressed R-IDs: []`
+    or `none`).
+
+    Flowctl does not enforce the verdict gate here — the reviewer LLM is
+    instructed to flip NEEDS_WORK when any non-deferred R-ID is unaddressed.
+    This helper just stores the array so downstream fix loops can target
+    specific requirements.
+    """
+    if not output:
+        return None
+
+    def _extract_rids(text: str) -> list[str]:
+        """Return R-ID tokens found in ``text`` (de-duped, order-preserving)."""
+        seen: set[str] = set()
+        ordered: list[str] = []
+        for match in re.finditer(r"\bR(\d+)\b", text):
+            rid = f"R{match.group(1)}"
+            if rid not in seen:
+                seen.add(rid)
+                ordered.append(rid)
+        return ordered
+
+    # Primary: `Unaddressed R-IDs: [R3, R5]` / `Unaddressed: R3, R5` / `Unaddressed R-ID: R3`
+    summary_match = re.search(
+        r"(?im)^[\s>*_`]*unaddressed(?:\s+r[-_ ]?ids?)?[\s*_`]*:\s*(.+?)\s*$",
+        output,
+    )
+    if summary_match:
+        payload = summary_match.group(1).strip()
+        # Strip markdown emphasis / brackets / trailing punctuation.
+        stripped = payload.strip("[]`*_ ").rstrip(".")
+        if stripped.lower() in {"", "none", "n/a", "[]"}:
+            return []
+        rids = _extract_rids(payload)
+        return rids  # may be empty if the payload had text but no R-ID tokens
+
+    # Fallback: look for a requirements coverage markdown table and extract
+    # rows with not-addressed status. Deferred rows are skipped.
+    coverage_match = re.search(
+        r"(?is)##\s*Requirements?\s+coverage[^\n]*\n(.+?)(?:\n##\s|\nUnaddressed\s|\Z)",
+        output,
+    )
+    if not coverage_match:
+        return None
+    table_text = coverage_match.group(1)
+    unaddressed: list[str] = []
+    seen: set[str] = set()
+    for line in table_text.splitlines():
+        stripped = line.strip()
+        if not stripped.startswith("|"):
+            continue
+        # Skip separator rows like | --- | --- | --- |
+        if re.fullmatch(r"\|[\s:\-|]+\|?", stripped):
+            continue
+        cols = [c.strip() for c in stripped.strip("|").split("|")]
+        if len(cols) < 2:
+            continue
+        rid_token = cols[0]
+        status = cols[1].lower()
+        # Header row detection
+        if rid_token.lower() in {"r-id", "rid", "r id", "r"}:
+            continue
+        rid_match = re.search(r"\bR(\d+)\b", rid_token)
+        if not rid_match:
+            continue
+        rid = f"R{rid_match.group(1)}"
+        # Normalize status: strip markdown emphasis; accept "not-addressed",
+        # "not addressed", "not_addressed", "unaddressed".
+        status_norm = re.sub(r"[`*_\s]+", "", status).lower()
+        if status_norm in {"not-addressed", "notaddressed", "unaddressed"}:
+            if rid not in seen:
+                seen.add(rid)
+                unaddressed.append(rid)
+    return unaddressed  # may be empty when table exists but all rows met/deferred
+
+
 def is_sandbox_failure(exit_code: int, stdout: str, stderr: str) -> bool:
     """Detect if codex failure is due to sandbox restrictions.
 
@@ -2410,6 +2499,58 @@ If you notice genuine issues with content INSIDE these files (e.g., a spec that 
 """
 
 
+# --- Per-R-ID requirements coverage (fn-29.2) ---
+#
+# Shared prompt block that instructs reviewers to emit a per-R-ID coverage table
+# whenever the epic spec numbers its acceptance criteria (`- **R1:** ...`). The
+# reviewer parses the heading in either `## Acceptance` or the legacy
+# `## Acceptance criteria` form (plan skill writes the former; older epic specs
+# may use the latter). Missing R-IDs flip the verdict to NEEDS_WORK unless the
+# spec marks the requirement deferred. The block is injected into impl-review
+# and epic-review (completion-review) prompts. Keep synchronized with the RP
+# workflow.md files.
+
+R_ID_COVERAGE_BLOCK = """## Requirements coverage (if spec has R-IDs)
+
+If the task or epic spec references an epic spec with numbered acceptance
+criteria like `- **R1:** ...`, `- **R2:** ...`, produce a per-R-ID coverage
+table. Read the epic spec's `## Acceptance` section (or the legacy
+`## Acceptance criteria` heading — reviewer MUST tolerate both). If no R-IDs
+are present anywhere, skip this block entirely — the rest of the review is
+unchanged.
+
+For each R-ID, classify status:
+
+| Status | Meaning |
+|--------|---------|
+| met | Diff clearly implements the requirement with appropriate tests/evidence |
+| partial | Diff advances the requirement but leaves gaps (missing tests, missing edge case, missing integration point) |
+| not-addressed | Diff does not advance this requirement at all |
+| deferred | Spec explicitly defers this requirement to a later task/PR |
+
+Report as a markdown table in the review output:
+
+| R-ID | Status | Evidence |
+|------|--------|----------|
+| R1 | met | src/auth.ts:42 + tests/auth.test.ts:17 |
+| R2 | partial | implementation exists but no error-path tests |
+| R3 | not-addressed | — |
+
+After the table, emit one line listing every `not-addressed` R-ID that is NOT
+explicitly deferred in the spec:
+
+> Unaddressed R-IDs: [R3, R5]
+
+If there are zero unaddressed R-IDs, emit `Unaddressed R-IDs: []` or omit the
+line entirely — both forms are valid. Deferred R-IDs are never listed here.
+
+**Verdict gate:** any `not-addressed` R-ID that is NOT marked `deferred` in the
+spec MUST flip the verdict to `NEEDS_WORK`. A clean coverage table (all `met`
+or `deferred`) does not by itself force SHIP — the other review gates still
+apply.
+"""
+
+
 def build_review_prompt(
     review_type: str,
     spec_content: str,
@@ -2524,6 +2665,8 @@ Do NOT mark NEEDS_WORK for:
 You MAY mention these as "FYI" observations without affecting the verdict.
 
 """
+            + R_ID_COVERAGE_BLOCK
+            + "\n"
             + CONFIDENCE_RUBRIC_BLOCK
             + "\n"
             + CLASSIFICATION_RUBRIC_BLOCK
@@ -2543,17 +2686,18 @@ For each surviving `introduced` finding:
 Then, under a separate `## Pre-existing issues (not blocking this verdict)` heading, list each `pre_existing` finding using the compact form `[severity, confidence N, introduced=false] file:line — summary`. Never silently drop pre-existing findings.
 
 After the findings list, emit:
+- The `## Requirements coverage` table and `Unaddressed R-IDs:` line (only when the spec uses R-IDs; otherwise skip).
 - A `Suppressed findings:` line tallying anchors dropped by the gate (omit when nothing was suppressed).
 - A `Classification counts:` line tallying `introduced` vs `pre_existing` survivors, e.g. `Classification counts: 2 introduced, 4 pre_existing.`.
 - A `Protected-path filter:` line tallying findings dropped by the protected-path filter (omit when nothing was dropped).
 
 Be critical. Find real issues.
 
-**Verdict gate:** only `introduced` findings affect the verdict. A review whose sole surviving findings are all `pre_existing` MUST ship.
+**Verdict gate:** only `introduced` findings affect the verdict. A review whose sole surviving findings are all `pre_existing` MUST ship. Any non-deferred `not-addressed` R-ID also forces NEEDS_WORK regardless of other findings.
 
 **REQUIRED**: End your response with exactly one verdict tag:
-<verdict>SHIP</verdict> - Ready to merge (no blocking `introduced` findings)
-<verdict>NEEDS_WORK</verdict> - `introduced` issues must be fixed
+<verdict>SHIP</verdict> - Ready to merge (no blocking `introduced` findings, all R-IDs met or deferred)
+<verdict>NEEDS_WORK</verdict> - `introduced` issues or unaddressed R-IDs must be fixed
 <verdict>MAJOR_RETHINK</verdict> - Fundamental approach problems
 
 Do NOT skip this tag. The automation depends on it."""
@@ -7030,6 +7174,7 @@ Do NOT mark NEEDS_WORK for:
 
 You MAY mention these as "FYI" observations without affecting the verdict.
 
+{R_ID_COVERAGE_BLOCK}
 {CONFIDENCE_RUBRIC_BLOCK}
 {CLASSIFICATION_RUBRIC_BLOCK}
 {PROTECTED_ARTIFACTS_BLOCK}
@@ -7046,17 +7191,18 @@ For each surviving `introduced` finding:
 Then, under a separate `## Pre-existing issues (not blocking this verdict)` heading, list each `pre_existing` finding as `[severity, confidence N, introduced=false] file:line — summary`. Never silently drop pre-existing findings.
 
 After the findings list, emit:
+- The `## Requirements coverage` table and `Unaddressed R-IDs:` line (only when the spec uses R-IDs; otherwise skip).
 - A `Suppressed findings:` line tallying anchors dropped by the gate (omit when nothing was suppressed).
 - A `Classification counts:` line tallying `introduced` vs `pre_existing` survivors, e.g. `Classification counts: 2 introduced, 4 pre_existing.`.
 - A `Protected-path filter:` line tallying findings dropped by the protected-path filter (omit when nothing was dropped).
 
 Be critical. Find real issues.
 
-**Verdict gate:** only `introduced` findings affect the verdict. A review whose sole surviving findings are all `pre_existing` MUST ship.
+**Verdict gate:** only `introduced` findings affect the verdict. A review whose sole surviving findings are all `pre_existing` MUST ship. Any non-deferred `not-addressed` R-ID also forces NEEDS_WORK regardless of other findings.
 
 **REQUIRED**: End your response with exactly one verdict tag:
-- `<verdict>SHIP</verdict>` - Ready to merge (no blocking `introduced` findings)
-- `<verdict>NEEDS_WORK</verdict>` - `introduced` issues must be fixed first
+- `<verdict>SHIP</verdict>` - Ready to merge (no blocking `introduced` findings, all R-IDs met or deferred)
+- `<verdict>NEEDS_WORK</verdict>` - `introduced` issues or unaddressed R-IDs must be fixed first
 - `<verdict>MAJOR_RETHINK</verdict>` - Fundamental problems, reconsider approach
 """
 
@@ -7247,9 +7393,10 @@ def cmd_codex_impl_review(args: argparse.Namespace) -> None:
     # Determine review id (task_id for task reviews, "branch" for standalone)
     review_id = task_id if task_id else "branch"
 
-    # Parse optional review-rigor signals from output (fn-29.3, fn-29.4)
+    # Parse optional review-rigor signals from output (fn-29.2, fn-29.3, fn-29.4)
     suppressed_count = parse_suppressed_count(output)
     classification_counts = parse_classification_counts(output)
+    unaddressed_rids = parse_unaddressed_rids(output)
 
     # Write receipt if path provided (Ralph-compatible schema)
     if receipt_path:
@@ -7280,6 +7427,8 @@ def cmd_codex_impl_review(args: argparse.Namespace) -> None:
         if classification_counts is not None:
             receipt_data["introduced_count"] = classification_counts["introduced"]
             receipt_data["pre_existing_count"] = classification_counts["pre_existing"]
+        if unaddressed_rids is not None:
+            receipt_data["unaddressed"] = unaddressed_rids
         Path(receipt_path).write_text(
             json.dumps(receipt_data, indent=2) + "\n", encoding="utf-8"
         )
@@ -7303,6 +7452,8 @@ def cmd_codex_impl_review(args: argparse.Namespace) -> None:
         if classification_counts is not None:
             json_payload["introduced_count"] = classification_counts["introduced"]
             json_payload["pre_existing_count"] = classification_counts["pre_existing"]
+        if unaddressed_rids is not None:
+            json_payload["unaddressed"] = unaddressed_rids
         json_output(
             json_payload
         )
@@ -7642,6 +7793,8 @@ For EACH requirement from Phase 1:
 - Missing doc updates mentioned in spec
 
 """
+        + R_ID_COVERAGE_BLOCK
+        + "\n"
         + CONFIDENCE_RUBRIC_BLOCK
         + "\n"
         + CLASSIFICATION_RUBRIC_BLOCK
@@ -7671,18 +7824,19 @@ For EACH requirement from Phase 1:
 Pre-existing gaps (code smells or missing features that predate this epic's branch) go under a separate `## Pre-existing issues (not blocking this verdict)` heading and do not gate the verdict.
 
 After the findings list, emit:
+- The `## Requirements coverage` table and `Unaddressed R-IDs:` line (only when the epic spec uses R-IDs; otherwise skip).
 - A `Suppressed findings:` line tallying anchors dropped by the gate (omit when nothing was suppressed).
 - A `Classification counts:` line tallying `introduced` vs `pre_existing` gaps, e.g. `Classification counts: 1 introduced, 0 pre_existing.`.
 - A `Protected-path filter:` line tallying gaps dropped by the protected-path filter (omit when nothing was dropped).
 
 ## Verdict
 
-**SHIP** - All requirements covered. Epic can close.
-**NEEDS_WORK** - Gaps found. Must fix before closing.
+**SHIP** - All requirements covered (all R-IDs met or deferred). Epic can close.
+**NEEDS_WORK** - Gaps found (or unaddressed R-IDs). Must fix before closing.
 
 **REQUIRED**: End your response with exactly one verdict tag:
-<verdict>SHIP</verdict> - All requirements implemented
-<verdict>NEEDS_WORK</verdict> - Gaps need addressing
+<verdict>SHIP</verdict> - All requirements implemented (R-IDs all met or deferred)
+<verdict>NEEDS_WORK</verdict> - Gaps or unaddressed R-IDs need addressing
 
 Do NOT skip this tag. The automation depends on it."""
     )
@@ -7885,9 +8039,10 @@ def cmd_codex_completion_review(args: argparse.Namespace) -> None:
     # Preserve session_id for continuity (avoid clobbering on resumed sessions)
     session_id_to_write = thread_id or session_id
 
-    # Parse optional review-rigor signals from output (fn-29.3, fn-29.4)
+    # Parse optional review-rigor signals from output (fn-29.2, fn-29.3, fn-29.4)
     suppressed_count = parse_suppressed_count(output)
     classification_counts = parse_classification_counts(output)
+    unaddressed_rids = parse_unaddressed_rids(output)
 
     # Write receipt if path provided (Ralph-compatible schema)
     if receipt_path:
@@ -7916,6 +8071,8 @@ def cmd_codex_completion_review(args: argparse.Namespace) -> None:
         if classification_counts is not None:
             receipt_data["introduced_count"] = classification_counts["introduced"]
             receipt_data["pre_existing_count"] = classification_counts["pre_existing"]
+        if unaddressed_rids is not None:
+            receipt_data["unaddressed"] = unaddressed_rids
         Path(receipt_path).write_text(
             json.dumps(receipt_data, indent=2) + "\n", encoding="utf-8"
         )
@@ -7939,6 +8096,8 @@ def cmd_codex_completion_review(args: argparse.Namespace) -> None:
         if classification_counts is not None:
             json_payload["introduced_count"] = classification_counts["introduced"]
             json_payload["pre_existing_count"] = classification_counts["pre_existing"]
+        if unaddressed_rids is not None:
+            json_payload["unaddressed"] = unaddressed_rids
         json_output(json_payload)
     else:
         print(output)
@@ -8137,9 +8296,10 @@ def cmd_copilot_impl_review(args: argparse.Namespace) -> None:
 
     review_id = task_id if task_id else "branch"
 
-    # Parse optional review-rigor signals from output (fn-29.3, fn-29.4)
+    # Parse optional review-rigor signals from output (fn-29.2, fn-29.3, fn-29.4)
     suppressed_count = parse_suppressed_count(output)
     classification_counts = parse_classification_counts(output)
+    unaddressed_rids = parse_unaddressed_rids(output)
 
     if receipt_path:
         receipt_data = {
@@ -8168,6 +8328,8 @@ def cmd_copilot_impl_review(args: argparse.Namespace) -> None:
         if classification_counts is not None:
             receipt_data["introduced_count"] = classification_counts["introduced"]
             receipt_data["pre_existing_count"] = classification_counts["pre_existing"]
+        if unaddressed_rids is not None:
+            receipt_data["unaddressed"] = unaddressed_rids
         Path(receipt_path).write_text(
             json.dumps(receipt_data, indent=2) + "\n", encoding="utf-8"
         )
@@ -8190,6 +8352,8 @@ def cmd_copilot_impl_review(args: argparse.Namespace) -> None:
         if classification_counts is not None:
             json_payload["introduced_count"] = classification_counts["introduced"]
             json_payload["pre_existing_count"] = classification_counts["pre_existing"]
+        if unaddressed_rids is not None:
+            json_payload["unaddressed"] = unaddressed_rids
         json_output(json_payload)
     else:
         print(output)
@@ -8521,9 +8685,10 @@ def cmd_copilot_completion_review(args: argparse.Namespace) -> None:
     # Preserve session_id for continuity (avoid clobbering on resumed sessions)
     session_id_to_write = returned_session_id or session_id
 
-    # Parse optional review-rigor signals from output (fn-29.3, fn-29.4)
+    # Parse optional review-rigor signals from output (fn-29.2, fn-29.3, fn-29.4)
     suppressed_count = parse_suppressed_count(output)
     classification_counts = parse_classification_counts(output)
+    unaddressed_rids = parse_unaddressed_rids(output)
 
     if receipt_path:
         receipt_data = {
@@ -8550,6 +8715,8 @@ def cmd_copilot_completion_review(args: argparse.Namespace) -> None:
         if classification_counts is not None:
             receipt_data["introduced_count"] = classification_counts["introduced"]
             receipt_data["pre_existing_count"] = classification_counts["pre_existing"]
+        if unaddressed_rids is not None:
+            receipt_data["unaddressed"] = unaddressed_rids
         Path(receipt_path).write_text(
             json.dumps(receipt_data, indent=2) + "\n", encoding="utf-8"
         )
@@ -8572,6 +8739,8 @@ def cmd_copilot_completion_review(args: argparse.Namespace) -> None:
         if classification_counts is not None:
             json_payload["introduced_count"] = classification_counts["introduced"]
             json_payload["pre_existing_count"] = classification_counts["pre_existing"]
+        if unaddressed_rids is not None:
+            json_payload["unaddressed"] = unaddressed_rids
         json_output(json_payload)
     else:
         print(output)

--- a/.flow/bin/flowctl.py
+++ b/.flow/bin/flowctl.py
@@ -1693,6 +1693,75 @@ def parse_suppressed_count(output: str) -> Optional[dict[str, int]]:
     return counts or None
 
 
+def parse_classification_counts(output: str) -> Optional[dict[str, int]]:
+    """Extract introduced/pre_existing tallies from review output (fn-29.4).
+
+    Primary signal: a summary line the reviewer is asked to emit, e.g.
+        Classification counts: 2 introduced, 4 pre_existing.
+
+    Fallback: count `Classification: introduced | pre_existing` fragments in
+    per-finding blocks. Either path returns `{"introduced": int, "pre_existing": int}`
+    with zero counts preserved when the other bucket is non-zero — so callers
+    can compute a verdict gate from `introduced_count`. Returns None when no
+    classification signal is present at all (legacy reviews, pre-migration).
+    """
+    if not output:
+        return None
+
+    # Canonical summary line (preferred — reviewer reports tallies directly).
+    summary_match = re.search(
+        r"(?im)^[\s>*_`]*classification\s+counts[\s*_`]*:\s*(.+?)\s*$",
+        output,
+    )
+    if summary_match:
+        payload = summary_match.group(1).strip().rstrip(".")
+        if payload and payload.lower() not in {"none", "n/a"}:
+            found: dict[str, int] = {}
+            for frag_match in re.finditer(
+                r"(\d+)\s*(introduced|pre[-_ ]existing)",
+                payload,
+                re.IGNORECASE,
+            ):
+                raw_bucket = frag_match.group(2).lower().replace("-", "_").replace(
+                    " ", "_"
+                )
+                bucket = "pre_existing" if "pre" in raw_bucket else "introduced"
+                try:
+                    found[bucket] = found.get(bucket, 0) + int(frag_match.group(1))
+                except ValueError:
+                    continue
+            if found:
+                # Fill missing bucket with 0 so downstream always has both keys.
+                found.setdefault("introduced", 0)
+                found.setdefault("pre_existing", 0)
+                return found
+
+    # Fallback: tally per-finding Classification: lines.
+    per_finding: dict[str, int] = {"introduced": 0, "pre_existing": 0}
+    saw_any = False
+    for frag_match in re.finditer(
+        r"(?im)classification[\s*_`]*[:=][\s*_`]*(introduced|pre[-_ ]existing)",
+        output,
+    ):
+        raw_bucket = frag_match.group(1).lower().replace("-", "_").replace(" ", "_")
+        bucket = "pre_existing" if "pre" in raw_bucket else "introduced"
+        per_finding[bucket] += 1
+        saw_any = True
+
+    # Also catch the inline `[..., introduced=false]` / `introduced=true` markers
+    # that appear in the pre-existing-issues report format.
+    for frag_match in re.finditer(
+        r"introduced\s*=\s*(true|false)",
+        output,
+        re.IGNORECASE,
+    ):
+        bucket = "introduced" if frag_match.group(1).lower() == "true" else "pre_existing"
+        per_finding[bucket] += 1
+        saw_any = True
+
+    return per_finding if saw_any else None
+
+
 def is_sandbox_failure(exit_code: int, stdout: str, stderr: str) -> bool:
     """Detect if codex failure is due to sandbox restrictions.
 
@@ -2274,6 +2343,43 @@ Each surviving finding carries a `Confidence: <N>` field alongside severity, fil
 """
 
 
+# --- Introduced-vs-pre_existing classification (fn-29.4) ---
+#
+# Shared classification rubric injected alongside CONFIDENCE_RUBRIC_BLOCK. Only
+# `introduced` findings gate the verdict; `pre_existing` surface in a separate
+# non-blocking section. Keep synchronized with the RP workflow.md files.
+
+CLASSIFICATION_RUBRIC_BLOCK = """## Introduced vs pre-existing classification
+
+For each finding, classify whether this branch's diff caused it:
+
+- **introduced** — this branch caused the issue (new code, or a pre-existing bug that this diff amplified/exposed in a way that now matters)
+- **pre_existing** — the issue was already present on the base branch; this diff did not touch it
+
+Evidence methods (use whatever is cheapest for this diff):
+- `git blame <file> <line>` to see when the line was last touched
+- Read the base-branch version of the file directly
+- Infer from diff context: a finding on an unchanged line in an unchanged file is `pre_existing` by default
+
+**Verdict gate:** only `introduced` findings affect the verdict. A review whose only surviving findings are all `pre_existing` ships.
+
+Report pre-existing findings in a dedicated non-blocking section:
+
+```
+## Pre-existing issues (not blocking this verdict)
+
+- [P1, confidence 75, introduced=false] src/legacy.ts:102 — null dereference on empty array
+- ...
+```
+
+Never delete pre-existing findings from the report — they stay visible for future prioritization. After the lists, emit a `Classification counts:` line tallying both buckets, e.g.:
+
+> Classification counts: 2 introduced, 4 pre_existing.
+
+Each surviving finding carries a `Classification: introduced | pre_existing` field alongside severity, confidence, file, and line.
+"""
+
+
 def build_review_prompt(
     review_type: str,
     spec_content: str,
@@ -2389,23 +2495,32 @@ You MAY mention these as "FYI" observations without affecting the verdict.
 
 """
             + CONFIDENCE_RUBRIC_BLOCK
+            + "\n"
+            + CLASSIFICATION_RUBRIC_BLOCK
             + """
 ## Output Format
 
-For each surviving finding:
+For each surviving `introduced` finding:
 - **Severity**: Critical / Major / Minor / Nitpick (P0 / P1 / P2 / P3 accepted)
 - **Confidence**: 0 / 25 / 50 / 75 / 100 (one of the five discrete anchors)
+- **Classification**: introduced
 - **File:Line**: Exact location
 - **Problem**: What's wrong
 - **Suggestion**: How to fix
 
-After the findings list, emit a `Suppressed findings:` line tallying anchors dropped by the gate (omit when nothing was suppressed).
+Then, under a separate `## Pre-existing issues (not blocking this verdict)` heading, list each `pre_existing` finding using the compact form `[severity, confidence N, introduced=false] file:line — summary`. Never silently drop pre-existing findings.
+
+After the findings list, emit:
+- A `Suppressed findings:` line tallying anchors dropped by the gate (omit when nothing was suppressed).
+- A `Classification counts:` line tallying `introduced` vs `pre_existing` survivors, e.g. `Classification counts: 2 introduced, 4 pre_existing.`.
 
 Be critical. Find real issues.
 
+**Verdict gate:** only `introduced` findings affect the verdict. A review whose sole surviving findings are all `pre_existing` MUST ship.
+
 **REQUIRED**: End your response with exactly one verdict tag:
-<verdict>SHIP</verdict> - Ready to merge
-<verdict>NEEDS_WORK</verdict> - Has issues that must be fixed
+<verdict>SHIP</verdict> - Ready to merge (no blocking `introduced` findings)
+<verdict>NEEDS_WORK</verdict> - `introduced` issues must be fixed
 <verdict>MAJOR_RETHINK</verdict> - Fundamental approach problems
 
 Do NOT skip this tag. The automation depends on it."""
@@ -6878,22 +6993,30 @@ Do NOT mark NEEDS_WORK for:
 You MAY mention these as "FYI" observations without affecting the verdict.
 
 {CONFIDENCE_RUBRIC_BLOCK}
+{CLASSIFICATION_RUBRIC_BLOCK}
 ## Output Format
 
-For each surviving finding:
+For each surviving `introduced` finding:
 - **Severity**: Critical / Major / Minor / Nitpick (P0 / P1 / P2 / P3 accepted)
 - **Confidence**: 0 / 25 / 50 / 75 / 100 (one of the five discrete anchors)
+- **Classification**: introduced
 - **File:Line**: Exact location
 - **Problem**: What's wrong
 - **Suggestion**: How to fix
 
-After the findings list, emit a `Suppressed findings:` line tallying anchors dropped by the gate (omit when nothing was suppressed).
+Then, under a separate `## Pre-existing issues (not blocking this verdict)` heading, list each `pre_existing` finding as `[severity, confidence N, introduced=false] file:line — summary`. Never silently drop pre-existing findings.
+
+After the findings list, emit:
+- A `Suppressed findings:` line tallying anchors dropped by the gate (omit when nothing was suppressed).
+- A `Classification counts:` line tallying `introduced` vs `pre_existing` survivors, e.g. `Classification counts: 2 introduced, 4 pre_existing.`.
 
 Be critical. Find real issues.
 
+**Verdict gate:** only `introduced` findings affect the verdict. A review whose sole surviving findings are all `pre_existing` MUST ship.
+
 **REQUIRED**: End your response with exactly one verdict tag:
-- `<verdict>SHIP</verdict>` - Ready to merge
-- `<verdict>NEEDS_WORK</verdict>` - Issues must be fixed first
+- `<verdict>SHIP</verdict>` - Ready to merge (no blocking `introduced` findings)
+- `<verdict>NEEDS_WORK</verdict>` - `introduced` issues must be fixed first
 - `<verdict>MAJOR_RETHINK</verdict>` - Fundamental problems, reconsider approach
 """
 
@@ -7084,8 +7207,9 @@ def cmd_codex_impl_review(args: argparse.Namespace) -> None:
     # Determine review id (task_id for task reviews, "branch" for standalone)
     review_id = task_id if task_id else "branch"
 
-    # Parse optional review-rigor signals from output (fn-29.3)
+    # Parse optional review-rigor signals from output (fn-29.3, fn-29.4)
     suppressed_count = parse_suppressed_count(output)
+    classification_counts = parse_classification_counts(output)
 
     # Write receipt if path provided (Ralph-compatible schema)
     if receipt_path:
@@ -7113,6 +7237,9 @@ def cmd_codex_impl_review(args: argparse.Namespace) -> None:
             receipt_data["focus"] = focus
         if suppressed_count:
             receipt_data["suppressed_count"] = suppressed_count
+        if classification_counts is not None:
+            receipt_data["introduced_count"] = classification_counts["introduced"]
+            receipt_data["pre_existing_count"] = classification_counts["pre_existing"]
         Path(receipt_path).write_text(
             json.dumps(receipt_data, indent=2) + "\n", encoding="utf-8"
         )
@@ -7133,6 +7260,9 @@ def cmd_codex_impl_review(args: argparse.Namespace) -> None:
         }
         if suppressed_count:
             json_payload["suppressed_count"] = suppressed_count
+        if classification_counts is not None:
+            json_payload["introduced_count"] = classification_counts["introduced"]
+            json_payload["pre_existing_count"] = classification_counts["pre_existing"]
         json_output(
             json_payload
         )
@@ -7473,6 +7603,8 @@ For EACH requirement from Phase 1:
 
 """
         + CONFIDENCE_RUBRIC_BLOCK
+        + "\n"
+        + CLASSIFICATION_RUBRIC_BLOCK
         + """
 ## Output Format
 
@@ -7491,10 +7623,14 @@ For EACH requirement from Phase 1:
 
 ## Gaps Found
 
-[For each GAP, describe what's missing and suggest fix. Include `Confidence: <0|25|50|75|100>`.]
+[For each GAP, describe what's missing and suggest fix. Include `Confidence: <0|25|50|75|100>` and `Classification: introduced | pre_existing` — `pre_existing` means the gap existed before this epic's branch touched the code and is therefore not blocking.]
 ```
 
-After the findings list, emit a `Suppressed findings:` line tallying anchors dropped by the gate (omit when nothing was suppressed).
+Pre-existing gaps (code smells or missing features that predate this epic's branch) go under a separate `## Pre-existing issues (not blocking this verdict)` heading and do not gate the verdict.
+
+After the findings list, emit:
+- A `Suppressed findings:` line tallying anchors dropped by the gate (omit when nothing was suppressed).
+- A `Classification counts:` line tallying `introduced` vs `pre_existing` gaps, e.g. `Classification counts: 1 introduced, 0 pre_existing.`.
 
 ## Verdict
 
@@ -7706,8 +7842,9 @@ def cmd_codex_completion_review(args: argparse.Namespace) -> None:
     # Preserve session_id for continuity (avoid clobbering on resumed sessions)
     session_id_to_write = thread_id or session_id
 
-    # Parse optional review-rigor signals from output (fn-29.3)
+    # Parse optional review-rigor signals from output (fn-29.3, fn-29.4)
     suppressed_count = parse_suppressed_count(output)
+    classification_counts = parse_classification_counts(output)
 
     # Write receipt if path provided (Ralph-compatible schema)
     if receipt_path:
@@ -7733,6 +7870,9 @@ def cmd_codex_completion_review(args: argparse.Namespace) -> None:
                 pass
         if suppressed_count:
             receipt_data["suppressed_count"] = suppressed_count
+        if classification_counts is not None:
+            receipt_data["introduced_count"] = classification_counts["introduced"]
+            receipt_data["pre_existing_count"] = classification_counts["pre_existing"]
         Path(receipt_path).write_text(
             json.dumps(receipt_data, indent=2) + "\n", encoding="utf-8"
         )
@@ -7753,6 +7893,9 @@ def cmd_codex_completion_review(args: argparse.Namespace) -> None:
         }
         if suppressed_count:
             json_payload["suppressed_count"] = suppressed_count
+        if classification_counts is not None:
+            json_payload["introduced_count"] = classification_counts["introduced"]
+            json_payload["pre_existing_count"] = classification_counts["pre_existing"]
         json_output(json_payload)
     else:
         print(output)
@@ -7951,8 +8094,9 @@ def cmd_copilot_impl_review(args: argparse.Namespace) -> None:
 
     review_id = task_id if task_id else "branch"
 
-    # Parse optional review-rigor signals from output (fn-29.3)
+    # Parse optional review-rigor signals from output (fn-29.3, fn-29.4)
     suppressed_count = parse_suppressed_count(output)
+    classification_counts = parse_classification_counts(output)
 
     if receipt_path:
         receipt_data = {
@@ -7978,6 +8122,9 @@ def cmd_copilot_impl_review(args: argparse.Namespace) -> None:
             receipt_data["focus"] = focus
         if suppressed_count:
             receipt_data["suppressed_count"] = suppressed_count
+        if classification_counts is not None:
+            receipt_data["introduced_count"] = classification_counts["introduced"]
+            receipt_data["pre_existing_count"] = classification_counts["pre_existing"]
         Path(receipt_path).write_text(
             json.dumps(receipt_data, indent=2) + "\n", encoding="utf-8"
         )
@@ -7997,6 +8144,9 @@ def cmd_copilot_impl_review(args: argparse.Namespace) -> None:
         }
         if suppressed_count:
             json_payload["suppressed_count"] = suppressed_count
+        if classification_counts is not None:
+            json_payload["introduced_count"] = classification_counts["introduced"]
+            json_payload["pre_existing_count"] = classification_counts["pre_existing"]
         json_output(json_payload)
     else:
         print(output)
@@ -8328,8 +8478,9 @@ def cmd_copilot_completion_review(args: argparse.Namespace) -> None:
     # Preserve session_id for continuity (avoid clobbering on resumed sessions)
     session_id_to_write = returned_session_id or session_id
 
-    # Parse optional review-rigor signals from output (fn-29.3)
+    # Parse optional review-rigor signals from output (fn-29.3, fn-29.4)
     suppressed_count = parse_suppressed_count(output)
+    classification_counts = parse_classification_counts(output)
 
     if receipt_path:
         receipt_data = {
@@ -8353,6 +8504,9 @@ def cmd_copilot_completion_review(args: argparse.Namespace) -> None:
                 pass
         if suppressed_count:
             receipt_data["suppressed_count"] = suppressed_count
+        if classification_counts is not None:
+            receipt_data["introduced_count"] = classification_counts["introduced"]
+            receipt_data["pre_existing_count"] = classification_counts["pre_existing"]
         Path(receipt_path).write_text(
             json.dumps(receipt_data, indent=2) + "\n", encoding="utf-8"
         )
@@ -8372,6 +8526,9 @@ def cmd_copilot_completion_review(args: argparse.Namespace) -> None:
         }
         if suppressed_count:
             json_payload["suppressed_count"] = suppressed_count
+        if classification_counts is not None:
+            json_payload["introduced_count"] = classification_counts["introduced"]
+            json_payload["pre_existing_count"] = classification_counts["pre_existing"]
         json_output(json_payload)
     else:
         print(output)

--- a/.flow/bin/flowctl.py
+++ b/.flow/bin/flowctl.py
@@ -2380,6 +2380,36 @@ Each surviving finding carries a `Classification: introduced | pre_existing` fie
 """
 
 
+# --- Protected artifacts (fn-29.5) ---
+#
+# Safety rail: external reviewers (codex/copilot on unfamiliar projects) routinely
+# look at committed `.flow/*` JSONs/specs and naturally suggest "why are these
+# committed?" Ralph in autofix mode could then apply that finding and destroy its
+# own state. This block is injected alongside the confidence + classification
+# rubrics so every review backend (rp, codex, copilot) honors the same hard list.
+# Keep synchronized with the three workflow.md files + quality-auditor.md.
+
+PROTECTED_ARTIFACTS_BLOCK = """## Protected artifacts
+
+The following paths are flow-next / project-pipeline artifacts. Any finding recommending their deletion, gitignore, or removal MUST be discarded during synthesis. Do not flag these paths for cleanup under any circumstances:
+
+- `.flow/*` — flow-next state, specs, tasks, epics, runtime
+- `.flow/bin/*` — bundled flowctl
+- `.flow/memory/*` — learnings store (pitfalls, conventions, decisions)
+- `.flow/specs/*.md` — epic specs (decision artifacts)
+- `.flow/tasks/*.md` — task specs (decision artifacts)
+- `docs/plans/*` — plan artifacts (if project uses this convention)
+- `docs/solutions/*` — solutions artifacts (if project uses this convention)
+- `scripts/ralph/*` — Ralph harness (when present)
+
+These files are intentionally committed. They are the pipeline's state, not clutter. An agent that deletes them destroys the project's planning trail and breaks Ralph autonomous runs.
+
+If you notice genuine issues with content INSIDE these files (e.g., a spec that contradicts itself, a stale runtime value, a memory entry that's wrong), flag the content — not the file's existence.
+
+**Protected-path filter.** Before emitting findings, scan each for recommendations to delete, gitignore, or `rm -rf` any path matching the protected list above. Drop those findings. If you drop any, report the drop count in a `Protected-path filter:` line in the review output (e.g. `Protected-path filter: dropped 2 findings`). Omit the line when nothing was dropped.
+"""
+
+
 def build_review_prompt(
     review_type: str,
     spec_content: str,
@@ -2497,6 +2527,8 @@ You MAY mention these as "FYI" observations without affecting the verdict.
             + CONFIDENCE_RUBRIC_BLOCK
             + "\n"
             + CLASSIFICATION_RUBRIC_BLOCK
+            + "\n"
+            + PROTECTED_ARTIFACTS_BLOCK
             + """
 ## Output Format
 
@@ -2513,6 +2545,7 @@ Then, under a separate `## Pre-existing issues (not blocking this verdict)` head
 After the findings list, emit:
 - A `Suppressed findings:` line tallying anchors dropped by the gate (omit when nothing was suppressed).
 - A `Classification counts:` line tallying `introduced` vs `pre_existing` survivors, e.g. `Classification counts: 2 introduced, 4 pre_existing.`.
+- A `Protected-path filter:` line tallying findings dropped by the protected-path filter (omit when nothing was dropped).
 
 Be critical. Find real issues.
 
@@ -2568,6 +2601,9 @@ Do NOT mark NEEDS_WORK for:
 
 You MAY mention these as "FYI" observations without affecting the verdict.
 
+"""
+            + PROTECTED_ARTIFACTS_BLOCK
+            + """
 ## Output Format
 
 For each issue found:
@@ -2575,6 +2611,8 @@ For each issue found:
 - **Location**: Which task or section (e.g., "fn-1.3 Description" or "Epic Acceptance #2")
 - **Problem**: What's wrong
 - **Suggestion**: How to fix
+
+After the issues list, emit a `Protected-path filter:` line tallying findings dropped by the protected-path filter (omit when nothing was dropped).
 
 Be critical. Find real issues.
 
@@ -6994,6 +7032,7 @@ You MAY mention these as "FYI" observations without affecting the verdict.
 
 {CONFIDENCE_RUBRIC_BLOCK}
 {CLASSIFICATION_RUBRIC_BLOCK}
+{PROTECTED_ARTIFACTS_BLOCK}
 ## Output Format
 
 For each surviving `introduced` finding:
@@ -7009,6 +7048,7 @@ Then, under a separate `## Pre-existing issues (not blocking this verdict)` head
 After the findings list, emit:
 - A `Suppressed findings:` line tallying anchors dropped by the gate (omit when nothing was suppressed).
 - A `Classification counts:` line tallying `introduced` vs `pre_existing` survivors, e.g. `Classification counts: 2 introduced, 4 pre_existing.`.
+- A `Protected-path filter:` line tallying findings dropped by the protected-path filter (omit when nothing was dropped).
 
 Be critical. Find real issues.
 
@@ -7605,6 +7645,8 @@ For EACH requirement from Phase 1:
         + CONFIDENCE_RUBRIC_BLOCK
         + "\n"
         + CLASSIFICATION_RUBRIC_BLOCK
+        + "\n"
+        + PROTECTED_ARTIFACTS_BLOCK
         + """
 ## Output Format
 
@@ -7631,6 +7673,7 @@ Pre-existing gaps (code smells or missing features that predate this epic's bran
 After the findings list, emit:
 - A `Suppressed findings:` line tallying anchors dropped by the gate (omit when nothing was suppressed).
 - A `Classification counts:` line tallying `introduced` vs `pre_existing` gaps, e.g. `Classification counts: 1 introduced, 0 pre_existing.`.
+- A `Protected-path filter:` line tallying gaps dropped by the protected-path filter (omit when nothing was dropped).
 
 ## Verdict
 

--- a/.flow/bin/flowctl.py
+++ b/.flow/bin/flowctl.py
@@ -8886,9 +8886,12 @@ def _classify_triage_path(path: str) -> str:
         return "other"
 
     # Generated / vendored wins over extension match — e.g. a .ts file under
-    # node_modules/ is still "generated" for our purposes.
+    # node_modules/ is still "generated" for our purposes. Match only at the
+    # repo-root prefix; git diff output is always repo-root-relative, and a
+    # loose substring match would false-positive paths like `scripts/build/…`
+    # against the `build/` prefix.
     for prefix in TRIAGE_GENERATED_PREFIXES:
-        if p.startswith(prefix) or f"/{prefix}" in f"/{p}":
+        if p.startswith(prefix):
             return "generated"
 
     base = p.rsplit("/", 1)[-1]
@@ -8919,13 +8922,88 @@ def _classify_triage_path(path: str) -> str:
     return "other"
 
 
-def _triage_deterministic(changed_files: list[str]) -> tuple[Optional[str], str]:
+_TRIAGE_VERSION_JSON_RE = re.compile(r'^\s*"version"\s*:\s*"[^"]*"\s*,?\s*$')
+_TRIAGE_VERSION_TOML_RE = re.compile(r'^\s*version\s*=\s*"[^"]*"\s*$')
+
+
+def _triage_chore_is_version_only(
+    path: str, base: str, repo_root: str
+) -> bool:
+    """Verify a chore-classified file's diff only touches version-like fields.
+
+    A file is basename-matched as ``chore`` (``package.json``, ``plugin.json``,
+    ``Cargo.toml``, ``pyproject.toml``, ``CHANGELOG.md``) but that alone does
+    not prove the edit is trivial — changing ``package.json`` dependencies or
+    scripts must still route through a full review. This helper inspects the
+    actual diff hunks and returns True only when every +/- content line is:
+
+    - a ``"version": "..."`` line (JSON manifests), or
+    - a ``version = "..."`` line (TOML manifests), or
+    - any addition-only line for ``CHANGELOG.md`` (prose content).
+
+    Any other modification (dependency bumps, script edits, CHANGELOG
+    deletions, etc.) disqualifies the file and the triage-skip layer falls
+    through to full review.
+    """
+    try:
+        proc = subprocess.run(
+            ["git", "diff", "--unified=0", f"{base}..HEAD", "--", path],
+            capture_output=True,
+            text=True,
+            check=False,
+            cwd=repo_root,
+        )
+    except OSError:
+        return False
+    if proc.returncode != 0 or not proc.stdout:
+        return False
+
+    base_name = path.rsplit("/", 1)[-1]
+    is_changelog = base_name == "CHANGELOG.md"
+    is_json = base_name.endswith(".json")
+    is_toml = base_name.endswith(".toml")
+
+    saw_change = False
+    for line in proc.stdout.splitlines():
+        if line.startswith(("+++", "---", "diff ", "index ", "@@", "Binary ")):
+            continue
+        if not (line.startswith("+") or line.startswith("-")):
+            continue
+        content = line[1:]
+        if not content.strip():
+            continue
+        saw_change = True
+        if is_changelog:
+            # CHANGELOG-only edits are safe when purely additive. Removals
+            # (history rewrites, entry deletions) warrant a full review.
+            if line.startswith("-"):
+                return False
+            continue
+        if is_json and _TRIAGE_VERSION_JSON_RE.match(content):
+            continue
+        if is_toml and _TRIAGE_VERSION_TOML_RE.match(content):
+            continue
+        return False
+    return saw_change
+
+
+def _triage_deterministic(
+    changed_files: list[str],
+    base: Optional[str] = None,
+    repo_root: Optional[str] = None,
+) -> tuple[Optional[str], str]:
     """Run the deterministic layer of triage.
 
     Returns ``(verdict_or_none, reason)``:
       - ``("SKIP", reason)`` — whitelist match, safe to skip
       - ``("REVIEW", reason)`` — hard override (code change, empty diff, etc.)
       - ``(None, reason)`` — ambiguous; caller may run LLM judge or default REVIEW
+
+    When ``chore``-classified files (manifests, CHANGELOG) are present, a
+    content-level check is required: callers must pass ``base`` + ``repo_root``
+    so the helper can inspect diff hunks. Without git context the chore path
+    falls through to ambiguous to prevent non-trivial ``package.json`` edits
+    from bypassing full review.
 
     ``reason`` is always a one-line human-readable string.
     """
@@ -8957,6 +9035,22 @@ def _triage_deterministic(changed_files: list[str]) -> tuple[Optional[str], str]
     # At this point every file is in {lockfile, docs, chore, generated}.
     kinds = set(buckets.keys())
 
+    # Chore-containing shapes require content verification before SKIP.
+    if "chore" in buckets:
+        if base is None or repo_root is None:
+            return (
+                None,
+                "manifest change (needs content verification — no git context)",
+            )
+        unverified = [
+            f
+            for f in buckets["chore"]
+            if not _triage_chore_is_version_only(f, base, repo_root)
+        ]
+        if unverified:
+            example = unverified[0]
+            return None, f"manifest edit beyond version field: {example}"
+
     if kinds == {"lockfile"}:
         if len(changed_files) == 1:
             return "SKIP", f"lockfile-only ({changed_files[0]})"
@@ -8973,24 +9067,17 @@ def _triage_deterministic(changed_files: list[str]) -> tuple[Optional[str], str]
         return "SKIP", f"generated-only ({len(changed_files)} files)"
 
     if kinds <= {"chore"}:
-        # pure manifest-only — allow (version bumps without CHANGELOG still count)
         return "SKIP", f"release-chore ({len(changed_files)} manifest files)"
 
     if kinds <= {"chore", "docs"}:
-        # Release chore with CHANGELOG + version bumps. Keep a tight cap so
-        # "one line of chore + a whole docs rewrite" doesn't silently slip.
         chore_files = buckets.get("chore", [])
         doc_files = buckets.get("docs", [])
-        # Only allow SKIP when the manifest file(s) look like version bumps —
-        # we trust the basename whitelist here and rely on the conservative
-        # default.
         return (
             "SKIP",
             f"release-chore ({len(chore_files)} manifest + {len(doc_files)} doc file(s))",
         )
 
     if kinds <= {"lockfile", "chore"}:
-        # dep update that also bumps package.json — common shape, safe.
         return (
             "SKIP",
             f"dep-update ({len(buckets.get('lockfile', []))} lock + "
@@ -9232,8 +9319,11 @@ def cmd_triage_skip(args: argparse.Namespace) -> None:
     except OSError:
         pass
 
-    # Deterministic layer.
-    det_verdict, det_reason = _triage_deterministic(changed_files)
+    # Deterministic layer. Pass git context so the chore-path content check
+    # can inspect diff hunks and reject non-trivial manifest edits.
+    det_verdict, det_reason = _triage_deterministic(
+        changed_files, base=base, repo_root=repo_root
+    )
 
     verdict: Optional[str] = det_verdict
     reason: str = det_reason

--- a/.flow/bin/flowctl.py
+++ b/.flow/bin/flowctl.py
@@ -8578,6 +8578,597 @@ def cmd_copilot_completion_review(args: argparse.Namespace) -> None:
         print(f"\nVERDICT={verdict or 'UNKNOWN'}")
 
 
+# --- Trivial-diff triage (fn-29.6) ---
+#
+# Fast pre-check before full impl-review: judges whether the diff is worth
+# a Carmack-level review. Saves rp/codex/copilot calls on lockfile-only /
+# release-chore / docs-only / generated-only commits. Conservative:
+# "when in doubt, REVIEW" — false SKIPs are strictly worse than false REVIEWs.
+#
+# Strategy (hybrid, deterministic-first):
+#   1. Deterministic REVIEW-override: any file that matches a code path
+#      (src/, flowctl.py, *.py/.ts/.js/.go/.rs/.sh/..., etc.) forces REVIEW
+#      without an LLM call. This is AC9.
+#   2. Deterministic SKIP whitelist: lockfile-only / docs-only / release-
+#      chore / generated-only diffs. Tight, narrow match — everything else
+#      falls through.
+#   3. Optional LLM judge (`--backend codex|copilot`) for ambiguous diffs.
+#      When tooling is unavailable, falls through to REVIEW (exit 1).
+#
+# Exit codes:
+#   0  SKIP (verdict=SHIP)
+#   1  proceed to full review (verdict not set by triage)
+#   2+ error (bad args, tooling unavailable when required, malformed output)
+
+TRIAGE_LOCKFILES: frozenset[str] = frozenset({
+    # Exact basenames only; matching is case-sensitive on basename.
+    "package-lock.json",
+    "bun.lock",
+    "bun.lockb",
+    "pnpm-lock.yaml",
+    "yarn.lock",
+    "Gemfile.lock",
+    "poetry.lock",
+    "Cargo.lock",
+    "uv.lock",
+    "composer.lock",
+    "mix.lock",
+    "go.sum",
+})
+
+TRIAGE_RELEASE_CHORE_BASENAMES: frozenset[str] = frozenset({
+    "plugin.json",
+    "package.json",
+    "Cargo.toml",
+    "pyproject.toml",
+    "CHANGELOG.md",
+})
+
+# Generated / vendored path prefixes. Matched against POSIX-normalized path
+# substrings. Keep this list tight — overly broad matches silently skip real
+# review work.
+TRIAGE_GENERATED_PREFIXES: tuple[str, ...] = (
+    "plugins/flow-next/codex/",
+    "node_modules/",
+    "vendor/",
+    "third_party/",
+    "dist/",
+    "build/",
+    ".next/",
+)
+
+# Extensions treated as executable code. A single match forces REVIEW.
+# Keep synchronized with common code files the reviewer actually needs to see.
+TRIAGE_CODE_EXTS: frozenset[str] = frozenset({
+    ".py",
+    ".pyi",
+    ".js",
+    ".jsx",
+    ".mjs",
+    ".cjs",
+    ".ts",
+    ".tsx",
+    ".go",
+    ".rs",
+    ".rb",
+    ".java",
+    ".kt",
+    ".scala",
+    ".swift",
+    ".cs",
+    ".c",
+    ".cc",
+    ".cpp",
+    ".cxx",
+    ".h",
+    ".hh",
+    ".hpp",
+    ".hxx",
+    ".sh",
+    ".bash",
+    ".zsh",
+    ".fish",
+    ".lua",
+    ".pl",
+    ".php",
+    ".ex",
+    ".exs",
+    ".erl",
+    ".elm",
+    ".clj",
+    ".sql",
+})
+
+# Docs-only extensions. A diff of only these (outside .flow/specs or
+# .flow/tasks — those are artifacts, not pure docs) may SKIP.
+TRIAGE_DOC_EXTS: frozenset[str] = frozenset({
+    ".md",
+    ".mdx",
+    ".txt",
+    ".rst",
+    ".adoc",
+})
+
+# Paths that are artifacts (not code, not docs). Changes here can be
+# semantically important (task status etc.) — conservative: treat as REVIEW
+# when present without other SKIP-category files.
+TRIAGE_ARTIFACT_PREFIXES: tuple[str, ...] = (
+    ".flow/specs/",
+    ".flow/tasks/",
+    ".flow/epics/",
+)
+
+
+def _classify_triage_path(path: str) -> str:
+    """Classify a changed file into one triage bucket.
+
+    Returns one of:
+      - ``code``      — forces REVIEW
+      - ``lockfile``  — SKIP candidate
+      - ``docs``      — SKIP candidate
+      - ``chore``     — release-chore SKIP candidate
+      - ``generated`` — SKIP candidate
+      - ``artifact``  — flow state spec/task (do not SKIP on these alone)
+      - ``other``     — unknown; forces REVIEW by fallthrough
+    """
+    # Normalize to POSIX for stable prefix matching even on Windows checkouts.
+    p = path.replace("\\", "/").strip()
+    if not p:
+        return "other"
+
+    # Generated / vendored wins over extension match — e.g. a .ts file under
+    # node_modules/ is still "generated" for our purposes.
+    for prefix in TRIAGE_GENERATED_PREFIXES:
+        if p.startswith(prefix) or f"/{prefix}" in f"/{p}":
+            return "generated"
+
+    base = p.rsplit("/", 1)[-1]
+    if base in TRIAGE_LOCKFILES:
+        return "lockfile"
+
+    # Artifacts (flow state) before release-chore — plugin.json inside
+    # .flow/epics/ isn't a chore.
+    for prefix in TRIAGE_ARTIFACT_PREFIXES:
+        if p.startswith(prefix):
+            return "artifact"
+
+    if base in TRIAGE_RELEASE_CHORE_BASENAMES:
+        return "chore"
+
+    # Extension-based classification. ``os.path.splitext`` handles multi-dot
+    # filenames (``foo.test.ts`` → ``.ts``).
+    ext = ""
+    dot = base.rfind(".")
+    if dot > 0:
+        ext = base[dot:].lower()
+
+    if ext in TRIAGE_CODE_EXTS:
+        return "code"
+    if ext in TRIAGE_DOC_EXTS:
+        return "docs"
+
+    return "other"
+
+
+def _triage_deterministic(changed_files: list[str]) -> tuple[Optional[str], str]:
+    """Run the deterministic layer of triage.
+
+    Returns ``(verdict_or_none, reason)``:
+      - ``("SKIP", reason)`` — whitelist match, safe to skip
+      - ``("REVIEW", reason)`` — hard override (code change, empty diff, etc.)
+      - ``(None, reason)`` — ambiguous; caller may run LLM judge or default REVIEW
+
+    ``reason`` is always a one-line human-readable string.
+    """
+    if not changed_files:
+        # No diff at all — nothing to review. Conservative: REVIEW so the
+        # caller sees this as an odd case (empty diff usually means bad base).
+        return "REVIEW", "no changed files (empty diff — refusing to skip)"
+
+    buckets: dict[str, list[str]] = {}
+    for f in changed_files:
+        kind = _classify_triage_path(f)
+        buckets.setdefault(kind, []).append(f)
+
+    # Any code file → REVIEW (AC9: src/, flowctl.py always reviewed).
+    if "code" in buckets:
+        example = buckets["code"][0]
+        return "REVIEW", f"code change detected: {example}"
+
+    # Any artifact file → REVIEW (flow state can carry semantic intent).
+    if "artifact" in buckets:
+        example = buckets["artifact"][0]
+        return "REVIEW", f"flow artifact change detected: {example}"
+
+    # Any unknown/other file → REVIEW (conservative fallthrough).
+    if "other" in buckets:
+        example = buckets["other"][0]
+        return "REVIEW", f"unclassified path: {example}"
+
+    # At this point every file is in {lockfile, docs, chore, generated}.
+    kinds = set(buckets.keys())
+
+    if kinds == {"lockfile"}:
+        if len(changed_files) == 1:
+            return "SKIP", f"lockfile-only ({changed_files[0]})"
+        return "SKIP", f"lockfile-only ({len(changed_files)} lock files)"
+
+    if kinds == {"docs"}:
+        if len(changed_files) == 1:
+            return "SKIP", f"docs-only ({changed_files[0]})"
+        return "SKIP", f"docs-only ({len(changed_files)} files)"
+
+    if kinds == {"generated"}:
+        if len(changed_files) == 1:
+            return "SKIP", f"generated-only ({changed_files[0]})"
+        return "SKIP", f"generated-only ({len(changed_files)} files)"
+
+    if kinds <= {"chore"}:
+        # pure manifest-only — allow (version bumps without CHANGELOG still count)
+        return "SKIP", f"release-chore ({len(changed_files)} manifest files)"
+
+    if kinds <= {"chore", "docs"}:
+        # Release chore with CHANGELOG + version bumps. Keep a tight cap so
+        # "one line of chore + a whole docs rewrite" doesn't silently slip.
+        chore_files = buckets.get("chore", [])
+        doc_files = buckets.get("docs", [])
+        # Only allow SKIP when the manifest file(s) look like version bumps —
+        # we trust the basename whitelist here and rely on the conservative
+        # default.
+        return (
+            "SKIP",
+            f"release-chore ({len(chore_files)} manifest + {len(doc_files)} doc file(s))",
+        )
+
+    if kinds <= {"lockfile", "chore"}:
+        # dep update that also bumps package.json — common shape, safe.
+        return (
+            "SKIP",
+            f"dep-update ({len(buckets.get('lockfile', []))} lock + "
+            f"{len(buckets.get('chore', []))} manifest file(s))",
+        )
+
+    if kinds <= {"lockfile", "generated"}:
+        return (
+            "SKIP",
+            f"lockfile+generated ({len(changed_files)} files)",
+        )
+
+    # Anything else — mixed or unknown combo — fall through to LLM / default REVIEW.
+    return None, f"mixed non-code categories: {sorted(kinds)}"
+
+
+def _triage_build_llm_prompt(
+    diff_stat: str, changed_files: list[str]
+) -> str:
+    """Build the one-shot triage prompt for fast-model judgment."""
+    # Cap the file list + stat to keep the prompt cheap.
+    files_preview = "\n".join(changed_files[:50])
+    if len(changed_files) > 50:
+        files_preview += f"\n... ({len(changed_files) - 50} more)"
+    stat = diff_stat.strip() or "(diff stat unavailable)"
+    return f"""Diff summary:
+{stat}
+
+Changed files:
+{files_preview}
+
+Is this diff worth a full code review?
+
+Answer SKIP only if the diff matches one of:
+- Lockfile-only bumps: package-lock.json, bun.lock, pnpm-lock.yaml, yarn.lock, Gemfile.lock, poetry.lock, Cargo.lock, uv.lock (and nothing else)
+- Pure release chore: version bump in plugin.json / package.json / Cargo.toml + CHANGELOG entry, no other code
+- Pure documentation: only *.md files changed, no executable code
+- Pure generated-file regeneration: plugins/flow-next/codex/ (from sync-codex.sh), or other clearly-generated paths
+- Pure vendored-asset changes: files under /vendor/, /third_party/, or similarly designated paths
+
+When in doubt, answer REVIEW. A missed review is worse than a skipped chore.
+
+Output exactly one line:
+SKIP: <one-line reason>
+or
+REVIEW: <one-line reason>
+"""
+
+
+def _triage_parse_llm_output(text: str) -> tuple[Optional[str], str]:
+    """Parse SKIP/REVIEW line from LLM output. Conservative on malformed."""
+    if not text:
+        return None, "empty LLM response"
+    # Prefer the last matching line so trailing reasoning doesn't win.
+    verdict: Optional[str] = None
+    reason: str = ""
+    for raw in text.splitlines():
+        line = raw.strip().lstrip(">*_ `").rstrip()
+        if not line:
+            continue
+        m = re.match(r"^(SKIP|REVIEW)\s*:\s*(.+?)\s*$", line, re.IGNORECASE)
+        if m:
+            verdict = m.group(1).upper()
+            reason = m.group(2).strip()
+    if verdict is None:
+        return None, "malformed LLM response (no SKIP:/REVIEW: line)"
+    return verdict, reason
+
+
+def _triage_run_codex_judge(
+    prompt: str, model: Optional[str], effort: Optional[str]
+) -> tuple[Optional[str], str, Optional[str]]:
+    """Invoke codex as the triage judge. Returns (verdict, reason, model_used).
+
+    verdict is ``SKIP`` / ``REVIEW`` / ``None`` (on tooling failure or malformed).
+    """
+    codex = shutil.which("codex")
+    if not codex:
+        return None, "codex CLI not available for triage", None
+    effective_model = model or "gpt-5-mini"
+    effective_effort = effort or "low"
+    cmd = [
+        codex,
+        "exec",
+        "--model",
+        effective_model,
+        "-c",
+        f'model_reasoning_effort="{effective_effort}"',
+        "--sandbox",
+        "read-only" if os.name != "nt" else "danger-full-access",
+        "--skip-git-repo-check",
+        "-",
+    ]
+    try:
+        result = subprocess.run(
+            cmd,
+            input=prompt,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=120,
+        )
+    except subprocess.TimeoutExpired:
+        return None, "codex triage timed out (120s)", effective_model
+    except OSError as e:
+        return None, f"codex triage OS error: {e}", effective_model
+    if result.returncode != 0:
+        msg = (result.stderr or "codex triage exited non-zero").strip().splitlines()[-1]
+        return None, f"codex triage failed: {msg}", effective_model
+    verdict, reason = _triage_parse_llm_output(result.stdout)
+    return verdict, reason, effective_model
+
+
+def _triage_run_copilot_judge(
+    prompt: str, model: Optional[str], effort: Optional[str]
+) -> tuple[Optional[str], str, Optional[str]]:
+    """Invoke copilot as the triage judge."""
+    copilot = shutil.which("copilot")
+    if not copilot:
+        return None, "copilot CLI not available for triage", None
+    effective_model = model or "claude-haiku-4.5"
+    effective_effort = effort or "low"
+    repo_root = get_repo_root()
+    cmd = [
+        copilot,
+        "-p",
+        prompt,
+        f"--resume={uuid.uuid4()}",
+        "--output-format",
+        "text",
+        "-s",
+        "--no-ask-user",
+        "--allow-all-tools",
+        "--add-dir",
+        str(repo_root),
+        "--disable-builtin-mcps",
+        "--no-custom-instructions",
+        "--log-level",
+        "error",
+        "--no-auto-update",
+        "--model",
+        effective_model,
+    ]
+    if not effective_model.startswith("claude-"):
+        cmd += ["--effort", effective_effort]
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=120,
+        )
+    except subprocess.TimeoutExpired:
+        return None, "copilot triage timed out (120s)", effective_model
+    except OSError as e:
+        return None, f"copilot triage OS error: {e}", effective_model
+    if result.returncode != 0:
+        msg = (result.stderr or "copilot triage exited non-zero").strip().splitlines()[-1]
+        return None, f"copilot triage failed: {msg}", effective_model
+    verdict, reason = _triage_parse_llm_output(result.stdout)
+    return verdict, reason, effective_model
+
+
+def cmd_triage_skip(args: argparse.Namespace) -> None:
+    """Trivial-diff triage pre-check.
+
+    Decides whether the diff between ``--base`` and HEAD is worth a full
+    Carmack-level review. Uses a deterministic whitelist first (lockfiles,
+    docs-only, generated, release-chore) and an optional LLM judge only for
+    ambiguous cases. When in doubt, falls through to exit 1 (proceed to
+    full review) — false SKIPs are strictly worse than false REVIEWs.
+
+    Exit codes:
+        0   SKIP (verdict=SHIP, receipt written if --receipt)
+        1   proceed to full review
+        2+  error (invalid arguments, malformed state)
+    """
+    base = args.base or "main"
+    # Resolve 'main' vs 'master' when caller didn't specify --base.
+    if not args.base:
+        repo_root = get_repo_root()
+        try:
+            subprocess.run(
+                ["git", "rev-parse", "--verify", "main"],
+                capture_output=True,
+                check=True,
+                cwd=repo_root,
+            )
+        except (subprocess.CalledProcessError, OSError):
+            try:
+                subprocess.run(
+                    ["git", "rev-parse", "--verify", "master"],
+                    capture_output=True,
+                    check=True,
+                    cwd=repo_root,
+                )
+                base = "master"
+            except (subprocess.CalledProcessError, OSError):
+                # Leave base="main"; git diff will fail below and we'll surface
+                # that as an error exit.
+                pass
+
+    repo_root = get_repo_root()
+    # Gather changed file list.
+    try:
+        proc = subprocess.run(
+            ["git", "diff", "--name-only", f"{base}..HEAD"],
+            capture_output=True,
+            text=True,
+            check=False,
+            cwd=repo_root,
+        )
+    except OSError as e:
+        error_exit(f"git diff failed: {e}", use_json=args.json, code=2)
+    if proc.returncode != 0:
+        stderr = (proc.stderr or "").strip()
+        error_exit(
+            f"git diff --name-only {base}..HEAD failed: {stderr}",
+            use_json=args.json,
+            code=2,
+        )
+    changed_files = [
+        line.strip() for line in proc.stdout.splitlines() if line.strip()
+    ]
+
+    # Gather --stat for the LLM prompt (best-effort).
+    diff_stat = ""
+    try:
+        stat_proc = subprocess.run(
+            ["git", "diff", "--stat", f"{base}..HEAD"],
+            capture_output=True,
+            text=True,
+            check=False,
+            cwd=repo_root,
+        )
+        if stat_proc.returncode == 0:
+            diff_stat = stat_proc.stdout.strip()
+    except OSError:
+        pass
+
+    # Deterministic layer.
+    det_verdict, det_reason = _triage_deterministic(changed_files)
+
+    verdict: Optional[str] = det_verdict
+    reason: str = det_reason
+    model_used: Optional[str] = None
+    judge_source = "deterministic"
+
+    # Optional LLM judge for ambiguous cases. ``--no-llm`` skips the call and
+    # defaults to REVIEW so tests / offline runs remain deterministic.
+    if det_verdict is None and not args.no_llm:
+        backend = (args.backend or "codex").strip().lower()
+        if backend == "codex":
+            v, r, m = _triage_run_codex_judge(
+                _triage_build_llm_prompt(diff_stat, changed_files),
+                args.model,
+                args.effort,
+            )
+        elif backend == "copilot":
+            v, r, m = _triage_run_copilot_judge(
+                _triage_build_llm_prompt(diff_stat, changed_files),
+                args.model,
+                args.effort,
+            )
+        else:
+            error_exit(
+                f"Unknown triage backend: {backend!r}. Valid: codex, copilot",
+                use_json=args.json,
+                code=2,
+            )
+        model_used = m
+        judge_source = f"{backend}-judge"
+        if v is None:
+            # Judge failed or malformed — conservative fallthrough to REVIEW.
+            verdict = "REVIEW"
+            reason = f"{r} (defaulting to REVIEW)"
+        else:
+            verdict = v
+            reason = r
+    elif det_verdict is None:
+        # No LLM path and deterministic was ambiguous → REVIEW (conservative).
+        verdict = "REVIEW"
+        reason = f"{det_reason} (no LLM, defaulting to REVIEW)"
+
+    # Write receipt on SKIP (only when requested). REVIEW path leaves receipt
+    # untouched so the downstream impl-review can write its own receipt.
+    receipt_written: Optional[str] = None
+    if verdict == "SKIP" and args.receipt:
+        receipt_data = {
+            "type": "impl_review",
+            "id": args.task or "branch",
+            "mode": "triage_skip",
+            "base": base,
+            "verdict": "SHIP",
+            "reason": reason,
+            "source": judge_source,
+            "changed_file_count": len(changed_files),
+            "timestamp": now_iso(),
+        }
+        if model_used:
+            receipt_data["model"] = model_used
+        ralph_iter = os.environ.get("RALPH_ITERATION")
+        if ralph_iter:
+            try:
+                receipt_data["iteration"] = int(ralph_iter)
+            except ValueError:
+                pass
+        try:
+            Path(args.receipt).parent.mkdir(parents=True, exist_ok=True)
+            Path(args.receipt).write_text(
+                json.dumps(receipt_data, indent=2) + "\n", encoding="utf-8"
+            )
+            receipt_written = args.receipt
+        except OSError as e:
+            error_exit(
+                f"failed to write receipt {args.receipt}: {e}",
+                use_json=args.json,
+                code=2,
+            )
+
+    # Output + exit.
+    if args.json:
+        payload = {
+            "verdict": "SHIP" if verdict == "SKIP" else "REVIEW",
+            "mode": "triage_skip" if verdict == "SKIP" else "triage_review",
+            "reason": reason,
+            "source": judge_source,
+            "base": base,
+            "changed_file_count": len(changed_files),
+        }
+        if model_used:
+            payload["model"] = model_used
+        if receipt_written:
+            payload["receipt"] = receipt_written
+        json_output(payload)
+    else:
+        if verdict == "SKIP":
+            print(f"SKIP: {reason}")
+            if receipt_written:
+                print(f"REVIEW_RECEIPT_WRITTEN: {receipt_written}")
+        else:
+            print(f"REVIEW: {reason}")
+
+    sys.exit(0 if verdict == "SKIP" else 1)
+
+
 # --- Checkpoint commands ---
 
 
@@ -9321,6 +9912,43 @@ def main() -> None:
     )
     p_validate.add_argument("--json", action="store_true", help="JSON output")
     p_validate.set_defaults(func=cmd_validate)
+
+    # triage-skip (fn-29.6)
+    p_triage = subparsers.add_parser(
+        "triage-skip",
+        help="Trivial-diff triage pre-check (exit 0=SKIP, 1=REVIEW, 2+=error)",
+    )
+    p_triage.add_argument(
+        "--base", help="Base ref to diff against (default: main, fallback master)"
+    )
+    p_triage.add_argument(
+        "--task", help="Task ID for receipt id field (default: 'branch')"
+    )
+    p_triage.add_argument(
+        "--backend",
+        choices=["codex", "copilot"],
+        default="codex",
+        help="LLM judge backend for ambiguous diffs (default: codex)",
+    )
+    p_triage.add_argument(
+        "--model",
+        help="Fast model override (default: gpt-5-mini for codex, claude-haiku-4.5 for copilot)",
+    )
+    p_triage.add_argument(
+        "--effort",
+        help="Reasoning effort for LLM judge (default: low)",
+    )
+    p_triage.add_argument(
+        "--receipt",
+        help="Path to write triage-skip receipt (only on SKIP verdict)",
+    )
+    p_triage.add_argument(
+        "--no-llm",
+        action="store_true",
+        help="Skip LLM judge; rely on deterministic whitelist only (ambiguous → REVIEW)",
+    )
+    p_triage.add_argument("--json", action="store_true", help="JSON output")
+    p_triage.set_defaults(func=cmd_triage_skip)
 
     # checkpoint
     p_checkpoint = subparsers.add_parser("checkpoint", help="Checkpoint commands")

--- a/.flow/epics/fn-29-review-rigor-bundle-r-ids-confidence.json
+++ b/.flow/epics/fn-29-review-rigor-bundle-r-ids-confidence.json
@@ -1,0 +1,13 @@
+{
+  "branch_name": "fn-29-review-rigor-bundle-r-ids-confidence",
+  "created_at": "2026-04-24T08:09:36.021784Z",
+  "depends_on_epics": [],
+  "id": "fn-29-review-rigor-bundle-r-ids-confidence",
+  "next_task": 1,
+  "plan_review_status": "unknown",
+  "plan_reviewed_at": null,
+  "spec_path": ".flow/specs/fn-29-review-rigor-bundle-r-ids-confidence.md",
+  "status": "open",
+  "title": "Review rigor bundle: R-IDs, confidence anchors, pre-existing separation, protected artifacts, trivial-diff skip",
+  "updated_at": "2026-04-24T08:11:40.138080Z"
+}

--- a/.flow/specs/fn-29-review-rigor-bundle-r-ids-confidence.md
+++ b/.flow/specs/fn-29-review-rigor-bundle-r-ids-confidence.md
@@ -1,0 +1,246 @@
+# Review rigor bundle: R-IDs, confidence anchors, pre-existing separation, protected artifacts, trivial-diff skip
+
+## Overview
+
+Five prompt-level + minimal-flowctl changes that raise review signal quality and cut review cost across all three backends (rp, codex, copilot). All Ralph-integrated — the autonomous loop gets sharper verdicts and skips pointless work. Ships as one coherent patch release.
+
+Inspired by MergeFoundry upstream patterns at `/tmp/mergefoundry-upstream` — specifically the review-rigor discipline, requirement-ID traceability, anchored confidence rubric, pre-existing classification, protected-artifact rules, and trivial-PR triage judgment.
+
+**All changes preserve the current Carmack-level review as the default. Nothing in this epic replaces the existing review — only adds structure to its inputs and outputs.**
+
+## Constraints (CRITICAL)
+
+- Prompt-only for review skills; minimal flowctl additions (trivial-skip helper, extended receipt fields)
+- Zero breaking changes to receipt contract — only additive fields (`unaddressed`, `suppressed_count`, `triage_skip` mode)
+- Ralph mode unchanged — receipt contract extended, fix loop consumes new fields gracefully
+- All three review backends (rp, codex, copilot) must benefit equally
+- No new dependencies
+- MergeFoundry-compatible: `.flow/specs/*.md` + `.flow/tasks/*.md` prose additions are additive; runtime state layered on top
+- Run `scripts/sync-codex.sh` after prompt changes; `scripts/bump.sh patch flow-next` for this release
+
+## Approach
+
+Five features, grouped into 6 implementation tasks + 1 docs task:
+
+1. **R-IDs + per-R-ID coverage** — stable requirement IDs in epic specs that travel into reviews
+2. **Confidence anchors (0/25/50/75/100)** + suppression gate
+3. **Pre-existing vs introduced separation**
+4. **Protected artifacts** in review prompts
+5. **Trivial-diff skip pre-check** via cheap model
+
+## Design & Data Models
+
+### R-ID convention
+
+Epic specs get explicit numbered acceptance criteria:
+
+```markdown
+## Acceptance criteria
+- **R1:** OAuth login works for Google provider
+- **R2:** Session persists across page reloads
+- **R3:** Logout clears session tokens
+```
+
+Rules:
+- R-IDs are **plain markdown prose**, not YAML. Keeps `.flow/specs/*.md` human-editable.
+- **Renumber-forbidden** after first review cycle. Reordering preserves IDs (`R1, R3, R5` is fine after deletion); never compact gaps.
+- Plan skill writes R-IDs automatically when creating/refining specs.
+- Plan-sync agent preserves R-IDs when syncing drift.
+
+Task specs gain optional frontmatter:
+
+```yaml
+---
+satisfies: [R1, R3]
+---
+```
+
+Additive; tasks without `satisfies` work unchanged. Plan-sync and plan skills populate when obvious.
+
+### Confidence anchor rubric
+
+Reviewer rates each finding on exactly 5 discrete values:
+
+| Anchor | Meaning |
+|--------|---------|
+| 100 | Verifiable from code alone, zero interpretation. Off-by-one in tested algorithm. Type error. Swapped arguments. |
+| 75 | Full execution path traced: input X → branch Y → line Z → wrong output. Reproducible from code alone. A normal caller hits it. |
+| 50 | Depends on conditions visible but not fully confirmable — e.g., whether a value can be null depends on unseen callers. |
+| 25 | Requires runtime conditions with no direct evidence (specific timing, specific input shapes). |
+| 0 | Speculative. |
+
+**Suppression gate:** after dedup, suppress findings below anchor 75. **Exception:** P0 findings at anchor 50+ survive — critical-but-uncertain issues stay visible. Report `suppressed_count` (by anchor) in the review summary.
+
+Review prompts instruct reviewers to use only these 5 values (no 33, 80, etc.). Treat as integers.
+
+### Pre-existing classification
+
+Reviewer classifies each finding with `pre_existing: true | false`:
+
+- **introduced** — caused by this branch's diff
+- **pre_existing** — was broken before this branch touched it
+
+Verdict gate: **only `introduced` findings affect verdict.** `pre_existing` surface in a separate "Pre-existing issues (not blocking)" section.
+
+Review prompt: "For each finding, inspect `git blame` or surrounding context. If the bug was present on the base branch, mark `pre_existing: true`."
+
+### Protected artifacts
+
+Review prompts include a hard-coded never-flag list. Any finding recommending deletion, gitignore, or removal of these paths must be discarded during synthesis:
+
+- `.flow/*` — flow-next state, specs, tasks, memory
+- `.flow/bin/*` — bundled flowctl
+- `.flow/memory/*` — learnings store
+- `docs/plans/*` — plan artifacts (if project uses this convention)
+- `docs/solutions/*` — solutions artifacts (if project uses this convention)
+- `scripts/ralph/*` — Ralph harness (when present in user project)
+
+Path list is prose in the review prompt, not a runtime check — reviewer honors it during finding generation.
+
+### Trivial-diff skip
+
+New flowctl helper: `flowctl triage-skip --base <ref>` (or inline in impl-review skill).
+
+Runs a cheap-model judgment (haiku for Claude, `gpt-5.4-mini`/`gpt-5.4-nano` for Codex, `claude-haiku-4.5` for Copilot) with the diff summary:
+
+> "Is this diff worth a full code review? Answer SKIP or REVIEW.
+> Skip only for: lockfile-only bumps (package-lock.json, bun.lock, pnpm-lock.yaml, yarn.lock, Gemfile.lock only), pure release chores (version bump + CHANGELOG entry only), pure generated-file regeneration (codex/ directory from sync-codex.sh), documentation-only diffs with no code changes. When in doubt, REVIEW — false SKIPs are worse than false REVIEWs."
+
+Returns:
+- `SKIP` → impl-review writes receipt `{mode: "triage_skip", verdict: "SHIP", reason: "<one-line>"}`, skips full review
+- `REVIEW` → proceeds to configured backend
+
+Default-on for Ralph (saves cycles). Opt-out via `--no-triage`.
+
+## Receipt contract extensions
+
+All review receipts gain these optional fields (existing consumers ignore unknown fields):
+
+```json
+{
+  "unaddressed": ["R2", "R5"],
+  "suppressed_count": {"50": 3, "25": 7, "0": 2},
+  "pre_existing_count": 4,
+  "introduced_count": 2
+}
+```
+
+New receipt mode for triage-skip:
+
+```json
+{
+  "type": "impl_review",
+  "id": "...",
+  "mode": "triage_skip",
+  "base": "main",
+  "verdict": "SHIP",
+  "reason": "lockfile-only (bun.lock)",
+  "model": "claude-haiku-4.5",
+  "timestamp": "..."
+}
+```
+
+Ralph reads these naturally — verdict is still SHIP/NEEDS_WORK, `unaddressed` gives the fix loop specific targets, `triage_skip` mode signals fast-path.
+
+## File change map
+
+### Prompts (zero flowctl change)
+- `plugins/flow-next/skills/flow-next-plan/steps.md` — R-ID generation in spec template; note rule for renumber-forbidden
+- `plugins/flow-next/skills/flow-next-plan/SKILL.md` — minor — mention R-ID output rule
+- `plugins/flow-next/skills/flow-next-impl-review/workflow.md` — confidence anchor rubric, pre-existing classification, protected artifacts list, per-R-ID coverage block
+- `plugins/flow-next/skills/flow-next-epic-review/workflow.md` — same additions for epic-level review; per-R-ID coverage is most valuable here (matches fn-25's bidirectional coverage)
+- `plugins/flow-next/agents/plan-sync.md` — preserve R-IDs; update `satisfies` when drift closes a gap
+- `plugins/flow-next/agents/quality-auditor.md` — confidence anchors on findings it emits
+
+### flowctl additions
+- `plugins/flow-next/scripts/flowctl.py` — `triage_skip` subcommand (lightweight; calls existing codex/copilot/claude shell-out or uses a minimal prompt via the configured backend's fast model); extended receipt schema (add optional fields); `.flow/bin/flowctl.py` synced
+
+### Docs
+- `CHANGELOG.md` — new entry for this release
+- `README.md` — brief mention of new review features
+- `plugins/flow-next/README.md` — review rigor section; trivial-skip behavior; R-ID convention
+- `CLAUDE.md` — spec grammar section gets R-ID bullet; receipt-extensions bullet
+- `~/work/mickel.tech/app/apps/flow-next/page.tsx` — update feature list / FAQ to mention requirement-ID traceability + trivial-skip
+
+### Codex mirror
+- `scripts/sync-codex.sh` run after prompt edits to regenerate `plugins/flow-next/codex/`
+
+### Version bump
+- `scripts/bump.sh patch flow-next` → 0.32.0 → 0.32.1 (or minor if reviewer feels scope warrants 0.33.0)
+
+## Ralph compatibility audit
+
+Every change must preserve Ralph's autonomous contract. Per feature:
+
+| Feature | Ralph impact |
+|---------|--------------|
+| R-IDs | Receipt gains `unaddressed` array; fix loop uses it for targeted fixes. Backward-compatible — receipts without `unaddressed` work as before. |
+| Confidence anchors | Noise reduction — Ralph fixes fewer speculative findings per cycle. |
+| Pre-existing separation | Ralph stops fighting bugs it didn't introduce. Verdict gate only considers `introduced` count. |
+| Protected artifacts | Safety rail — Ralph can't auto-apply "delete `.flow/`" findings. |
+| Trivial-diff skip | Default-on for Ralph. Saves rp/codex/copilot calls on release chores, lockfile bumps. Receipt mode `triage_skip` is valid for fix-loop gating. |
+
+All changes are opt-out (not opt-in) for Ralph — the sharper review is the new default.
+
+## Acceptance criteria
+
+- **R1:** Plan skill emits R-IDs on acceptance criteria in every new `.flow/specs/*.md`; existing specs without R-IDs are not retroactively modified.
+- **R2:** Task specs support optional `satisfies: [R1, R3]` frontmatter; plan and plan-sync populate when obvious.
+- **R3:** Impl-review and epic-review workflows produce per-R-ID coverage status (met/partial/not-addressed/deferred) when a plan with R-IDs exists.
+- **R4:** Any unaddressed R-ID (unless explicitly marked deferred in spec) flips verdict to NEEDS_WORK; receipt carries `unaddressed` array.
+- **R5:** Review prompts instruct reviewer to use discrete 0/25/50/75/100 confidence anchors and to suppress <75 except P0@50+; receipt reports `suppressed_count`.
+- **R6:** Review prompts instruct reviewer to classify each finding `pre_existing: true|false`; verdict gate considers only `introduced`; pre-existing findings surface in separate report section.
+- **R7:** Review prompts contain protected-artifact path list; findings recommending deletion of those paths are discarded during synthesis.
+- **R8:** `flowctl triage-skip --base <ref>` (or equivalent inline logic) returns SKIP for lockfile-only / release-chore / docs-only / generated-file-only diffs using a fast model.
+- **R9:** On SKIP, impl-review skill writes receipt with `mode: "triage_skip"`, `verdict: "SHIP"`, `reason: "<one-line>"`; no expensive backend review is invoked.
+- **R10:** Ralph mode respects all above changes without any Ralph-config file changes; trivial-skip is on by default in Ralph mode, opt-out via `--no-triage`.
+- **R11:** All three backends (rp, codex, copilot) emit the new receipt fields consistently. Receipt format remains JSON and remains readable by existing Ralph scripts (unknown fields ignored).
+- **R12:** Docs updated: README, plugin README, CLAUDE.md, CHANGELOG, website flow-next page. All mention the five features.
+- **R13:** `scripts/sync-codex.sh` run after edits; Codex mirror regenerated. `scripts/bump.sh` run for version bump. No manual edits to `plugins/flow-next/codex/`.
+
+## Boundaries
+
+- Not adding multi-persona dispatch (see Epic 4 `--deep` flag instead).
+- Not adding validation pass (Epic 4 `--validate`).
+- Not adding walk-through routing (Epic 4 `--interactive`).
+- Not touching the Carmack-level review prompt content — only adding structure around it.
+- Not migrating existing open epic specs to add R-IDs retroactively.
+- Not changing hooks, flowctl state schema, or Ralph config.env format.
+
+## Risks
+
+| Risk | Mitigation |
+|------|------------|
+| Reviewer ignores confidence rubric and uses ad-hoc numbers | Prompt explicitly enumerates the 5 values; ask reviewer to restate their anchor choice before scoring |
+| Trivial-skip false positives (real issues skipped) | Strict whitelist (lockfile-only, chore-only, docs-only); "when in doubt, REVIEW" rule baked into prompt |
+| Pre-existing classification drift — reviewer marks everything pre-existing to pass | Prompt requires `git blame`/base-branch evidence; Ralph fix loop can't auto-close a PR with 0 introduced findings if tests fail |
+| R-ID schema drift across edits | Plan-sync preserves R-IDs; renumber-forbidden rule stated in plan skill prompt and in CLAUDE.md |
+| Receipt field additions break older Ralph scripts | All new fields are optional; Ralph scripts read by key (`verdict`, `mode`) not by field count |
+| Codex/Copilot fast-model cost | Trivial-skip calls are cheaper than full reviews; net cost goes down |
+
+## Decision context
+
+**Why bundle as one epic:** all five features touch the same three review prompt files and the same receipt contract. Shipping separately triples the review/CHANGELOG/bump overhead for the same surface area.
+
+**Why all Ralph-integrated (not opt-in):** these are safety + signal improvements. Nothing added here costs more per review (trivial-skip saves cost). No reason to gate.
+
+**Why R-IDs in prose, not YAML:** `.flow/specs/*.md` is human-edited during interviews. Prose is more readable and survives markdown re-rendering; runtime doesn't need to parse the IDs strictly (reviewer matches them via LLM reasoning).
+
+**Why explicit 5 anchors:** continuous confidence scores collapse to a few discrete clusters in practice. Forcing the reviewer to pick one of five makes signal calibration reliable — MergeFoundry upstream data confirmed this pattern.
+
+## Testing strategy
+
+No unit tests added (prompt-only + minor flowctl). Validate via:
+
+- Run `/flow-next:plan` on a new feature → verify spec has R1/R2/... prefixes
+- Run `/flow-next:work` on any task from an R-ID-bearing spec → verify task spec may carry `satisfies` if plan populated it
+- Run `/flow-next:impl-review` on a branch → verify output includes per-R-ID coverage table + confidence anchors + pre-existing section
+- Trigger a "delete .flow/ runtime" finding synthetically (prompt the reviewer with a diff that includes `.flow/*`) → verify it's discarded
+- Run `/flow-next:impl-review` on a lockfile-only branch → verify triage-skip fires, receipt has `mode: triage_skip`, no rp/codex/copilot call
+- Run Ralph E2E smoke (`plugins/flow-next/scripts/ralph_smoke_test.sh`) to confirm loop still closes on an epic
+
+## Follow-ups (not in this epic)
+
+- Validation pass after NEEDS_WORK (Epic 4 `--validate`)
+- Multi-persona lite (Epic 4 `--deep`) — adds passes **on top of** the existing Carmack review, not replacing it
+- Walk-through routing (Epic 4 `--interactive`)

--- a/.flow/tasks/fn-29-review-rigor-bundle-r-ids-confidence.1.json
+++ b/.flow/tasks/fn-29-review-rigor-bundle-r-ids-confidence.1.json
@@ -1,0 +1,14 @@
+{
+  "assignee": null,
+  "claim_note": "",
+  "claimed_at": null,
+  "created_at": "2026-04-24T08:11:55.500342Z",
+  "depends_on": [],
+  "epic": "fn-29-review-rigor-bundle-r-ids-confidence",
+  "id": "fn-29-review-rigor-bundle-r-ids-confidence.1",
+  "priority": null,
+  "spec_path": ".flow/tasks/fn-29-review-rigor-bundle-r-ids-confidence.1.md",
+  "status": "todo",
+  "title": "R-IDs in epic specs + plan skill + plan-sync preservation",
+  "updated_at": "2026-04-24T08:15:42.176415Z"
+}

--- a/.flow/tasks/fn-29-review-rigor-bundle-r-ids-confidence.1.md
+++ b/.flow/tasks/fn-29-review-rigor-bundle-r-ids-confidence.1.md
@@ -82,7 +82,8 @@ Inspired by MergeFoundry upstream's requirement-ID traceability pattern. Stable 
 - Enforcement of `satisfies` population (plan-sync populates when obvious; omissions are not errors).
 
 ## Done summary
-_(populated by /flow-next:work upon completion)_
-
+Added R-ID convention to plan skill (epic-spec template uses `- **Rn:**` prose prefix, renumber-forbidden rule, optional `satisfies: [Rn]` task frontmatter) and plan-sync preservation rules. Root CLAUDE.md documents the convention under the flow-next spec-grammar section.
 ## Evidence
-_(populated by /flow-next:work upon completion)_
+- Commits: 99da2686653aa74515f0c1d46b82f7f799a19f19
+- Tests: plugins/flow-next/scripts/smoke_test.sh (67 passed, 0 failed)
+- PRs:

--- a/.flow/tasks/fn-29-review-rigor-bundle-r-ids-confidence.1.md
+++ b/.flow/tasks/fn-29-review-rigor-bundle-r-ids-confidence.1.md
@@ -1,0 +1,88 @@
+# fn-29-review-rigor-bundle.1 R-IDs in epic specs + plan skill + plan-sync preservation
+
+## Description
+
+Add R-ID (requirement ID) convention to epic specs and propagate through plan + plan-sync. R-IDs are plain-markdown prose prefixes on acceptance criteria (`R1:`, `R2:`). Renumber-forbidden after first review cycle. Task specs gain optional `satisfies: [R1, R3]` frontmatter.
+
+**Size:** S (prompt-only)
+
+**Files:**
+- `plugins/flow-next/skills/flow-next-plan/steps.md`
+- `plugins/flow-next/skills/flow-next-plan/SKILL.md`
+- `plugins/flow-next/agents/plan-sync.md`
+- `CLAUDE.md` (root project guide — brief note in spec-grammar section)
+
+## Change details
+
+### plan/steps.md — spec template
+
+In the epic-spec template section, update the `## Acceptance criteria` block to use R-ID prefixes. Example:
+
+```markdown
+## Acceptance criteria
+- **R1:** <testable criterion>
+- **R2:** <testable criterion>
+- **R3:** <testable criterion>
+```
+
+Add a planning rule:
+
+> **R-ID rule.** Number acceptance criteria as `R1`, `R2`, `R3`, ... in creation order. Once a review cycle has run against an R-ID, **never renumber**. Reordering is fine (R1, R3, R5 after R2/R4 deletion is correct). New criteria take the next unused number. Gaps are fine.
+
+### plan/steps.md — task spec template
+
+Add optional `satisfies: [Rn, Rm]` frontmatter to the task spec template:
+
+```markdown
+---
+satisfies: [R1, R3]
+---
+
+# fn-N-slug.M Task title
+```
+
+Rule: populate only when obvious from the task description. Tasks that do infrastructure, refactoring, or shared plumbing may legitimately have no `satisfies` entry.
+
+### plan/SKILL.md
+
+Add one bullet under "Output rules":
+
+- R-IDs are mandatory on new epic spec acceptance criteria (see `steps.md` R-ID rule)
+
+### plan-sync.md agent
+
+Add a preservation rule in the agent prompt:
+
+> **R-ID preservation.** When syncing drift between spec and implementation:
+> - Never renumber existing R-IDs.
+> - New acceptance criteria take the next unused number (respect gaps).
+> - If an acceptance criterion is deleted, leave the gap (do not compact).
+> - When updating task specs, populate `satisfies: [...]` frontmatter if the diff clearly advances specific R-IDs.
+
+### CLAUDE.md (root)
+
+One sentence under the flow-next section mentioning R-ID convention and linking to the plan skill.
+
+## Rationale
+
+Inspired by MergeFoundry upstream's requirement-ID traceability pattern. Stable IDs survive plan edits and let review verdicts pinpoint exactly which requirements are unaddressed — not prose-matching, anchor-matching.
+
+## Acceptance
+
+- **AC1:** New epic specs written by plan skill have R1/R2/... prefixes on acceptance criteria.
+- **AC2:** Plan skill output rules document the renumber-forbidden rule explicitly.
+- **AC3:** Task specs support optional `satisfies: [Rn]` frontmatter without breaking existing parsers (frontmatter is additive).
+- **AC4:** Plan-sync agent preserves existing R-IDs and populates `satisfies` where obvious.
+- **AC5:** CLAUDE.md root references R-ID convention so non-flow-next readers discover it.
+
+## Out of scope
+
+- Retroactive R-ID injection on existing open epics (0.31+ specs stay unchanged).
+- flowctl validation of R-IDs (reviewer matches them via LLM reasoning, not strict parsing).
+- Enforcement of `satisfies` population (plan-sync populates when obvious; omissions are not errors).
+
+## Done summary
+_(populated by /flow-next:work upon completion)_
+
+## Evidence
+_(populated by /flow-next:work upon completion)_

--- a/.flow/tasks/fn-29-review-rigor-bundle-r-ids-confidence.2.json
+++ b/.flow/tasks/fn-29-review-rigor-bundle-r-ids-confidence.2.json
@@ -1,0 +1,16 @@
+{
+  "assignee": null,
+  "claim_note": "",
+  "claimed_at": null,
+  "created_at": "2026-04-24T08:11:55.619352Z",
+  "depends_on": [
+    "fn-29-review-rigor-bundle-r-ids-confidence.1"
+  ],
+  "epic": "fn-29-review-rigor-bundle-r-ids-confidence",
+  "id": "fn-29-review-rigor-bundle-r-ids-confidence.2",
+  "priority": null,
+  "spec_path": ".flow/tasks/fn-29-review-rigor-bundle-r-ids-confidence.2.md",
+  "status": "todo",
+  "title": "Per-R-ID coverage reporting in impl-review + epic-review prompts",
+  "updated_at": "2026-04-24T08:15:52.897082Z"
+}

--- a/.flow/tasks/fn-29-review-rigor-bundle-r-ids-confidence.2.md
+++ b/.flow/tasks/fn-29-review-rigor-bundle-r-ids-confidence.2.md
@@ -1,0 +1,102 @@
+# fn-29-review-rigor-bundle.2 Per-R-ID coverage in impl-review + epic-review prompts
+
+## Description
+
+Extend review prompts so reviewers produce an explicit per-R-ID coverage table when a plan with R-IDs exists. Receipt carries `unaddressed: [R2, R5]`. Verdict flips to NEEDS_WORK on any unaddressed R-ID unless spec marks it deferred.
+
+**Size:** M (prompt-only)
+
+**Files:**
+- `plugins/flow-next/skills/flow-next-impl-review/workflow.md`
+- `plugins/flow-next/skills/flow-next-epic-review/workflow.md`
+- `plugins/flow-next/scripts/flowctl.py` (receipt schema — add `unaddressed` optional field to all three backends' receipt builders)
+- `.flow/bin/flowctl.py` (mirror)
+
+## Change details
+
+### impl-review/workflow.md
+
+Add a "Requirements Coverage" phase to the review prompt, **between current intent discovery and findings synthesis**:
+
+```markdown
+## Requirements Coverage (if spec has R-IDs)
+
+If the task spec references an epic spec (`.flow/specs/fn-N-slug.md`), read the epic spec's `## Acceptance` (or legacy `## Acceptance criteria`) section and extract R-IDs. <!-- Updated by plan-sync: fn-29-review-rigor-bundle-r-ids-confidence.1 used `## Acceptance` heading in the plan-skill template (fn-29 epic itself uses `## Acceptance criteria`); reviewer must tolerate both. -->
+
+For each R-ID in scope of this branch's diff, classify status:
+
+| Status | Meaning |
+|--------|---------|
+| met | Diff clearly implements the requirement with appropriate tests |
+| partial | Diff advances the requirement but leaves gaps (missing tests, missing edge case, missing integration point) |
+| not-addressed | Diff does not advance this requirement at all |
+| deferred | Spec explicitly defers this requirement to a later task/PR |
+
+Report as a markdown table in the review output:
+
+| R-ID | Status | Evidence |
+|------|--------|----------|
+| R1 | met | src/auth.ts:42 + tests/auth.test.ts:17 |
+| R2 | partial | implementation exists but no error-path tests |
+| R3 | not-addressed | — |
+
+**Verdict gate:** any `not-addressed` R-ID (not `deferred`) → verdict must be `NEEDS_WORK`. Receipt must carry `unaddressed: ["R3"]`.
+```
+
+### epic-review/workflow.md
+
+Same block, plus bidirectional coverage already in fn-25:
+
+- Forward (spec → code): per-R-ID table as above
+- Reverse (code → spec): for each new/modified file, trace to an R-ID or classify as `LEGITIMATE_SUPPORT` / `UNDOCUMENTED_ADDITION` / `UNRELATED_CHANGE`
+
+Both phases feed the final verdict.
+
+### flowctl receipt schema
+
+In each receipt-writer (codex impl-review, codex epic-review, copilot impl-review, copilot epic-review, rp receipt writes via the skill), add optional `unaddressed` field:
+
+```python
+if unaddressed_rids:  # list of R-ID strings parsed from review output
+    receipt_data["unaddressed"] = unaddressed_rids
+```
+
+Parse the `unaddressed` list from the review output by looking for a line matching `^Unaddressed R-IDs?:\s*\[([R0-9,\s]+)\]` or extracting from the table.
+
+**Backward compatibility:** existing Ralph scripts read receipts by key; unknown/missing fields do not break anything.
+
+### Ralph awareness (prompt-only, no script change needed)
+
+Worker agent receives the review output and the `unaddressed` list. When fixing NEEDS_WORK, the worker prompt already says "address each issue"; with R-IDs, it gets precise targets. No Ralph script changes required — the fix loop just has better inputs.
+
+## Rationale
+
+MergeFoundry upstream's plan-coverage verification is one of the sharpest signals for "is this PR actually done?" Prose verdicts ("looks good") fail to catch missed requirements silently. An explicit per-R-ID table forces the reviewer to account for every criterion.
+
+Current flow-next already has fn-25's bidirectional coverage. R-IDs make the forward direction anchor-based instead of natural-language matching.
+
+## Acceptance
+
+- **AC1:** impl-review workflow emits per-R-ID coverage table when spec has R-IDs.
+- **AC2:** epic-review workflow emits per-R-ID coverage table (complementing fn-25's reverse coverage).
+- **AC3:** Receipt writes `unaddressed: [...]` optional field when reviewer reports any `not-addressed` R-IDs.
+- **AC4:** Verdict is NEEDS_WORK whenever `unaddressed` is non-empty (excluding `deferred`).
+- **AC5:** Specs without R-IDs continue to work — the per-R-ID block is skipped gracefully.
+- **AC6:** Existing Ralph smoke tests pass.
+
+## Out of scope
+
+- Strict flowctl parsing of R-ID status (reviewer LLM classifies; flowctl just stores the array).
+- UI/TUI rendering of `unaddressed` (separate follow-up).
+- Changing fn-25's reverse-coverage classification taxonomy.
+
+## Dependencies
+
+- Depends on fn-29-review-rigor-bundle.1 (R-IDs must exist in specs first).
+
+## Done summary
+Added per-R-ID requirements coverage reporting to impl-review and epic-review prompts across all three backends (rp, codex, copilot): reviewers emit a coverage table + `Unaddressed R-IDs:` summary whenever the spec uses R-IDs, flowctl parses the line (or falls back to scanning the table) into an optional `unaddressed` receipt field, and the verdict-gate instruction tells the reviewer LLM to flip NEEDS_WORK when any non-deferred R-ID is not-addressed. Backward compatible — specs without R-IDs skip the block entirely and receipts omit the field.
+## Evidence
+- Commits: c10d7ceea45c3635bf777697b67906d2ae820387
+- Tests: plugins/flow-next/scripts/smoke_test.sh (71/71), python3 parse_unaddressed_rids unit checks (summary line + coverage table + fallbacks), python3 prompt-builder checks (build_review_prompt/build_standalone_review_prompt/build_completion_review_prompt all emit R-ID coverage block), bash shell-parser smoke (RP receipt writer handles [R3, R5] / [] / none / missing line)
+- PRs:

--- a/.flow/tasks/fn-29-review-rigor-bundle-r-ids-confidence.3.json
+++ b/.flow/tasks/fn-29-review-rigor-bundle-r-ids-confidence.3.json
@@ -1,0 +1,14 @@
+{
+  "assignee": null,
+  "claim_note": "",
+  "claimed_at": null,
+  "created_at": "2026-04-24T08:11:55.742143Z",
+  "depends_on": [],
+  "epic": "fn-29-review-rigor-bundle-r-ids-confidence",
+  "id": "fn-29-review-rigor-bundle-r-ids-confidence.3",
+  "priority": null,
+  "spec_path": ".flow/tasks/fn-29-review-rigor-bundle-r-ids-confidence.3.md",
+  "status": "todo",
+  "title": "Confidence anchors (0/25/50/75/100) + suppression gate in review prompts",
+  "updated_at": "2026-04-24T08:15:42.416915Z"
+}

--- a/.flow/tasks/fn-29-review-rigor-bundle-r-ids-confidence.3.md
+++ b/.flow/tasks/fn-29-review-rigor-bundle-r-ids-confidence.3.md
@@ -1,0 +1,98 @@
+# fn-29-review-rigor-bundle.3 Confidence anchors + suppression gate
+
+## Description
+
+Add discrete 5-value confidence rubric (0/25/50/75/100) to review prompts. Suppress findings below anchor 75 except P0 findings at 50+. Report `suppressed_count` by anchor.
+
+**Size:** S (prompt-only)
+
+**Files:**
+- `plugins/flow-next/skills/flow-next-impl-review/workflow.md`
+- `plugins/flow-next/skills/flow-next-epic-review/workflow.md`
+- `plugins/flow-next/agents/quality-auditor.md` (quality-auditor also emits findings; same rubric)
+
+## Change details
+
+### Review prompts (impl-review + epic-review)
+
+Add a "Confidence calibration" section to the review prompt, before the findings format:
+
+```markdown
+## Confidence calibration
+
+Rate each finding on exactly one of these 5 discrete anchors. Do not use interpolated values (no 33, 80, 90).
+
+| Anchor | Meaning |
+|--------|---------|
+| 100 | Verifiable from the code alone, zero interpretation. A definitive logic error (off-by-one in a tested algorithm, wrong return type, swapped arguments, clear type error). The bug is mechanical. |
+| 75 | Full execution path traced: "input X enters here, takes this branch, reaches line Z, produces wrong result." Reproducible from the code alone. A normal caller will hit it. |
+| 50 | Depends on conditions visible but not fully confirmable from this diff — e.g., whether a value can actually be null depends on callers not in the diff. Surfaces only as P0-escape or via soft-bucket routing. |
+| 25 | Requires runtime conditions with no direct evidence — specific timing, specific input shapes, specific external state. |
+| 0 | Speculative. Not worth filing. |
+
+## Suppression gate
+
+After all findings are collected:
+1. Suppress findings below anchor 75.
+2. **Exception:** P0 severity findings at anchor 50+ survive the gate. Critical-but-uncertain issues must not be silently dropped.
+3. Report the suppressed count by anchor in a `Suppressed findings` section of the review output.
+
+Example:
+
+> Suppressed findings: 3 at anchor 50, 7 at anchor 25, 2 at anchor 0.
+```
+
+### Findings format
+
+Each surviving finding in the review output carries a `confidence: <N>` field alongside severity, file, line:
+
+```markdown
+### Finding 1: [title]
+- **Severity:** P1
+- **Confidence:** 75
+- **Location:** src/auth.ts:42
+- **Classification:** introduced
+- **Detail:** ...
+- **Suggested fix:** ...
+```
+
+### quality-auditor.md agent
+
+Add the same confidence calibration block. The quality-auditor runs post-task; its findings go through the same suppression logic. No separate receipt write — its output is consumed by the worker agent inline.
+
+### flowctl receipt
+
+Add optional `suppressed_count` field to the receipt schema (all three backends):
+
+```python
+if suppressed_count:  # dict {anchor: count}
+    receipt_data["suppressed_count"] = suppressed_count
+```
+
+Parse from review output by scanning for the `Suppressed findings:` line.
+
+## Rationale
+
+Free-form confidence language ("probably", "might be", "definitely") produces fuzzy priority signals. MergeFoundry upstream's discrete 5-anchor rubric forces the reviewer to commit, and the gate turns the anchors into actionable filtering. Ralph benefits directly — fewer anchor-25 speculations in the fix loop.
+
+## Acceptance
+
+- **AC1:** impl-review and epic-review prompts contain the 5-anchor rubric verbatim.
+- **AC2:** Quality-auditor agent uses the same rubric.
+- **AC3:** Review output emits `Confidence: <0|25|50|75|100>` on every finding.
+- **AC4:** Suppression gate drops <75 findings except P0 at 50+.
+- **AC5:** Review output includes a `Suppressed findings:` summary when any were suppressed.
+- **AC6:** Receipt optionally carries `suppressed_count: {anchor: count}` dict.
+- **AC7:** Existing Ralph smoke tests pass.
+
+## Out of scope
+
+- Per-backend tuning (rp vs codex vs copilot) — same rubric applies uniformly.
+- Quantitative validation that the gate improves signal (collect metrics post-ship).
+- Cross-reviewer agreement promotion (requires multi-persona; see Epic 4 `--deep`).
+
+## Done summary
+_(populated by /flow-next:work upon completion)_
+
+## Evidence
+_(populated by /flow-next:work upon completion)_

--- a/.flow/tasks/fn-29-review-rigor-bundle-r-ids-confidence.3.md
+++ b/.flow/tasks/fn-29-review-rigor-bundle-r-ids-confidence.3.md
@@ -92,7 +92,8 @@ Free-form confidence language ("probably", "might be", "definitely") produces fu
 - Cross-reviewer agreement promotion (requires multi-persona; see Epic 4 `--deep`).
 
 ## Done summary
-_(populated by /flow-next:work upon completion)_
-
+Added 5-anchor confidence rubric (0/25/50/75/100) + suppression gate to impl-review, epic-review, and standalone review prompts across rp/codex/copilot backends; quality-auditor agent mirrors the same rubric. Receipts now optionally carry `suppressed_count` (parsed via `parse_suppressed_count` helper in flowctl.py + awk splice in RP workflow.md files); smoke suite gains targeted regression coverage.
 ## Evidence
-_(populated by /flow-next:work upon completion)_
+- Commits: cdfd42c403e6c936dda74a8a88714c98632f282c
+- Tests: plugins/flow-next/scripts/smoke_test.sh (68 passed, 0 failed)
+- PRs:

--- a/.flow/tasks/fn-29-review-rigor-bundle-r-ids-confidence.4.json
+++ b/.flow/tasks/fn-29-review-rigor-bundle-r-ids-confidence.4.json
@@ -1,0 +1,14 @@
+{
+  "assignee": null,
+  "claim_note": "",
+  "claimed_at": null,
+  "created_at": "2026-04-24T08:11:55.862110Z",
+  "depends_on": [],
+  "epic": "fn-29-review-rigor-bundle-r-ids-confidence",
+  "id": "fn-29-review-rigor-bundle-r-ids-confidence.4",
+  "priority": null,
+  "spec_path": ".flow/tasks/fn-29-review-rigor-bundle-r-ids-confidence.4.md",
+  "status": "todo",
+  "title": "Pre-existing vs introduced classification in review prompts + verdict gate",
+  "updated_at": "2026-04-24T08:15:42.534352Z"
+}

--- a/.flow/tasks/fn-29-review-rigor-bundle-r-ids-confidence.4.md
+++ b/.flow/tasks/fn-29-review-rigor-bundle-r-ids-confidence.4.md
@@ -1,0 +1,104 @@
+# fn-29-review-rigor-bundle.4 Pre-existing vs introduced classification + verdict gate
+
+## Description
+
+Reviewer classifies every finding as either `introduced` (caused by this branch's diff) or `pre_existing` (was broken before). Verdict only considers `introduced` findings. Pre-existing findings surface in a separate non-blocking section.
+
+**Size:** S (prompt-only)
+
+**Files:**
+- `plugins/flow-next/skills/flow-next-impl-review/workflow.md`
+- `plugins/flow-next/skills/flow-next-epic-review/workflow.md`
+- `plugins/flow-next/scripts/flowctl.py` (receipt schema — `introduced_count`, `pre_existing_count`)
+- `.flow/bin/flowctl.py` (mirror)
+
+## Change details
+
+### Review prompts
+
+Add a "Classification" subsection to the review prompt, above the findings format:
+
+```markdown
+## Introduced vs pre-existing classification
+
+For each finding, determine whether it was caused by this branch's diff or was already present on the base branch.
+
+Evidence methods (reviewer may use any):
+- `git blame <file> <line>` to see when the line was last touched
+- Read the base-branch version of the file directly
+- Infer from diff context: if the finding is on an unchanged line in an unchanged file, it's pre_existing by default
+
+Mark each finding:
+- **introduced** — this branch caused the issue (new code, or pre-existing issue amplified/exposed by this diff in a way that now matters)
+- **pre_existing** — issue was present on base branch, not caused by this branch
+
+**Verdict gate:** only `introduced` findings affect verdict. A review with only pre-existing findings SHIPs.
+
+Report pre-existing findings in a separate section:
+
+## Pre-existing issues (not blocking this verdict)
+
+- [P1, confidence 75, introduced=false] src/legacy.ts:102 — null dereference on empty array
+- ...
+
+Never delete pre-existing findings from the report — they remain visible for future work prioritization.
+```
+
+### Findings format
+
+Classification joins severity, confidence, file, line:
+
+```markdown
+### Finding 1: [title]
+- **Severity:** P1
+- **Confidence:** 75
+- **Classification:** introduced | pre_existing
+- **Location:** src/auth.ts:42
+- **Detail:** ...
+- **Suggested fix:** ...
+```
+
+### flowctl receipt
+
+Add two optional counters to receipt schema:
+
+```python
+if introduced_count is not None:
+    receipt_data["introduced_count"] = introduced_count
+if pre_existing_count is not None:
+    receipt_data["pre_existing_count"] = pre_existing_count
+```
+
+Parse by counting classified findings in the review output. Ralph's fix loop can use `introduced_count` to confirm there's actually something to fix.
+
+### Verdict coordination with R-IDs
+
+Combine with fn-29-review-rigor-bundle.2 verdict gate:
+- Verdict = `SHIP` only if `unaddressed` is empty AND `introduced_count` (or its P0/P1 subset) does not block
+- Verdict = `NEEDS_WORK` if either gate fails
+- Pre-existing findings never block
+
+## Rationale
+
+Reviewers without this classification tend to flag every issue in the diff neighborhood, including pre-existing problems that Ralph then spends cycles "fixing" or that block SHIP unnecessarily. MergeFoundry upstream's `pre_existing: true` separation is a clean discipline — branch responsibility stays branch-scoped.
+
+## Acceptance
+
+- **AC1:** Review prompts contain the introduced-vs-pre-existing classification block.
+- **AC2:** Every finding in the review output carries `Classification: introduced | pre_existing`.
+- **AC3:** Pre-existing findings appear in a separate "Pre-existing issues (not blocking)" section.
+- **AC4:** Verdict gate treats only `introduced` findings as blocking. A diff that only surfaces pre-existing bugs verdict SHIPs.
+- **AC5:** Receipt optionally carries `introduced_count` and `pre_existing_count`.
+- **AC6:** Existing Ralph smoke tests pass — Ralph no longer fights pre-existing bugs.
+
+## Out of scope
+
+- Auto-filing pre-existing findings into a tracker (Epic 4 tracker-defer follow-up or separate epic).
+- Cross-branch drift detection (comparing what's pre-existing across multiple branches).
+
+## Done summary
+Added introduced-vs-pre_existing classification to impl-review and epic-review prompts across rp/codex/copilot backends with a verdict gate that ignores pre_existing findings. Receipts optionally carry introduced_count + pre_existing_count, parsed via new parse_classification_counts() plus portable grep-based extractors in the RP workflow receipt splices.
+## Evidence
+- Commits: 47195bb9f9a726b955b933f909276a97d112786e
+- Tests: plugins/flow-next/scripts/smoke_test.sh (69 passed, 0 failed)
+- PRs:

--- a/.flow/tasks/fn-29-review-rigor-bundle-r-ids-confidence.5.json
+++ b/.flow/tasks/fn-29-review-rigor-bundle-r-ids-confidence.5.json
@@ -1,0 +1,14 @@
+{
+  "assignee": null,
+  "claim_note": "",
+  "claimed_at": null,
+  "created_at": "2026-04-24T08:11:55.977670Z",
+  "depends_on": [],
+  "epic": "fn-29-review-rigor-bundle-r-ids-confidence",
+  "id": "fn-29-review-rigor-bundle-r-ids-confidence.5",
+  "priority": null,
+  "spec_path": ".flow/tasks/fn-29-review-rigor-bundle-r-ids-confidence.5.md",
+  "status": "todo",
+  "title": "Protected artifacts path list in review prompts",
+  "updated_at": "2026-04-24T08:15:42.654809Z"
+}

--- a/.flow/tasks/fn-29-review-rigor-bundle-r-ids-confidence.5.md
+++ b/.flow/tasks/fn-29-review-rigor-bundle-r-ids-confidence.5.md
@@ -1,0 +1,70 @@
+# fn-29-review-rigor-bundle.5 Protected artifacts path list in review prompts
+
+## Description
+
+Add a hardcoded never-flag path list to review prompts. Any finding recommending deletion, gitignore, or removal of files under these paths is discarded during synthesis. Prevents reviewer (especially external models unfamiliar with flow-next conventions) from suggesting destructive cleanups of `.flow/` state or Ralph harness files.
+
+**Size:** XS (prompt-only)
+
+**Files:**
+- `plugins/flow-next/skills/flow-next-impl-review/workflow.md`
+- `plugins/flow-next/skills/flow-next-epic-review/workflow.md`
+- `plugins/flow-next/skills/flow-next-plan-review/` (if review prompt exists — check and add)
+
+## Change details
+
+### Review prompts
+
+Add near the top of the review prompt (before findings synthesis):
+
+```markdown
+## Protected artifacts
+
+The following paths are flow-next / project-pipeline artifacts. Any finding recommending their deletion, gitignore, or removal MUST be discarded during synthesis. Do not flag these paths for cleanup under any circumstances:
+
+- `.flow/*` — flow-next state, specs, tasks, epics, runtime
+- `.flow/bin/*` — bundled flowctl
+- `.flow/memory/*` — learnings store
+- `.flow/specs/*.md` — epic specs (decision artifacts)
+- `.flow/tasks/*.md` — task specs (decision artifacts)
+- `docs/plans/*` — plan artifacts (if project uses this convention)
+- `docs/solutions/*` — solutions artifacts (if project uses this convention)
+- `scripts/ralph/*` — Ralph harness (when present)
+
+These files are intentionally committed. They are the pipeline's state, not clutter. An agent that deletes them destroys the project's planning trail and breaks Ralph autonomous runs.
+
+If you notice genuine issues with content INSIDE these files (e.g., a spec that contradicts itself, a runtime state that's stale), flag the content — not the file's existence.
+```
+
+### plan-review prompt (if it exists as separate file)
+
+Same block. plan-review reviews plan documents; same protection applies.
+
+### Synthesis discipline
+
+Add a rule at the findings-merge step:
+
+> **Protected-path filter.** Before emitting findings, scan each for recommendations to delete, gitignore, or rm-rf any path matching the protected list above. Drop those findings. Log drop count in the review output ("Protected-path filter: dropped N findings").
+
+## Rationale
+
+This is a safety rail, not a feature. External reviewers (codex/copilot running on an unfamiliar project) look at `.flow/` JSONs and naturally suggest "why are these committed?" Ralph in autofix mode could then apply that finding and destroy its own state. MergeFoundry upstream's protected-artifacts rule caught this failure mode; flow-next needs the same.
+
+## Acceptance
+
+- **AC1:** impl-review and epic-review workflow prompts contain the protected-paths list.
+- **AC2:** plan-review (if present) contains the same list.
+- **AC3:** Review synthesis step drops findings recommending deletion of protected paths.
+- **AC4:** A synthetic test where the reviewer is given a diff including `.flow/*.json` files produces no deletion/gitignore finding in the output.
+- **AC5:** Drop count (if any) is reported transparently in the review output.
+
+## Out of scope
+
+- Runtime enforcement (flowctl blocking rm of `.flow/*`) — this is a review-prompt discipline, not a hook.
+- User-configurable protected paths — list is hardcoded for the plugin's use case.
+
+## Done summary
+_(populated by /flow-next:work upon completion)_
+
+## Evidence
+_(populated by /flow-next:work upon completion)_

--- a/.flow/tasks/fn-29-review-rigor-bundle-r-ids-confidence.5.md
+++ b/.flow/tasks/fn-29-review-rigor-bundle-r-ids-confidence.5.md
@@ -64,7 +64,8 @@ This is a safety rail, not a feature. External reviewers (codex/copilot running 
 - User-configurable protected paths — list is hardcoded for the plugin's use case.
 
 ## Done summary
-_(populated by /flow-next:work upon completion)_
-
+Added hardcoded protected-artifacts path list (.flow/*, .flow/memory/*, .flow/specs/*.md, .flow/tasks/*.md, docs/plans/*, docs/solutions/*, scripts/ralph/*) to all three review prompts (impl-review, epic-review, plan-review) plus quality-auditor agent. Shared PROTECTED_ARTIFACTS_BLOCK constant in flowctl.py injected into build_review_prompt (impl + plan), build_standalone_review_prompt, and build_completion_review_prompt so rp/codex/copilot backends all discard findings recommending deletion/gitignore/removal of those paths and surface drop count via a "Protected-path filter:" line. .flow/bin/flowctl.py synced; Codex mirror regenerated via sync-codex.sh.
 ## Evidence
-_(populated by /flow-next:work upon completion)_
+- Commits: c27f606150168e9f0442eea4e4592437f22df89a
+- Tests: plugins/flow-next/scripts/smoke_test.sh (69/69 passed), python3 prompt-builder checks: build_review_prompt (impl + plan), build_standalone_review_prompt, build_completion_review_prompt all include Protected artifacts block, parse_suppressed_count + parse_classification_counts + parse_codex_verdict still parse correctly with Protected-path filter line present
+- PRs:

--- a/.flow/tasks/fn-29-review-rigor-bundle-r-ids-confidence.6.json
+++ b/.flow/tasks/fn-29-review-rigor-bundle-r-ids-confidence.6.json
@@ -1,0 +1,14 @@
+{
+  "assignee": null,
+  "claim_note": "",
+  "claimed_at": null,
+  "created_at": "2026-04-24T08:11:56.100338Z",
+  "depends_on": [],
+  "epic": "fn-29-review-rigor-bundle-r-ids-confidence",
+  "id": "fn-29-review-rigor-bundle-r-ids-confidence.6",
+  "priority": null,
+  "spec_path": ".flow/tasks/fn-29-review-rigor-bundle-r-ids-confidence.6.md",
+  "status": "todo",
+  "title": "Trivial-diff skip pre-check (flowctl helper + impl-review integration)",
+  "updated_at": "2026-04-24T08:15:42.770327Z"
+}

--- a/.flow/tasks/fn-29-review-rigor-bundle-r-ids-confidence.6.md
+++ b/.flow/tasks/fn-29-review-rigor-bundle-r-ids-confidence.6.md
@@ -150,7 +150,8 @@ Ralph loops regularly produce lockfile-only commits (dep updates via tools), rel
 | User expects full review on lockfile-only diff | `--no-triage` opt-out documented |
 
 ## Done summary
-_(populated by /flow-next:work upon completion)_
-
+Added `flowctl triage-skip` subcommand + impl-review Step 0.5 integration that short-circuits lockfile-only / docs-only / release-chore / generated-only diffs with SHIP verdict (mode=triage_skip), avoiding full rp/codex/copilot review calls. Deterministic whitelist layer is the default (conservative: ambiguous → REVIEW); optional LLM judge via FLOW_TRIAGE_LLM=1 (codex gpt-5-mini / copilot claude-haiku-4.5). Opt-out via --no-triage or FLOW_RALPH_NO_TRIAGE. Smoke tests (71/71) cover classifier, deterministic logic (all 4 AC scenarios: lockfile/docs/release-chore/generated → SKIP, code → REVIEW), LLM-output parser, and git-diff e2e.
 ## Evidence
-_(populated by /flow-next:work upon completion)_
+- Commits: 691b13e172d36b69c8bfafe1709082914f33af90
+- Tests: plugins/flow-next/scripts/smoke_test.sh (71/71 passed)
+- PRs:

--- a/.flow/tasks/fn-29-review-rigor-bundle-r-ids-confidence.6.md
+++ b/.flow/tasks/fn-29-review-rigor-bundle-r-ids-confidence.6.md
@@ -1,0 +1,156 @@
+# fn-29-review-rigor-bundle.6 Trivial-diff skip pre-check
+
+## Description
+
+Add fast-model triage to impl-review: before invoking the configured backend, a cheap-model judgment decides whether the diff is worth a full review. Lockfile-only / release-chore / docs-only / generated-file-only diffs return `VERDICT=SHIP` with receipt `mode: triage_skip` and reason. Saves rp/codex/copilot calls on Ralph runs and user-triggered reviews alike.
+
+**Size:** M (flowctl + skill integration)
+
+**Files:**
+- `plugins/flow-next/scripts/flowctl.py` — new `triage-skip` subcommand
+- `.flow/bin/flowctl.py` (mirror)
+- `plugins/flow-next/skills/flow-next-impl-review/SKILL.md` — Step 0 triage call; opt-out flag
+- `plugins/flow-next/skills/flow-next-impl-review/workflow.md` — workflow section describing triage
+
+## Change details
+
+### flowctl `triage-skip` subcommand
+
+Signature:
+
+```
+flowctl triage-skip [--base <ref>] [--backend <codex|copilot|claude>] [--model <fast-model>] [--receipt <path>] [--json]
+```
+
+Behavior:
+1. Compute diff summary: `git diff --stat <base>..HEAD` + list of changed files
+2. Build a minimal triage prompt:
+
+   ```
+   Diff summary:
+   <stat output>
+
+   Changed files:
+   <list>
+
+   Is this diff worth a full code review?
+
+   Answer SKIP only if the diff matches one of:
+   - Lockfile-only bumps: package-lock.json, bun.lock, pnpm-lock.yaml, yarn.lock, Gemfile.lock, poetry.lock, Cargo.lock, uv.lock (and nothing else)
+   - Pure release chore: version bump in plugin.json / package.json / Cargo.toml + CHANGELOG entry, no other code
+   - Pure documentation: only *.md files changed, no executable code
+   - Pure generated-file regeneration: plugins/flow-next/codex/ (from sync-codex.sh), or other clearly-generated paths
+   - Pure vendored-asset changes: files under /vendor/, /third_party/, or similarly designated paths
+
+   When in doubt, answer REVIEW. A missed review is worse than a skipped chore.
+
+   Output exactly one line:
+   SKIP: <one-line reason>
+   or
+   REVIEW: <one-line reason>
+   ```
+
+3. Invoke the fast model:
+   - Claude backend available → spawn Agent with `model: "haiku"` (`claude-haiku-4-5-20251001`)
+   - Codex backend → `codex exec --model gpt-5.4-mini` with `-c model_reasoning_effort="low"`
+   - Copilot backend → `gh copilot` with `claude-haiku-4.5`
+   - Backend selection uses the same priority chain as impl-review: `--backend` arg > `FLOW_REVIEW_BACKEND` > config > default-codex
+4. Parse output:
+   - `SKIP: <reason>` → return exit 0 + `{verdict: "SHIP", mode: "triage_skip", reason: "<reason>"}`
+   - `REVIEW: <reason>` → return exit 1 (non-zero signals "proceed to full review") + json blob with reason
+   - Malformed output → return exit 1 (conservative — fall through to full review)
+5. If `--receipt` provided and SKIP: write receipt with:
+
+   ```json
+   {
+     "type": "impl_review",
+     "id": "<uuid>",
+     "mode": "triage_skip",
+     "base": "<base-ref>",
+     "verdict": "SHIP",
+     "reason": "<one-line>",
+     "model": "<fast-model-used>",
+     "timestamp": "<iso>"
+   }
+   ```
+
+### impl-review skill integration
+
+Add Step 0 to `SKILL.md` workflow, **before** Step 1 (detect backend):
+
+```markdown
+### Step 0: Trivial-diff triage (skip pointless reviews)
+
+Unless `--no-triage` is in $ARGUMENTS, run:
+
+FLOWCTL="${DROID_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT}}/scripts/flowctl"
+
+TRIAGE_OUT=$($FLOWCTL triage-skip --base "${BASE_COMMIT:-main}" --receipt "${REVIEW_RECEIPT_PATH:-/tmp/impl-review-receipt.json}" --json)
+
+if [[ $? -eq 0 ]]; then
+  echo "Triage-skip: $(echo "$TRIAGE_OUT" | jq -r '.reason')"
+  echo "VERDICT=SHIP"
+  exit 0
+fi
+```
+
+Exit 0 from triage-skip means "this skipped"; impl-review exits early with SHIP. Exit 1 means "proceed to full review"; impl-review falls through to Step 1.
+
+Document the opt-out in the skill body:
+
+> **Triage opt-out.** Pass `--no-triage` to skip the fast-model pre-check. Useful for forced deep reviews or when the triage model is unavailable.
+
+### Ralph compatibility
+
+Ralph sets `REVIEW_RECEIPT_PATH` before invoking `/flow-next:impl-review`. On SKIP, the receipt is written with `mode: triage_skip` and `verdict: SHIP`. Ralph's gate logic reads `verdict` — `SHIP` satisfies the gate regardless of mode. No Ralph-script changes required.
+
+Triage is **on by default** in Ralph mode. Ralph opt-out via env var:
+
+```bash
+FLOW_RALPH_NO_TRIAGE=1
+```
+
+Skill checks `FLOW_RALPH_NO_TRIAGE` and `--no-triage` arg with equivalent effect.
+
+### Cost-model note
+
+Triage call uses a fast model (haiku / gpt-5.4-mini). Roughly 1/20th the cost of a full Carmack-level review. Net cost on a Ralph run: decreases whenever triage catches a trivial diff; otherwise ~2% overhead.
+
+## Rationale
+
+Ralph loops regularly produce lockfile-only commits (dep updates via tools), release-chore commits (version bumps), and docs-only commits. Each one currently triggers rp/codex/copilot full review. MergeFoundry upstream's trivial-PR judgment pattern saves those cycles cheaply. Conservative "when in doubt, REVIEW" rule prevents false skips.
+
+## Acceptance
+
+- **AC1:** `flowctl triage-skip` subcommand exists with `--base`, `--backend`, `--model`, `--receipt`, `--json` flags.
+- **AC2:** Exit code 0 = SKIP, exit code 1 = proceed to full review, exit code ≥ 2 = error (tooling unavailable / malformed output).
+- **AC3:** On SKIP with `--receipt`, receipt written with `mode: triage_skip`, `verdict: SHIP`, `reason`, `model`.
+- **AC4:** impl-review SKILL.md calls triage-skip as Step 0 when `--no-triage` / `FLOW_RALPH_NO_TRIAGE` absent.
+- **AC5:** impl-review exits early on SKIP with `VERDICT=SHIP` in output; no backend call invoked.
+- **AC6:** Lockfile-only diff (single `bun.lock` change) → SKIP.
+- **AC7:** Version-bump + CHANGELOG diff only → SKIP.
+- **AC8:** Pure docs diff (only `*.md` in changed files) → SKIP.
+- **AC9:** Any diff touching `src/` or `plugins/flow-next/scripts/flowctl.py` → REVIEW (even if small).
+- **AC10:** Ralph smoke test runs unchanged; if triage-skip fires on an actual Ralph cycle, receipt verdict=SHIP advances the loop correctly.
+- **AC11:** `--no-triage` opt-out works; `FLOW_RALPH_NO_TRIAGE=1` also disables triage.
+
+## Out of scope
+
+- LLM-as-judge for pre-existing vs introduced during triage (full review handles that).
+- Multi-file heuristic sophistication (e.g., "small docs change piggy-backed with one code line") — keep triage rules tight and conservative.
+- Caching triage decisions across re-reviews (fresh call each time).
+
+## Risks
+
+| Risk | Mitigation |
+|------|------------|
+| Fast model hallucinates SKIP on real code changes | Strict whitelist prompt; "when in doubt REVIEW" rule; exit-1 default on malformed |
+| Triage adds latency to user-triggered reviews | Fast model is ~1-2s; negligible vs full review |
+| Triage backend unavailable (haiku down) | Non-zero exit code + falls through to full review |
+| User expects full review on lockfile-only diff | `--no-triage` opt-out documented |
+
+## Done summary
+_(populated by /flow-next:work upon completion)_
+
+## Evidence
+_(populated by /flow-next:work upon completion)_

--- a/.flow/tasks/fn-29-review-rigor-bundle-r-ids-confidence.7.json
+++ b/.flow/tasks/fn-29-review-rigor-bundle-r-ids-confidence.7.json
@@ -1,0 +1,21 @@
+{
+  "assignee": null,
+  "claim_note": "",
+  "claimed_at": null,
+  "created_at": "2026-04-24T08:11:56.219853Z",
+  "depends_on": [
+    "fn-29-review-rigor-bundle-r-ids-confidence.1",
+    "fn-29-review-rigor-bundle-r-ids-confidence.2",
+    "fn-29-review-rigor-bundle-r-ids-confidence.3",
+    "fn-29-review-rigor-bundle-r-ids-confidence.4",
+    "fn-29-review-rigor-bundle-r-ids-confidence.5",
+    "fn-29-review-rigor-bundle-r-ids-confidence.6"
+  ],
+  "epic": "fn-29-review-rigor-bundle-r-ids-confidence",
+  "id": "fn-29-review-rigor-bundle-r-ids-confidence.7",
+  "priority": null,
+  "spec_path": ".flow/tasks/fn-29-review-rigor-bundle-r-ids-confidence.7.md",
+  "status": "todo",
+  "title": "Docs, website, codex mirror, version bump",
+  "updated_at": "2026-04-24T08:15:53.012700Z"
+}

--- a/.flow/tasks/fn-29-review-rigor-bundle-r-ids-confidence.7.md
+++ b/.flow/tasks/fn-29-review-rigor-bundle-r-ids-confidence.7.md
@@ -1,0 +1,128 @@
+# fn-29-review-rigor-bundle.7 Docs, website, codex mirror, version bump
+
+## Description
+
+Roll up the five preceding tasks into user-facing communication: CHANGELOG entry, README/plugin-README updates, CLAUDE.md note, website page refresh, codex mirror regeneration, version bump.
+
+**Size:** M (docs + scripts, no code logic)
+
+**Files:**
+- `CHANGELOG.md`
+- `README.md`
+- `plugins/flow-next/README.md`
+- `CLAUDE.md`
+- `/Users/gordon/work/mickel.tech/app/apps/flow-next/page.tsx`
+- `plugins/flow-next/.claude-plugin/plugin.json` (via bump.sh)
+- `plugins/flow-next/.codex-plugin/plugin.json` (via bump.sh)
+- `.claude-plugin/marketplace.json` (via bump.sh)
+- `plugins/flow-next/codex/**` (via sync-codex.sh — auto-regenerated)
+
+## Change details
+
+### CHANGELOG.md
+
+Prepend a new entry at top. Style matches existing flow-next 0.32.0 / 0.31.0 entries. Version target: patch bump to 0.32.1 (prompt-only + minor flowctl additive) or minor bump to 0.33.0 if scope warrants it. Recommend 0.33.0 — it introduces multiple new review behaviors and a new flowctl subcommand.
+
+Template:
+
+```markdown
+## [flow-next 0.33.0] - YYYY-MM-DD
+
+### Added
+- **Requirement-ID traceability (R-IDs).** Epic specs emit numbered acceptance criteria (`R1:`, `R2:`, ...). Task specs support optional `satisfies: [R1, R3]` frontmatter. Impl-review and epic-review produce per-R-ID coverage tables (met / partial / not-addressed / deferred). Any unaddressed R-ID → verdict=NEEDS_WORK; receipt carries `unaddressed` array. Renumber-forbidden after first review cycle.
+- **Confidence anchors (0/25/50/75/100) + suppression gate.** Reviewers rate each finding on 5 discrete anchors. Findings below 75 are suppressed except P0@50+. Review output reports suppressed count by anchor; receipt optionally carries `suppressed_count` dict.
+- **Introduced vs pre-existing classification.** Reviewers mark each finding `introduced` (caused by this branch) or `pre_existing` (was broken before). Verdict gate considers only `introduced`. Pre-existing findings surface in a separate non-blocking section. Receipt carries `introduced_count` and `pre_existing_count`.
+- **Protected artifacts in review prompts.** Hardcoded never-flag list (`.flow/*`, `docs/plans/*`, `docs/solutions/*`, `scripts/ralph/*`, etc.). Review synthesis discards findings recommending their deletion/gitignore. Prevents external reviewers unfamiliar with flow-next conventions from proposing destructive cleanups.
+- **Trivial-diff skip (`flowctl triage-skip`).** Deterministic whitelist pre-check (lockfile-only / docs-only / release-chore / generated-file-only) returns `VERDICT=SHIP` with receipt `mode: triage_skip` (`source: deterministic`). Optional fast-model LLM judge (gpt-5-mini / claude-haiku-4.5) gated behind `FLOW_TRIAGE_LLM=1`; deterministic layer is conservative (ambiguous → REVIEW). On by default in Ralph mode; opt-out via `--no-triage` or `FLOW_RALPH_NO_TRIAGE=1`. Saves rp/codex/copilot calls on trivial commits. <!-- Updated by plan-sync: fn-29-review-rigor-bundle-r-ids-confidence.6 shipped deterministic-default (LLM opt-in via FLOW_TRIAGE_LLM=1), not fast-model-first as the spec originally described. -->
+
+### Changed
+- Impl-review and epic-review workflows emit structured per-finding metadata (severity, confidence, classification) instead of free-form prose.
+- Receipt schema gains optional fields: `unaddressed`, `suppressed_count`, `introduced_count`, `pre_existing_count`, plus new receipt mode `triage_skip`. All additive — existing Ralph scripts read by key and ignore unknowns.
+
+### Notes
+- Zero breaking changes. Specs without R-IDs continue to work. Ralph's autonomous loop is unchanged in shape; review inputs and outputs are sharper.
+- Carmack-level review remains the default and baseline. This release adds structure; it does not change the review style.
+```
+
+### README.md (root)
+
+Short bullet in the flow-next feature list mentioning the rigor bundle. One sentence max.
+
+### plugins/flow-next/README.md
+
+Add a "Review rigor" section describing the five features with example outputs. Reference the receipt extensions. Link to CHANGELOG for specifics.
+
+Also update the version badge (`bump.sh` handles this automatically).
+
+### CLAUDE.md (root)
+
+Add bullets under flow-next section:
+
+- R-IDs: epic specs use `R1:`, `R2:` prefixes on acceptance criteria; renumber-forbidden.
+- Review receipts may carry `unaddressed`, `suppressed_count`, `introduced_count`, `pre_existing_count`; `mode: triage_skip` indicates fast-path.
+- `flowctl triage-skip --base <ref>` skips trivial diffs via deterministic whitelist; `FLOW_TRIAGE_LLM=1` enables optional fast-model judge for ambiguous diffs. <!-- Updated by plan-sync: fn-29-review-rigor-bundle-r-ids-confidence.6 shipped deterministic-default, not fast-model-first. -->
+
+### Website: ~/work/mickel.tech/app/apps/flow-next/page.tsx
+
+Update:
+- Version string `0.32.0` → new version
+- Metadata description — add "requirement-ID traceability" / "trivial-diff triage" keywords if feature-section permits
+- Feature grid / FAQ if it mentions review rigor
+
+The page currently is 1029 LOC of Next.js JSX with a curated feature list. Target the most visible sections: hero, feature grid, FAQ.
+
+### sync-codex + bump
+
+Run in order after all task 1-6 edits land:
+
+```bash
+# From repo root
+scripts/sync-codex.sh
+scripts/bump.sh minor flow-next   # or patch — judge scope
+```
+
+`sync-codex.sh` regenerates `plugins/flow-next/codex/{skills,agents,hooks.json}` — the Codex mirror of the new prompts. Commit the regenerated files.
+
+`bump.sh minor flow-next` updates three manifests (marketplace.json, flow-next plugin.json, codex-plugin plugin.json) and the README badge.
+
+### Tag + release
+
+After merge:
+
+```bash
+git tag flow-next-v0.33.0
+git push origin flow-next-v0.33.0
+```
+
+Triggers release automation + Discord notification per existing release workflow (docs/RELEASING.md).
+
+## Rationale
+
+This is pure rollup. Split out because doing all of this in the same task as prompt edits produces a muddy commit history and risks shipping docs that describe half-implemented features.
+
+## Acceptance
+
+- **AC1:** CHANGELOG has a new `[flow-next 0.33.0]` (or 0.32.1) entry listing all five features.
+- **AC2:** plugin README has a "Review rigor" section.
+- **AC3:** CLAUDE.md root references R-IDs, new receipt fields, triage-skip.
+- **AC4:** Website page version + metadata reflect new release; at least one feature mention added.
+- **AC5:** `scripts/sync-codex.sh` run cleanly with no manual edits needed to `plugins/flow-next/codex/`.
+- **AC6:** `scripts/bump.sh` updates all three manifests + README badge.
+- **AC7:** Git status shows no stray files after the codex regeneration step.
+- **AC8:** Tag pushed (or staged, per user decision) to trigger release.
+
+## Dependencies
+
+- Depends on tasks 1-6 all merging first.
+
+## Out of scope
+
+- Separate Discord announcement copy (uses default release automation).
+- npm package publish (flow-next is not an npm package).
+- Breaking-change migration docs (this release is additive).
+
+## Done summary
+_(populated by /flow-next:work upon completion)_
+
+## Evidence
+_(populated by /flow-next:work upon completion)_

--- a/.flow/tasks/fn-29-review-rigor-bundle-r-ids-confidence.7.md
+++ b/.flow/tasks/fn-29-review-rigor-bundle-r-ids-confidence.7.md
@@ -122,7 +122,8 @@ This is pure rollup. Split out because doing all of this in the same task as pro
 - Breaking-change migration docs (this release is additive).
 
 ## Done summary
-_(populated by /flow-next:work upon completion)_
-
+Rolled up fn-29 review rigor bundle into 0.32.1 release: CHANGELOG entry, root+plugin README updates (new "Review Rigor" section), CLAUDE.md receipt/triage additions, website page refresh (mickel.tech), Codex mirror regenerated via scripts/sync-codex.sh, and scripts/bump.sh patch flow-next lifted all three manifests + both README badges from 0.32.0 -> 0.32.1. Smoke: 71/71.
 ## Evidence
-_(populated by /flow-next:work upon completion)_
+- Commits: cb44eab1bfe754736775b930276f65dc827b4d1a, 585baaf4442d72e2d012a4c1f8f2540120e9c7b4
+- Tests: plugins/flow-next/scripts/smoke_test.sh (71/71 pass, baseline + post-change)
+- PRs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to the flow-next.
 
+## [flow-next 0.32.1] - 2026-04-24
+
+### Added
+- **Requirement-ID traceability (R-IDs).** Epic specs emit numbered acceptance criteria (`- **R1:**`, `- **R2:**`, ...). Task specs support optional `satisfies: [R1, R3]` frontmatter. Impl-review and epic-review produce per-R-ID coverage tables (met / partial / not-addressed / deferred). Any unaddressed R-ID flips verdict to `NEEDS_WORK`; receipt carries an `unaddressed` array. Renumber-forbidden after first review cycle — deletions leave gaps, new criteria take the next unused number. Plan skill writes R-IDs on creation; plan-sync preserves them during drift updates.
+- **Confidence anchors (0 / 25 / 50 / 75 / 100) + suppression gate.** Reviewers score each finding on exactly five discrete anchors. Findings below 75 are suppressed except P0 @ 50+. Reviews report `suppressed_count` by anchor; receipt optionally carries a `suppressed_count` dict. Prose rubric tells the reviewer to treat scores as integers, not a continuous scale.
+- **Introduced vs pre-existing classification.** Reviewers mark each finding `introduced: true` (caused by this branch's diff) or `pre_existing: true` (broken on the base branch). Verdict gate considers only `introduced`. Pre-existing findings surface in a separate non-blocking "Pre-existing issues" section. Receipt carries `introduced_count` and `pre_existing_count`.
+- **Protected artifacts list in review prompts.** Hardcoded never-flag paths (`.flow/*`, `.flow/bin/*`, `.flow/memory/*`, `docs/plans/*`, `docs/solutions/*`, `scripts/ralph/*`). Review synthesis discards findings recommending their deletion or gitignore. Prevents cross-model reviewers unfamiliar with flow-next conventions from proposing destructive cleanups.
+- **Trivial-diff skip (`flowctl triage-skip`).** Deterministic whitelist pre-check (lockfile-only / docs-only / release-chore / generated-file-only) returns `VERDICT=SHIP` with receipt `mode: triage_skip` and `source: deterministic`. Optional fast-model LLM judge (`gpt-5-mini` / `claude-haiku-4.5`) gated behind `FLOW_TRIAGE_LLM=1`; deterministic layer is conservative (ambiguous → REVIEW). On by default in Ralph mode; opt-out via `--no-triage` or `FLOW_RALPH_NO_TRIAGE=1`. Saves rp / codex / copilot calls on trivial commits.
+
+### Changed
+- Impl-review and epic-review workflows now emit structured per-finding metadata (severity, confidence, introduced/pre_existing) instead of free-form prose.
+- Receipt schema gains optional fields: `unaddressed`, `suppressed_count`, `introduced_count`, `pre_existing_count`, plus new receipt `mode: triage_skip`. All additive — existing Ralph scripts read by key and ignore unknowns.
+
+### Notes
+- Zero breaking changes. Specs without R-IDs continue to work. Ralph's autonomous loop is unchanged in shape; review inputs and outputs are sharper.
+- Carmack-level review remains the default and baseline. This release adds structure; it does not change the review style.
+- Smoke suite: 71 tests pass (unchanged — rollup is prompt + docs only).
+
 ## [flow-next 0.32.0] - 2026-04-24
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,11 @@ R-ID convention (v0.32.1+):
 - Task specs may carry optional `satisfies: [R1, R3]` frontmatter linking to the epic's R-IDs; additive and omittable.
 - Plan skill writes R-IDs on every new spec; plan-sync preserves them during drift updates. See `plugins/flow-next/skills/flow-next-plan/steps.md` for the full rule.
 
+Review rigor additions (v0.32.1+):
+- Review receipts may carry optional fields: `unaddressed` (array of R-IDs not addressed by the branch), `suppressed_count` (dict keyed by confidence anchor: `{"50": 3, "25": 7, "0": 2}`), `introduced_count`, `pre_existing_count`. New receipt `mode: triage_skip` indicates trivial-diff fast-path. All additive; old Ralph scripts read by key and ignore unknowns.
+- `flowctl triage-skip --base <ref>` runs a deterministic whitelist (lockfile-only / docs-only / release-chore / generated-file-only) and returns `VERDICT=SHIP` without invoking the configured backend. On by default in Ralph mode; opt-out via `--no-triage` or `FLOW_RALPH_NO_TRIAGE=1`. Optional fast-model LLM judge for ambiguous diffs gated behind `FLOW_TRIAGE_LLM=1`.
+- Review prompts score findings on five discrete confidence anchors (`0 / 25 / 50 / 75 / 100`) and suppress `<75` except P0 @ 50+; findings classified `introduced` vs `pre_existing` (verdict gate considers only `introduced`); protected-artifact list prevents findings that recommend deletion of `.flow/*`, `scripts/ralph/*`, etc.
+
 Ralph (autonomous loop):
 - Script template lives in `plugins/flow-next/skills/flow-next-ralph-init/templates/`.
 - Ralph uses `flowctl rp` wrappers (not direct rp-cli) for reviews.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,12 @@ Review backend spec grammar (v0.31.0+):
 - `flowctl review-backend --json` returns `{backend, spec, model, effort, source}` (spec-form round-trippable); text mode prints bare backend for skill grep back-compat
 - Receipts now include a `spec` field alongside `model` + `effort`: `{"mode": "codex", "model": "gpt-5.4", "effort": "high", "spec": "codex:gpt-5.4:high"}`
 
+R-ID convention (v0.32.1+):
+- New epic specs number acceptance criteria as `- **R1:** ...`, `- **R2:** ...` in creation order (plain markdown prose, not YAML).
+- Renumber-forbidden after first review cycle — deletions leave gaps (`R1, R3, R5`); new criteria take the next unused number.
+- Task specs may carry optional `satisfies: [R1, R3]` frontmatter linking to the epic's R-IDs; additive and omittable.
+- Plan skill writes R-IDs on every new spec; plan-sync preserves them during drift updates. See `plugins/flow-next/skills/flow-next-plan/steps.md` for the full rule.
+
 Ralph (autonomous loop):
 - Script template lives in `plugins/flow-next/skills/flow-next-ralph-init/templates/`.
 - Ralph uses `flowctl rp` wrappers (not direct rp-cli) for reviews.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Flow-Next
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Flow-next](https://img.shields.io/badge/Flow--next-v0.32.0-green)](plugins/flow-next/)
+[![Flow-next](https://img.shields.io/badge/Flow--next-v0.32.1-green)](plugins/flow-next/)
 [![Docs](https://img.shields.io/badge/Docs-📖-informational)](plugins/flow-next/README.md)
 
 [![Author](https://img.shields.io/badge/Author-Gordon_Mickel-orange)](https://mickel.tech)
@@ -25,7 +25,7 @@ Flow-Next is an AI agent orchestration plugin. Bundled task tracking, dependency
 
 Works on **Claude Code**, **OpenAI Codex** (CLI + Desktop), **Factory Droid**, and **OpenCode**.
 
-> 🆕 **v0.30.0 — GitHub Copilot CLI review backend.** Third cross-model review option alongside RepoPrompt and Codex. Works on Linux/Windows/CI via a GitHub Copilot subscription. [Setup](plugins/flow-next/README.md#cross-model-reviews).
+> 🆕 **v0.32.1 — Review rigor bundle.** Requirement-ID traceability (R-IDs), confidence anchors (0/25/50/75/100), introduced-vs-pre-existing classification, protected-artifact list, and `flowctl triage-skip` for trivial diffs. All three review backends benefit equally. [Details](CHANGELOG.md).
 
 ---
 

--- a/plugins/flow-next/.claude-plugin/plugin.json
+++ b/plugins/flow-next/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "flow-next",
-  "version": "0.32.0",
+  "version": "0.32.1",
   "description": "Zero-dependency planning + execution with .flow/ task tracking and Ralph autonomous mode (multi-model review gates). Worker subagent per task for context isolation. Prime assesses 8 pillars (48 criteria) with GitHub API integration. Includes 20 subagents, 11 commands, 16 skills.",
   "author": {
     "name": "Gordon Mickel",

--- a/plugins/flow-next/.codex-plugin/plugin.json
+++ b/plugins/flow-next/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "flow-next",
-  "version": "0.32.0",
+  "version": "0.32.1",
   "description": "Zero-dependency planning + execution with .flow/ task tracking and Ralph autonomous mode. Worker subagent per task for context isolation. Compatible with Codex, Claude Code, and Factory Droid.",
   "author": {
     "name": "Gordon Mickel",

--- a/plugins/flow-next/README.md
+++ b/plugins/flow-next/README.md
@@ -6,7 +6,7 @@
 [![Claude Code](https://img.shields.io/badge/Claude_Code-Plugin-blueviolet)](https://claude.ai/code)
 [![OpenAI Codex](https://img.shields.io/badge/OpenAI_Codex-Plugin-10a37f)](https://developers.openai.com/codex/cli/)
 
-[![Version](https://img.shields.io/badge/Version-0.32.0-green)](../../CHANGELOG.md)
+[![Version](https://img.shields.io/badge/Version-0.32.1-green)](../../CHANGELOG.md)
 
 [![Status](https://img.shields.io/badge/Status-Active_Development-brightgreen)](../../CHANGELOG.md)
 [![Discord](https://img.shields.io/badge/Discord-Join-5865F2?logo=discord&logoColor=white)](https://discord.gg/f3DYq8AAm5)
@@ -1075,6 +1075,88 @@ flowctl task show-backend fn-5.2 --json   # per-task raw + resolved + field-leve
 | Ralph overnight runs | Any works; RP auto-opens with --create (1.5.68+); Copilot/Codex need no window |
 
 Without a backend configured, reviews fail with a clear error. Run `/flow-next:setup` or pass `--review=X`.
+
+### Review Rigor (v0.32.1+)
+
+Five prompt-level + minimal-flowctl improvements that raise review signal and cut review cost. All three backends (rp, codex, copilot) benefit equally. Zero breaking changes — receipt additions are additive.
+
+**1. Requirement-ID traceability (R-IDs).** Epic specs emit numbered acceptance criteria:
+
+```markdown
+## Acceptance criteria
+- **R1:** OAuth login works for Google provider
+- **R2:** Session persists across page reloads
+- **R3:** Logout clears session tokens
+```
+
+Task specs optionally reference them via frontmatter:
+
+```yaml
+---
+satisfies: [R1, R3]
+---
+```
+
+Rules:
+- Plain markdown prose, not YAML — keeps specs human-editable.
+- **Renumber-forbidden** after the first review cycle. Deletions leave gaps (`R1, R3, R5` stays that way); new criteria take the next unused number.
+- Plan skill writes R-IDs on creation; plan-sync preserves them through drift updates.
+- Impl-review and epic-review emit a per-R-ID coverage table (met / partial / not-addressed / deferred).
+- Any unaddressed R-ID flips verdict to `NEEDS_WORK`; receipt carries an `unaddressed: ["R2", "R5"]` array so the fix loop has targeted work.
+
+**2. Confidence anchors (0 / 25 / 50 / 75 / 100).** Reviewers score every finding on exactly five discrete values:
+
+| Anchor | Meaning |
+|--------|---------|
+| 100 | Verifiable from code alone, zero interpretation. |
+| 75 | Full execution path traced — input → branch → wrong output. |
+| 50 | Depends on conditions visible but not fully confirmable. |
+| 25 | Requires runtime conditions with no direct evidence. |
+| 0 | Speculative. |
+
+**Suppression gate:** after dedup, findings below 75 are dropped. Exception: P0 findings at 50+ survive. Reviews report `suppressed_count` by anchor; receipt optionally carries it as `{"50": 3, "25": 7, "0": 2}`.
+
+**3. Introduced vs pre-existing.** Each finding is classified:
+- `introduced: true` — caused by this branch's diff.
+- `pre_existing: true` — broken on the base branch.
+
+Verdict gate considers only `introduced` findings. Pre-existing issues surface in a separate non-blocking "Pre-existing issues" section. Receipt carries `introduced_count` + `pre_existing_count` so Ralph stops fighting bugs it didn't introduce.
+
+**4. Protected artifacts.** Review prompts carry a hardcoded never-flag list — findings recommending deletion or gitignore of these paths are discarded during synthesis:
+
+- `.flow/*` (specs, tasks, memory, state)
+- `.flow/bin/*` (bundled flowctl)
+- `.flow/memory/*` (learnings store)
+- `docs/plans/*`, `docs/solutions/*` (when the project uses them)
+- `scripts/ralph/*` (Ralph harness)
+
+Prevents cross-model reviewers unfamiliar with flow-next conventions from proposing destructive cleanups.
+
+**5. Trivial-diff skip.** `flowctl triage-skip --base <ref>` runs a deterministic whitelist (lockfile-only / docs-only / release-chore / generated-file-only) and returns `VERDICT=SHIP` without invoking the configured backend. Receipt is written with `mode: triage_skip`, `source: deterministic`, and a one-line reason.
+
+```bash
+flowctl triage-skip --base main
+# VERDICT=SHIP
+# reason=lockfile-only (bun.lock)
+# source=deterministic
+```
+
+Optional LLM layer (gpt-5-mini / claude-haiku-4.5) for ambiguous diffs is gated behind `FLOW_TRIAGE_LLM=1`. On by default in Ralph mode; opt-out via `--no-triage` or `FLOW_RALPH_NO_TRIAGE=1`. Saves rp / codex / copilot calls on trivial commits.
+
+**Receipt schema (additive only).** All review receipts may carry these optional fields; existing consumers that read by key ignore unknowns:
+
+```json
+{
+  "mode": "codex",
+  "verdict": "NEEDS_WORK",
+  "unaddressed": ["R2", "R5"],
+  "suppressed_count": {"50": 3, "25": 7, "0": 2},
+  "introduced_count": 2,
+  "pre_existing_count": 4
+}
+```
+
+See [CHANGELOG — flow-next 0.32.1](../../CHANGELOG.md#flow-next-0321---2026-04-24) for the full list.
 
 ### Dependency Graphs
 

--- a/plugins/flow-next/agents/plan-sync.md
+++ b/plugins/flow-next/agents/plan-sync.md
@@ -197,3 +197,13 @@ Updated traceability:  # Only if table exists and rows affected
 - **Preserve intent** - Update references, not requirements
 - **Minimal changes** - Only fix stale references, don't rewrite specs
 - **Skip if no drift** - Return quickly if implementation matches spec
+
+## R-ID preservation (MANDATORY)
+
+When syncing drift between spec and implementation:
+
+- **Never renumber existing R-IDs** in the epic spec's `## Acceptance` section or `## Requirement coverage` table. Stable IDs are the whole point — renumbering silently breaks review receipts and prior verdicts.
+- **New acceptance criteria take the next unused number.** If the spec has `R1, R2, R4` (R3 deleted), a new criterion becomes `R5` — respect the gap, do not compact.
+- **If an acceptance criterion is deleted, leave the gap.** Do not shift `R4` down to `R3`.
+- **When updating task specs, populate `satisfies: [R1, R3]` frontmatter** if the drift clearly advances specific R-IDs. If the task already has `satisfies`, preserve existing entries and only add/remove when drift clearly warrants it.
+- **Never add `satisfies` to infrastructure/refactor/plumbing tasks** unless the drift genuinely changes what the task covers.

--- a/plugins/flow-next/agents/quality-auditor.md
+++ b/plugins/flow-next/agents/quality-auditor.md
@@ -94,6 +94,21 @@ Example:
 
 > Suppressed findings: 3 at anchor 50, 7 at anchor 25, 2 at anchor 0.
 
+### Protected artifacts (fn-29.5)
+
+The following paths are flow-next / project-pipeline artifacts. Never recommend their deletion, gitignore, or removal:
+
+- `.flow/*` — flow-next state, specs, tasks, epics, runtime
+- `.flow/bin/*` — bundled flowctl
+- `.flow/memory/*` — learnings store
+- `.flow/specs/*.md`, `.flow/tasks/*.md` — decision artifacts
+- `docs/plans/*`, `docs/solutions/*` — plan/solution artifacts (if project uses them)
+- `scripts/ralph/*` — Ralph harness (when present)
+
+These files are intentionally committed. Flag content issues inside them if you see any, but never the files' existence.
+
+**Protected-path filter.** Before emitting findings, drop any that recommend deletion, gitignore, or `rm -rf` of paths in the list above. If you drop any, report the count in a `Protected-path filter:` line (omit when nothing was dropped).
+
 ### 8. Design System Conformance (if DESIGN.md exists)
 
 Skip this section if no DESIGN.md in project root.

--- a/plugins/flow-next/agents/quality-auditor.md
+++ b/plugins/flow-next/agents/quality-auditor.md
@@ -71,6 +71,29 @@ Red flags:
 - Missing pagination/limits
 - Blocking operations on hot paths
 
+### Confidence calibration (fn-29.3)
+
+Rate each finding on exactly one of these 5 discrete anchors. Do not use interpolated values (no 33, 80, 90).
+
+| Anchor | Meaning |
+|--------|---------|
+| 100 | Verifiable from the code alone, zero interpretation. A definitive logic error (off-by-one in a tested algorithm, wrong return type, swapped arguments, clear type error). The bug is mechanical. |
+| 75 | Full execution path traced: "input X enters here, takes this branch, reaches line Z, produces wrong result." Reproducible from the code alone. A normal caller will hit it. |
+| 50 | Depends on conditions visible but not fully confirmable from this diff — e.g., whether a value can actually be null depends on callers not in the diff. Surfaces only as P0-escape or via soft-bucket routing. |
+| 25 | Requires runtime conditions with no direct evidence — specific timing, specific input shapes, specific external state. |
+| 0 | Speculative. Not worth filing. |
+
+### Suppression gate
+
+After all findings are collected:
+1. Suppress findings below anchor 75.
+2. **Exception:** P0 / Critical findings at anchor 50+ survive the gate. Critical-but-uncertain issues must not be silently dropped.
+3. Report the suppressed count by anchor in a `Suppressed findings:` line in the audit output (omit when nothing was suppressed).
+
+Example:
+
+> Suppressed findings: 3 at anchor 50, 7 at anchor 25, 2 at anchor 0.
+
 ### 8. Design System Conformance (if DESIGN.md exists)
 
 Skip this section if no DESIGN.md in project root.
@@ -93,16 +116,20 @@ If DESIGN.md exists and diff contains frontend files (.jsx, .tsx, .vue, .svelte,
 - Ship recommendation: ✅ Ship / ⚠️ Fix first / ❌ Major rework
 
 ### Critical (MUST fix before shipping)
-- **[File:line]**: [Issue]
+- **[File:line]** (Confidence: 0|25|50|75|100): [Issue]
   - Risk: [What could go wrong]
   - Fix: [Specific suggestion]
 
 ### Should Fix (High priority)
-- **[File:line]**: [Issue]
+- **[File:line]** (Confidence: 0|25|50|75|100): [Issue]
   - [Brief fix suggestion]
 
 ### Consider (Nice to have)
-- [Minor improvement suggestion]
+- (Confidence: 0|25|50|75|100) [Minor improvement suggestion]
+
+### Suppressed findings
+> Suppressed findings: <N> at anchor 50, <N> at anchor 25, <N> at anchor 0.
+(Omit this section entirely when nothing was suppressed.)
 
 ### Test Gaps
 - [ ] [Untested scenario]

--- a/plugins/flow-next/codex/agents/plan-sync.toml
+++ b/plugins/flow-next/codex/agents/plan-sync.toml
@@ -197,4 +197,14 @@ Updated traceability:  # Only if table exists and rows affected
 - **Preserve intent** - Update references, not requirements
 - **Minimal changes** - Only fix stale references, don't rewrite specs
 - **Skip if no drift** - Return quickly if implementation matches spec
+
+## R-ID preservation (MANDATORY)
+
+When syncing drift between spec and implementation:
+
+- **Never renumber existing R-IDs** in the epic spec's `## Acceptance` section or `## Requirement coverage` table. Stable IDs are the whole point — renumbering silently breaks review receipts and prior verdicts.
+- **New acceptance criteria take the next unused number.** If the spec has `R1, R2, R4` (R3 deleted), a new criterion becomes `R5` — respect the gap, do not compact.
+- **If an acceptance criterion is deleted, leave the gap.** Do not shift `R4` down to `R3`.
+- **When updating task specs, populate `satisfies: [R1, R3]` frontmatter** if the drift clearly advances specific R-IDs. If the task already has `satisfies`, preserve existing entries and only add/remove when drift clearly warrants it.
+- **Never add `satisfies` to infrastructure/refactor/plumbing tasks** unless the drift genuinely changes what the task covers.
 """

--- a/plugins/flow-next/codex/agents/quality-auditor.toml
+++ b/plugins/flow-next/codex/agents/quality-auditor.toml
@@ -95,6 +95,21 @@ Example:
 
 > Suppressed findings: 3 at anchor 50, 7 at anchor 25, 2 at anchor 0.
 
+### Protected artifacts (fn-29.5)
+
+The following paths are flow-next / project-pipeline artifacts. Never recommend their deletion, gitignore, or removal:
+
+- `.flow/*` — flow-next state, specs, tasks, epics, runtime
+- `.flow/bin/*` — bundled flowctl
+- `.flow/memory/*` — learnings store
+- `.flow/specs/*.md`, `.flow/tasks/*.md` — decision artifacts
+- `docs/plans/*`, `docs/solutions/*` — plan/solution artifacts (if project uses them)
+- `scripts/ralph/*` — Ralph harness (when present)
+
+These files are intentionally committed. Flag content issues inside them if you see any, but never the files' existence.
+
+**Protected-path filter.** Before emitting findings, drop any that recommend deletion, gitignore, or `rm -rf` of paths in the list above. If you drop any, report the count in a `Protected-path filter:` line (omit when nothing was dropped).
+
 ### 8. Design System Conformance (if DESIGN.md exists)
 
 Skip this section if no DESIGN.md in project root.

--- a/plugins/flow-next/codex/agents/quality-auditor.toml
+++ b/plugins/flow-next/codex/agents/quality-auditor.toml
@@ -72,6 +72,29 @@ Red flags:
 - Missing pagination/limits
 - Blocking operations on hot paths
 
+### Confidence calibration (fn-29.3)
+
+Rate each finding on exactly one of these 5 discrete anchors. Do not use interpolated values (no 33, 80, 90).
+
+| Anchor | Meaning |
+|--------|---------|
+| 100 | Verifiable from the code alone, zero interpretation. A definitive logic error (off-by-one in a tested algorithm, wrong return type, swapped arguments, clear type error). The bug is mechanical. |
+| 75 | Full execution path traced: "input X enters here, takes this branch, reaches line Z, produces wrong result." Reproducible from the code alone. A normal caller will hit it. |
+| 50 | Depends on conditions visible but not fully confirmable from this diff — e.g., whether a value can actually be null depends on callers not in the diff. Surfaces only as P0-escape or via soft-bucket routing. |
+| 25 | Requires runtime conditions with no direct evidence — specific timing, specific input shapes, specific external state. |
+| 0 | Speculative. Not worth filing. |
+
+### Suppression gate
+
+After all findings are collected:
+1. Suppress findings below anchor 75.
+2. **Exception:** P0 / Critical findings at anchor 50+ survive the gate. Critical-but-uncertain issues must not be silently dropped.
+3. Report the suppressed count by anchor in a `Suppressed findings:` line in the audit output (omit when nothing was suppressed).
+
+Example:
+
+> Suppressed findings: 3 at anchor 50, 7 at anchor 25, 2 at anchor 0.
+
 ### 8. Design System Conformance (if DESIGN.md exists)
 
 Skip this section if no DESIGN.md in project root.
@@ -94,16 +117,20 @@ If DESIGN.md exists and diff contains frontend files (.jsx, .tsx, .vue, .svelte,
 - Ship recommendation: ✅ Ship / ⚠️ Fix first / ❌ Major rework
 
 ### Critical (MUST fix before shipping)
-- **[File:line]**: [Issue]
+- **[File:line]** (Confidence: 0|25|50|75|100): [Issue]
   - Risk: [What could go wrong]
   - Fix: [Specific suggestion]
 
 ### Should Fix (High priority)
-- **[File:line]**: [Issue]
+- **[File:line]** (Confidence: 0|25|50|75|100): [Issue]
   - [Brief fix suggestion]
 
 ### Consider (Nice to have)
-- [Minor improvement suggestion]
+- (Confidence: 0|25|50|75|100) [Minor improvement suggestion]
+
+### Suppressed findings
+> Suppressed findings: <N> at anchor 50, <N> at anchor 25, <N> at anchor 0.
+(Omit this section entirely when nothing was suppressed.)
 
 ### Test Gaps
 - [ ] [Untested scenario]

--- a/plugins/flow-next/codex/skills/flow-next-epic-review/workflow.md
+++ b/plugins/flow-next/codex/skills/flow-next-epic-review/workflow.md
@@ -327,6 +327,46 @@ Report untraced changes but don't auto-reject. UNDOCUMENTED_ADDITION is a flag f
 - Performance (impl-review covers this)
 - Legitimate refactoring needed to implement requirements (flag as LEGITIMATE_SUPPORT but don't block)
 
+## Requirements coverage (if epic spec has R-IDs)
+
+If the epic spec numbers its acceptance criteria like `- **R1:** ...`, `- **R2:** ...`,
+produce a per-R-ID coverage table. Read the epic spec's `## Acceptance` section
+(or the legacy `## Acceptance criteria` heading — reviewer MUST tolerate both).
+If no R-IDs are present, skip this block entirely — Phase 2 and Phase 3 above
+still apply.
+
+This forward coverage (spec → code) is **additive to Phase 3 reverse coverage
+(code → spec)**. Both phases feed the final verdict.
+
+For each R-ID, classify status:
+
+| Status | Meaning |
+|--------|---------|
+| met | Implementation delivers the requirement with appropriate tests/evidence |
+| partial | Implementation advances the requirement but leaves gaps |
+| not-addressed | Implementation does not advance this requirement at all |
+| deferred | Spec explicitly defers this requirement to a later epic/PR |
+
+Report as a markdown table in the review output:
+
+| R-ID | Status | Evidence |
+|------|--------|----------|
+| R1 | met | src/auth.ts:42 + tests/auth.test.ts:17 |
+| R2 | partial | implementation exists but no error-path tests |
+| R3 | not-addressed | — |
+
+After the table, emit one line listing every `not-addressed` R-ID that is NOT
+explicitly deferred in the spec:
+
+> Unaddressed R-IDs: [R3, R5]
+
+If there are zero unaddressed R-IDs, emit `Unaddressed R-IDs: []` or omit the
+line entirely. Deferred R-IDs are never listed here.
+
+**Verdict gate:** any `not-addressed` R-ID that is NOT marked `deferred` in the
+spec MUST flip the verdict to `NEEDS_WORK`, regardless of reverse-coverage
+findings.
+
 ## Confidence calibration
 
 Rate each gap on exactly one of these 5 discrete anchors. Do not use interpolated values (no 33, 80, 90).
@@ -413,6 +453,7 @@ For each untraced change:
 (Note: the reverse-coverage `Classification` uses untraced-change labels, distinct from the `introduced` / `pre_existing` per-gap classification above.)
 
 After the findings list, emit:
+- The `## Requirements coverage` table and `Unaddressed R-IDs:` line (only when the epic spec uses R-IDs; otherwise skip).
 - A `Suppressed findings:` line tallying anchors dropped by the gate (omit when nothing was suppressed).
 - A `Classification counts:` line tallying `introduced` vs `pre_existing` gaps, e.g. `Classification counts: 1 introduced, 0 pre_existing.`.
 - A `Protected-path filter:` line tallying gaps dropped by the protected-path filter (omit when nothing was dropped).
@@ -420,8 +461,8 @@ After the findings list, emit:
 **REQUIRED**: You MUST end your response with exactly one verdict tag. This is mandatory:
 `<verdict>SHIP</verdict>` or `<verdict>NEEDS_WORK</verdict>`
 
-- SHIP: All `introduced` spec requirements are implemented (pre-existing gaps do not block)
-- NEEDS_WORK: One or more `introduced` requirements are missing, partial, or wrong
+- SHIP: All `introduced` spec requirements are implemented and every R-ID is `met` or `deferred` (pre-existing gaps do not block)
+- NEEDS_WORK: One or more `introduced` requirements are missing, partial, or wrong — or any non-deferred R-ID is `not-addressed`
 
 Do NOT skip this tag. The automation depends on it.
 EOF
@@ -511,12 +552,41 @@ if [[ -n "${REVIEW_RECEIPT_PATH:-}" ]]; then
     fi
   fi
 
+  # Optional: capture unaddressed R-IDs (fn-29.2).
+  # Reviewer emits `Unaddressed R-IDs: [R3, R5]` (or `[]` / `none` for empty).
+  # Absent line => epic spec has no R-IDs — leave field off the receipt entirely.
+  UNADDRESSED_JSON=""
+  UNADDRESSED_LINE="$(printf '%s' "$REVIEW_RESPONSE" \
+    | grep -iE '^[>*_` ]*unaddressed([[:space:]]+r[-_ ]?ids?)?[ *_`]*:' \
+    | head -n 1 \
+    | sed -E 's/^[^:]+:[[:space:]]*//; s/[[:space:]]*$//; s/\.$//')"
+  if [[ -n "$UNADDRESSED_LINE" ]]; then
+    normalized="$(printf '%s' "$UNADDRESSED_LINE" | sed -E 's/^[[:space:]]*\[|\][[:space:]]*$//g; s/[[:space:]]+//g')"
+    lower="$(printf '%s' "$normalized" | tr '[:upper:]' '[:lower:]')"
+    if [[ "$lower" == "none" || "$lower" == "n/a" || -z "$lower" ]]; then
+      UNADDRESSED_JSON="[]"
+    else
+      rids="$(printf '%s' "$UNADDRESSED_LINE" \
+        | grep -oE '\bR[0-9]+\b' \
+        | awk '!seen[$0]++')"
+      if [[ -z "$rids" ]]; then
+        UNADDRESSED_JSON="[]"
+      else
+        UNADDRESSED_JSON="$(printf '%s' "$rids" \
+          | awk 'BEGIN{printf "["} {printf (NR>1?",":"") "\"" $0 "\""} END{printf "]"}')"
+      fi
+    fi
+  fi
+
   EXTRA_FIELDS=""
   if [[ -n "$SUPPRESSED_JSON" && "$SUPPRESSED_JSON" != "{}" ]]; then
     EXTRA_FIELDS+=",\"suppressed_count\":$SUPPRESSED_JSON"
   fi
   if [[ -n "$INTRODUCED_COUNT" && -n "$PRE_EXISTING_COUNT" ]]; then
     EXTRA_FIELDS+=",\"introduced_count\":$INTRODUCED_COUNT,\"pre_existing_count\":$PRE_EXISTING_COUNT"
+  fi
+  if [[ -n "$UNADDRESSED_JSON" ]]; then
+    EXTRA_FIELDS+=",\"unaddressed\":$UNADDRESSED_JSON"
   fi
 
   cat > "$REVIEW_RECEIPT_PATH" <<EOF

--- a/plugins/flow-next/codex/skills/flow-next-epic-review/workflow.md
+++ b/plugins/flow-next/codex/skills/flow-next-epic-review/workflow.md
@@ -350,14 +350,59 @@ Example:
 
 > Suppressed findings: 3 at anchor 50, 7 at anchor 25, 2 at anchor 0.
 
+## Introduced vs pre-existing classification
+
+For each gap, classify whether this branch's diff caused it:
+
+- **introduced** — this epic's branch is responsible for the gap (new requirement not implemented, or a requirement this epic was supposed to satisfy and did not)
+- **pre_existing** — the gap predates this epic's branch (the requirement was already not satisfied on the base branch; this epic did not touch the relevant code). Pre-existing gaps do not block this verdict.
+
+Evidence methods:
+- `git blame <file> <line>` to see when the line was last touched
+- Read the base-branch version of the file directly
+- Check the epic scope: a gap about an area this epic never claimed to touch is `pre_existing`
+
+**Verdict gate:** only `introduced` gaps affect the verdict. An epic-review whose sole surviving gaps are all `pre_existing` MUST ship.
+
+Pre-existing gaps go under a separate `## Pre-existing issues (not blocking this verdict)` heading:
+
+```
+## Pre-existing issues (not blocking this verdict)
+
+- [confidence 75, introduced=false] missing migration docs in README — predates this epic
+```
+
+Never delete pre-existing gaps from the report — they stay visible for future prioritization.
+
+## Protected artifacts
+
+The following paths are flow-next / project-pipeline artifacts. Any gap/finding recommending their deletion, gitignore, or removal MUST be discarded during synthesis. Do not flag these paths for cleanup under any circumstances:
+
+- `.flow/*` — flow-next state, specs, tasks, epics, runtime
+- `.flow/bin/*` — bundled flowctl
+- `.flow/memory/*` — learnings store (pitfalls, conventions, decisions)
+- `.flow/specs/*.md` — epic specs (decision artifacts)
+- `.flow/tasks/*.md` — task specs (decision artifacts)
+- `docs/plans/*` — plan artifacts (if project uses this convention)
+- `docs/solutions/*` — solutions artifacts (if project uses this convention)
+- `scripts/ralph/*` — Ralph harness (when present)
+
+These files are intentionally committed. They are the pipeline's state, not clutter. An agent that deletes them destroys the project's planning trail and breaks Ralph autonomous runs.
+
+If you notice genuine issues with content INSIDE these files (e.g., a spec that contradicts itself, a stale runtime value, a memory entry that's wrong), flag the content — not the file's existence.
+
+**Protected-path filter.** Before emitting findings, scan each for recommendations to delete, gitignore, or `rm -rf` any path matching the protected list above. Drop those findings. If you drop any, report the drop count in a `Protected-path filter:` line in the review output (e.g. `Protected-path filter: dropped 2 findings`). Omit the line when nothing was dropped.
+
 ## Output Format
 
-**Forward coverage (Spec → Code):**
-For each gap found:
+**Forward coverage (Spec → Code):** for each `introduced` gap:
 - **Requirement**: What the spec says
 - **Status**: Missing / Partial / Wrong
 - **Confidence**: 0 / 25 / 50 / 75 / 100 (one of the five discrete anchors)
+- **Classification**: introduced
 - **Evidence**: What you found (or didn't find) in the code
+
+List each `pre_existing` gap under the dedicated non-blocking section above using the compact form `[confidence N, introduced=false] requirement — summary`.
 
 **Reverse coverage (Code → Spec):**
 For each untraced change:
@@ -365,13 +410,18 @@ For each untraced change:
 - **Classification**: UNDOCUMENTED_ADDITION / LEGITIMATE_SUPPORT / UNRELATED_CHANGE
 - **Note**: Brief explanation
 
-After the findings list, emit a `Suppressed findings:` line tallying anchors dropped by the gate (omit when nothing was suppressed).
+(Note: the reverse-coverage `Classification` uses untraced-change labels, distinct from the `introduced` / `pre_existing` per-gap classification above.)
+
+After the findings list, emit:
+- A `Suppressed findings:` line tallying anchors dropped by the gate (omit when nothing was suppressed).
+- A `Classification counts:` line tallying `introduced` vs `pre_existing` gaps, e.g. `Classification counts: 1 introduced, 0 pre_existing.`.
+- A `Protected-path filter:` line tallying gaps dropped by the protected-path filter (omit when nothing was dropped).
 
 **REQUIRED**: You MUST end your response with exactly one verdict tag. This is mandatory:
 `<verdict>SHIP</verdict>` or `<verdict>NEEDS_WORK</verdict>`
 
-- SHIP: All spec requirements are implemented
-- NEEDS_WORK: One or more requirements are missing, partial, or wrong
+- SHIP: All `introduced` spec requirements are implemented (pre-existing gaps do not block)
+- NEEDS_WORK: One or more `introduced` requirements are missing, partial, or wrong
 
 Do NOT skip this tag. The automation depends on it.
 EOF
@@ -437,15 +487,41 @@ if [[ -n "${REVIEW_RECEIPT_PATH:-}" ]]; then
       }
       END { printf "}" }')"
 
-  if [[ -n "$SUPPRESSED_JSON" && "$SUPPRESSED_JSON" != "{}" ]]; then
-    cat > "$REVIEW_RECEIPT_PATH" <<EOF
-{"type":"completion_review","id":"$EPIC_ID","mode":"rp","verdict":"SHIP","suppressed_count":$SUPPRESSED_JSON,"timestamp":"$ts"}
-EOF
-  else
-    cat > "$REVIEW_RECEIPT_PATH" <<EOF
-{"type":"completion_review","id":"$EPIC_ID","mode":"rp","verdict":"SHIP","timestamp":"$ts"}
-EOF
+  # Optional: capture introduced vs pre_existing classification tally (fn-29.4).
+  # Reviewer emits a line like "Classification counts: 1 introduced, 0 pre_existing."
+  # Uses portable grep -Eio so this works on BSD awk / mawk / gawk alike.
+  CLASSIFICATION_LINE="$(printf '%s' "$REVIEW_RESPONSE" \
+    | grep -iE '^[>*_` ]*classification counts[ *_`]*:' \
+    | head -n 1 \
+    | sed -E 's/^[^:]+:[[:space:]]*//; s/\.$//')"
+  INTRODUCED_COUNT=""
+  PRE_EXISTING_COUNT=""
+  if [[ -n "$CLASSIFICATION_LINE" ]]; then
+    INTRODUCED_COUNT="$(printf '%s' "$CLASSIFICATION_LINE" \
+      | grep -Eio '[0-9]+[[:space:]]+introduced' \
+      | head -n 1 \
+      | grep -Eo '^[0-9]+')"
+    PRE_EXISTING_COUNT="$(printf '%s' "$CLASSIFICATION_LINE" \
+      | grep -Eio '[0-9]+[[:space:]]+pre[-_ ]?existing' \
+      | head -n 1 \
+      | grep -Eo '^[0-9]+')"
+    if [[ -n "$INTRODUCED_COUNT" || -n "$PRE_EXISTING_COUNT" ]]; then
+      INTRODUCED_COUNT="${INTRODUCED_COUNT:-0}"
+      PRE_EXISTING_COUNT="${PRE_EXISTING_COUNT:-0}"
+    fi
   fi
+
+  EXTRA_FIELDS=""
+  if [[ -n "$SUPPRESSED_JSON" && "$SUPPRESSED_JSON" != "{}" ]]; then
+    EXTRA_FIELDS+=",\"suppressed_count\":$SUPPRESSED_JSON"
+  fi
+  if [[ -n "$INTRODUCED_COUNT" && -n "$PRE_EXISTING_COUNT" ]]; then
+    EXTRA_FIELDS+=",\"introduced_count\":$INTRODUCED_COUNT,\"pre_existing_count\":$PRE_EXISTING_COUNT"
+  fi
+
+  cat > "$REVIEW_RECEIPT_PATH" <<EOF
+{"type":"completion_review","id":"$EPIC_ID","mode":"rp","verdict":"SHIP"$EXTRA_FIELDS,"timestamp":"$ts"}
+EOF
   echo "REVIEW_RECEIPT_WRITTEN: $REVIEW_RECEIPT_PATH"
 fi
 ```

--- a/plugins/flow-next/codex/skills/flow-next-epic-review/workflow.md
+++ b/plugins/flow-next/codex/skills/flow-next-epic-review/workflow.md
@@ -327,12 +327,36 @@ Report untraced changes but don't auto-reject. UNDOCUMENTED_ADDITION is a flag f
 - Performance (impl-review covers this)
 - Legitimate refactoring needed to implement requirements (flag as LEGITIMATE_SUPPORT but don't block)
 
+## Confidence calibration
+
+Rate each gap on exactly one of these 5 discrete anchors. Do not use interpolated values (no 33, 80, 90).
+
+| Anchor | Meaning |
+|--------|---------|
+| 100 | Verifiable from the code alone, zero interpretation. A definitive logic error (off-by-one in a tested algorithm, wrong return type, swapped arguments, clear type error). The bug is mechanical. |
+| 75 | Full execution path traced: "input X enters here, takes this branch, reaches line Z, produces wrong result." Reproducible from the code alone. A normal caller will hit it. |
+| 50 | Depends on conditions visible but not fully confirmable from this diff — e.g., whether a value can actually be null depends on callers not in the diff. Surfaces only as P0-escape or via soft-bucket routing. |
+| 25 | Requires runtime conditions with no direct evidence — specific timing, specific input shapes, specific external state. |
+| 0 | Speculative. Not worth filing. |
+
+## Suppression gate
+
+After all gaps/findings are collected:
+1. Suppress findings below anchor 75.
+2. **Exception:** P0 severity findings at anchor 50+ survive the gate. Critical-but-uncertain issues must not be silently dropped.
+3. Report the suppressed count by anchor in a `Suppressed findings` section of the review output.
+
+Example:
+
+> Suppressed findings: 3 at anchor 50, 7 at anchor 25, 2 at anchor 0.
+
 ## Output Format
 
 **Forward coverage (Spec → Code):**
 For each gap found:
 - **Requirement**: What the spec says
 - **Status**: Missing / Partial / Wrong
+- **Confidence**: 0 / 25 / 50 / 75 / 100 (one of the five discrete anchors)
 - **Evidence**: What you found (or didn't find) in the code
 
 **Reverse coverage (Code → Spec):**
@@ -340,6 +364,8 @@ For each untraced change:
 - **File**: Changed file path
 - **Classification**: UNDOCUMENTED_ADDITION / LEGITIMATE_SUPPORT / UNRELATED_CHANGE
 - **Note**: Brief explanation
+
+After the findings list, emit a `Suppressed findings:` line tallying anchors dropped by the gate (omit when nothing was suppressed).
 
 **REQUIRED**: You MUST end your response with exactly one verdict tag. This is mandatory:
 `<verdict>SHIP</verdict>` or `<verdict>NEEDS_WORK</verdict>`
@@ -390,9 +416,36 @@ Receipt written after SHIP verdict (not on NEEDS_WORK):
 if [[ -n "${REVIEW_RECEIPT_PATH:-}" ]]; then
   ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
   mkdir -p "$(dirname "$REVIEW_RECEIPT_PATH")"
-  cat > "$REVIEW_RECEIPT_PATH" <<EOF
+
+  # Optional: capture suppression-gate tally (fn-29.3).
+  # Reviewer emits a line like "Suppressed findings: 3 at anchor 50, 7 at anchor 25, 2 at anchor 0."
+  SUPPRESSED_JSON="$(printf '%s' "$REVIEW_RESPONSE" \
+    | grep -iE '^[>*_` ]*suppressed findings[ *_`]*:' \
+    | head -n 1 \
+    | sed -E 's/^[^:]+:[[:space:]]*//; s/\.$//' \
+    | awk '
+      BEGIN { first=1; printf "{" }
+      {
+        n=split($0, parts, /,[[:space:]]*/)
+        for (i=1; i<=n; i++) {
+          if (match(parts[i], /([0-9]+)[[:space:]]+at[[:space:]]+anchor[[:space:]]+(0|25|50|75|100)/, m)) {
+            if (!first) printf ","
+            printf "\"%s\":%s", m[2], m[1]
+            first=0
+          }
+        }
+      }
+      END { printf "}" }')"
+
+  if [[ -n "$SUPPRESSED_JSON" && "$SUPPRESSED_JSON" != "{}" ]]; then
+    cat > "$REVIEW_RECEIPT_PATH" <<EOF
+{"type":"completion_review","id":"$EPIC_ID","mode":"rp","verdict":"SHIP","suppressed_count":$SUPPRESSED_JSON,"timestamp":"$ts"}
+EOF
+  else
+    cat > "$REVIEW_RECEIPT_PATH" <<EOF
 {"type":"completion_review","id":"$EPIC_ID","mode":"rp","verdict":"SHIP","timestamp":"$ts"}
 EOF
+  fi
   echo "REVIEW_RECEIPT_WRITTEN: $REVIEW_RECEIPT_PATH"
 fi
 ```

--- a/plugins/flow-next/codex/skills/flow-next-impl-review/SKILL.md
+++ b/plugins/flow-next/codex/skills/flow-next-impl-review/SKILL.md
@@ -115,10 +115,47 @@ REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 
 Parse $ARGUMENTS for:
 - `--base <commit>` → `BASE_COMMIT` (if provided, use for scoped diff)
+- `--no-triage` → set `TRIAGE_DISABLED=1` (skip trivial-diff pre-check)
 - First positional arg matching `fn-*` → `TASK_ID`
 - Remaining args → focus areas
 
 If `--base` not provided, `BASE_COMMIT` stays empty (will fall back to main/master).
+
+### Step 0.5: Trivial-diff triage (fn-29.6)
+
+Before invoking the configured backend, run a fast pre-check that short-circuits
+lockfile-only, docs-only, release-chore, and generated-file diffs. On SKIP, the
+receipt is written with `mode: "triage_skip"` / `verdict: "SHIP"` and the
+expensive backend call is skipped entirely.
+
+Opt-out: `--no-triage` argument or `FLOW_RALPH_NO_TRIAGE=1` env var.
+
+```bash
+if [[ -z "${TRIAGE_DISABLED:-}" && -z "${FLOW_RALPH_NO_TRIAGE:-}" ]]; then
+  RECEIPT_PATH="${REVIEW_RECEIPT_PATH:-/tmp/impl-review-receipt.json}"
+  TRIAGE_ARGS=(triage-skip --receipt "$RECEIPT_PATH" --json)
+  [[ -n "$BASE_COMMIT" ]] && TRIAGE_ARGS+=(--base "$BASE_COMMIT")
+  [[ -n "$TASK_ID" ]] && TRIAGE_ARGS+=(--task "$TASK_ID")
+  # Deterministic-only by default; set FLOW_TRIAGE_LLM=1 to enable LLM judge
+  # for ambiguous diffs. Deterministic is conservative — ambiguous → REVIEW.
+  [[ -z "${FLOW_TRIAGE_LLM:-}" ]] && TRIAGE_ARGS+=(--no-llm)
+
+  if TRIAGE_OUT=$($FLOWCTL "${TRIAGE_ARGS[@]}" 2>/dev/null); then
+    # Exit 0 = SKIP. Receipt already written by flowctl.
+    SKIP_REASON=$(echo "$TRIAGE_OUT" | jq -r '.reason // "trivial diff"' 2>/dev/null || echo "trivial diff")
+    echo "Triage-skip: $SKIP_REASON"
+    echo "VERDICT=SHIP"
+    exit 0
+  fi
+  # Exit 1 = proceed to full review (normal path). Exit >=2 = error, also falls
+  # through so impl-review proceeds safely rather than failing on triage.
+fi
+```
+
+**Opt-out note:** Pass `--no-triage` to force the full backend review (useful
+when explicitly validating a suspicious chore diff, or when the deterministic
+whitelist misclassifies). `FLOW_RALPH_NO_TRIAGE=1` has the same effect for
+Ralph runs.
 
 ### Step 1: Detect Backend
 

--- a/plugins/flow-next/codex/skills/flow-next-impl-review/workflow.md
+++ b/plugins/flow-next/codex/skills/flow-next-impl-review/workflow.md
@@ -329,13 +329,39 @@ Walk through these scenarios mentally for any new/modified code paths:
 
 Only flag issues that apply to the **changed code** - not pre-existing patterns.
 
+## Confidence calibration
+
+Rate each finding on exactly one of these 5 discrete anchors. Do not use interpolated values (no 33, 80, 90).
+
+| Anchor | Meaning |
+|--------|---------|
+| 100 | Verifiable from the code alone, zero interpretation. A definitive logic error (off-by-one in a tested algorithm, wrong return type, swapped arguments, clear type error). The bug is mechanical. |
+| 75 | Full execution path traced: "input X enters here, takes this branch, reaches line Z, produces wrong result." Reproducible from the code alone. A normal caller will hit it. |
+| 50 | Depends on conditions visible but not fully confirmable from this diff — e.g., whether a value can actually be null depends on callers not in the diff. Surfaces only as P0-escape or via soft-bucket routing. |
+| 25 | Requires runtime conditions with no direct evidence — specific timing, specific input shapes, specific external state. |
+| 0 | Speculative. Not worth filing. |
+
+## Suppression gate
+
+After all findings are collected:
+1. Suppress findings below anchor 75.
+2. **Exception:** P0 severity findings at anchor 50+ survive the gate. Critical-but-uncertain issues must not be silently dropped.
+3. Report the suppressed count by anchor in a `Suppressed findings` section of the review output.
+
+Example:
+
+> Suppressed findings: 3 at anchor 50, 7 at anchor 25, 2 at anchor 0.
+
 ## Output Format
 
-For each issue:
-- **Severity**: Critical / Major / Minor / Nitpick
+For each surviving finding:
+- **Severity**: Critical / Major / Minor / Nitpick (P0 / P1 / P2 / P3 accepted)
+- **Confidence**: 0 / 25 / 50 / 75 / 100 (one of the five discrete anchors)
 - **File:Line**: Exact location
 - **Problem**: What's wrong
 - **Suggestion**: How to fix
+
+After the findings list, emit a `Suppressed findings:` line tallying anchors dropped by the gate (omit when nothing was suppressed).
 
 **REQUIRED**: You MUST end your response with exactly one verdict tag. This is mandatory:
 `<verdict>SHIP</verdict>` or `<verdict>NEEDS_WORK</verdict>` or `<verdict>MAJOR_RETHINK</verdict>`
@@ -375,9 +401,37 @@ fi
 if [[ -n "${REVIEW_RECEIPT_PATH:-}" ]]; then
   ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
   mkdir -p "$(dirname "$REVIEW_RECEIPT_PATH")"
-  cat > "$REVIEW_RECEIPT_PATH" <<EOF
+
+  # Optional: capture suppression-gate tally (fn-29.3).
+  # Reviewer emits a line like "Suppressed findings: 3 at anchor 50, 7 at anchor 25, 2 at anchor 0."
+  SUPPRESSED_JSON="$(printf '%s' "$REVIEW_RESPONSE" \
+    | grep -iE '^[>*_` ]*suppressed findings[ *_`]*:' \
+    | head -n 1 \
+    | sed -E 's/^[^:]+:[[:space:]]*//; s/\.$//' \
+    | awk '
+      BEGIN { first=1; printf "{" }
+      {
+        n=split($0, parts, /,[[:space:]]*/)
+        for (i=1; i<=n; i++) {
+          if (match(parts[i], /([0-9]+)[[:space:]]+at[[:space:]]+anchor[[:space:]]+(0|25|50|75|100)/, m)) {
+            if (!first) printf ","
+            printf "\"%s\":%s", m[2], m[1]
+            first=0
+          }
+        }
+      }
+      END { printf "}" }')"
+
+  # Build receipt; inject suppressed_count only when non-empty
+  if [[ -n "$SUPPRESSED_JSON" && "$SUPPRESSED_JSON" != "{}" ]]; then
+    cat > "$REVIEW_RECEIPT_PATH" <<EOF
+{"type":"impl_review","id":"<TASK_ID>","mode":"rp","verdict":"$VERDICT","suppressed_count":$SUPPRESSED_JSON,"timestamp":"$ts"}
+EOF
+  else
+    cat > "$REVIEW_RECEIPT_PATH" <<EOF
 {"type":"impl_review","id":"<TASK_ID>","mode":"rp","verdict":"$VERDICT","timestamp":"$ts"}
 EOF
+  fi
   echo "REVIEW_RECEIPT_WRITTEN: $REVIEW_RECEIPT_PATH"
 fi
 ```

--- a/plugins/flow-next/codex/skills/flow-next-impl-review/workflow.md
+++ b/plugins/flow-next/codex/skills/flow-next-impl-review/workflow.md
@@ -83,6 +83,82 @@ Per-task `review` (set via `flowctl task set-backend`) overrides env.
 
 ---
 
+## Phase 0.5: Trivial-diff triage (fn-29.6)
+
+A cheap pre-check that short-circuits lockfile-only, docs-only, release-chore,
+and generated-file diffs. Runs before the configured backend — when it returns
+SKIP, the receipt is written with `mode: "triage_skip"` / `verdict: "SHIP"`
+and no expensive backend review is invoked.
+
+**Default behavior:** deterministic whitelist only (no LLM call). Ambiguous
+diffs default to REVIEW. Opt-in to LLM judge with `FLOW_TRIAGE_LLM=1`.
+
+**Opt-out:**
+- `--no-triage` argument on the skill
+- `FLOW_RALPH_NO_TRIAGE=1` env var (Ralph runs)
+
+**Invocation (from SKILL.md):**
+
+```bash
+if [[ -z "${TRIAGE_DISABLED:-}" && -z "${FLOW_RALPH_NO_TRIAGE:-}" ]]; then
+  RECEIPT_PATH="${REVIEW_RECEIPT_PATH:-/tmp/impl-review-receipt.json}"
+  TRIAGE_ARGS=(triage-skip --receipt "$RECEIPT_PATH" --json)
+  [[ -n "$BASE_COMMIT" ]] && TRIAGE_ARGS+=(--base "$BASE_COMMIT")
+  [[ -n "$TASK_ID" ]] && TRIAGE_ARGS+=(--task "$TASK_ID")
+  [[ -z "${FLOW_TRIAGE_LLM:-}" ]] && TRIAGE_ARGS+=(--no-llm)
+
+  if TRIAGE_OUT=$($FLOWCTL "${TRIAGE_ARGS[@]}" 2>/dev/null); then
+    SKIP_REASON=$(echo "$TRIAGE_OUT" | jq -r '.reason // "trivial diff"' 2>/dev/null)
+    echo "Triage-skip: $SKIP_REASON"
+    echo "VERDICT=SHIP"
+    exit 0
+  fi
+fi
+```
+
+**Exit codes:**
+- `0` → SKIP (verdict=SHIP, receipt written, skill exits early)
+- `1` → proceed to full review (normal fallthrough to backend)
+- `>=2` → error (falls through to full review — never fail closed)
+
+**Receipt shape on SKIP:**
+
+```json
+{
+  "type": "impl_review",
+  "id": "fn-29.6",
+  "mode": "triage_skip",
+  "base": "main",
+  "verdict": "SHIP",
+  "reason": "lockfile-only (bun.lock)",
+  "source": "deterministic",
+  "changed_file_count": 1,
+  "timestamp": "2026-04-24T10:00:00Z"
+}
+```
+
+Ralph reads `verdict` — `SHIP` satisfies the gate regardless of `mode`. No
+Ralph-script changes required.
+
+**Triage rules (deterministic layer):**
+
+| Shape | Action |
+|-------|--------|
+| Any code file (`.py`, `.ts`, `.go`, `.sh`, ...) present | REVIEW (AC9) |
+| Any `.flow/specs/*.md` / `.flow/tasks/*.md` / `.flow/epics/*.json` | REVIEW |
+| All files are lockfiles (`package-lock.json`, `bun.lock`, ...) | SKIP |
+| All files are docs (`.md`, `.mdx`, `.txt`, `.rst`, `.adoc`) | SKIP |
+| All files are under generated paths (`codex/`, `vendor/`, `node_modules/`, ...) | SKIP |
+| Release-chore: `plugin.json` / `package.json` / `Cargo.toml` / `pyproject.toml` + optional `CHANGELOG.md` | SKIP |
+| Lockfile + manifest combo | SKIP |
+| Anything else | REVIEW (conservative fallthrough) |
+
+When `FLOW_TRIAGE_LLM=1`, ambiguous diffs get a one-shot fast-model call
+(`gpt-5-mini` for codex backend, `claude-haiku-4.5` for copilot backend).
+Malformed LLM output falls through to REVIEW.
+
+---
+
 ## Codex Backend Workflow
 
 Use when `BACKEND="codex"`.
@@ -329,6 +405,44 @@ Walk through these scenarios mentally for any new/modified code paths:
 
 Only flag issues that apply to the **changed code** - not pre-existing patterns.
 
+## Requirements coverage (if spec has R-IDs)
+
+If the task spec references an epic spec with numbered acceptance criteria like
+`- **R1:** ...`, `- **R2:** ...`, produce a per-R-ID coverage table. Read the
+epic spec's `## Acceptance` section (or the legacy `## Acceptance criteria`
+heading — reviewer MUST tolerate both). If no R-IDs are present anywhere, skip
+this block entirely — the rest of the review is unchanged.
+
+For each R-ID, classify status:
+
+| Status | Meaning |
+|--------|---------|
+| met | Diff clearly implements the requirement with appropriate tests/evidence |
+| partial | Diff advances the requirement but leaves gaps (missing tests, missing edge case, missing integration point) |
+| not-addressed | Diff does not advance this requirement at all |
+| deferred | Spec explicitly defers this requirement to a later task/PR |
+
+Report as a markdown table in the review output:
+
+| R-ID | Status | Evidence |
+|------|--------|----------|
+| R1 | met | src/auth.ts:42 + tests/auth.test.ts:17 |
+| R2 | partial | implementation exists but no error-path tests |
+| R3 | not-addressed | — |
+
+After the table, emit one line listing every `not-addressed` R-ID that is NOT
+explicitly deferred in the spec:
+
+> Unaddressed R-IDs: [R3, R5]
+
+If there are zero unaddressed R-IDs, emit `Unaddressed R-IDs: []` or omit the
+line entirely — both forms are valid. Deferred R-IDs are never listed here.
+
+**Verdict gate:** any `not-addressed` R-ID that is NOT marked `deferred` in the
+spec MUST flip the verdict to `NEEDS_WORK`. A clean coverage table (all `met`
+or `deferred`) does not by itself force SHIP — the other review gates still
+apply.
+
 ## Confidence calibration
 
 Rate each finding on exactly one of these 5 discrete anchors. Do not use interpolated values (no 33, 80, 90).
@@ -409,12 +523,13 @@ For each surviving `introduced` finding:
 Then list each `pre_existing` finding under a separate `## Pre-existing issues (not blocking this verdict)` heading using the compact form `[severity, confidence N, introduced=false] file:line — summary`.
 
 After the findings list, emit:
+- The `## Requirements coverage` table and `Unaddressed R-IDs:` line (only when the spec uses R-IDs; otherwise skip).
 - A `Suppressed findings:` line tallying anchors dropped by the gate (omit when nothing was suppressed).
 - A `Classification counts:` line tallying `introduced` vs `pre_existing` survivors, e.g. `Classification counts: 2 introduced, 4 pre_existing.`.
 - A `Protected-path filter:` line tallying findings dropped by the protected-path filter (omit when nothing was dropped).
 
 **REQUIRED**: You MUST end your response with exactly one verdict tag. This is mandatory:
-`<verdict>SHIP</verdict>` (no blocking `introduced` findings) or `<verdict>NEEDS_WORK</verdict>` (introduced findings to fix) or `<verdict>MAJOR_RETHINK</verdict>`
+`<verdict>SHIP</verdict>` (no blocking `introduced` findings, all R-IDs met or deferred) or `<verdict>NEEDS_WORK</verdict>` (introduced findings or unaddressed R-IDs to fix) or `<verdict>MAJOR_RETHINK</verdict>`
 
 Do NOT skip this tag. The automation depends on it.
 EOF
@@ -497,13 +612,44 @@ if [[ -n "${REVIEW_RECEIPT_PATH:-}" ]]; then
     fi
   fi
 
-  # Build receipt; inject optional fn-29.3/fn-29.4 signals only when present
+  # Optional: capture unaddressed R-IDs (fn-29.2).
+  # Reviewer emits `Unaddressed R-IDs: [R3, R5]` (or `[]` / `none` for empty).
+  # Absent line => legacy spec (no R-IDs) — leave field off the receipt entirely.
+  UNADDRESSED_JSON=""
+  UNADDRESSED_LINE="$(printf '%s' "$REVIEW_RESPONSE" \
+    | grep -iE '^[>*_` ]*unaddressed([[:space:]]+r[-_ ]?ids?)?[ *_`]*:' \
+    | head -n 1 \
+    | sed -E 's/^[^:]+:[[:space:]]*//; s/[[:space:]]*$//; s/\.$//')"
+  if [[ -n "$UNADDRESSED_LINE" ]]; then
+    # Strip surrounding brackets/quotes; treat "none"/"n/a"/"" as empty list.
+    normalized="$(printf '%s' "$UNADDRESSED_LINE" | sed -E 's/^[[:space:]]*\[|\][[:space:]]*$//g; s/[[:space:]]+//g')"
+    lower="$(printf '%s' "$normalized" | tr '[:upper:]' '[:lower:]')"
+    if [[ "$lower" == "none" || "$lower" == "n/a" || -z "$lower" ]]; then
+      UNADDRESSED_JSON="[]"
+    else
+      # Extract R-ID tokens (R followed by digits), de-dup preserving order.
+      rids="$(printf '%s' "$UNADDRESSED_LINE" \
+        | grep -oE '\bR[0-9]+\b' \
+        | awk '!seen[$0]++')"
+      if [[ -z "$rids" ]]; then
+        UNADDRESSED_JSON="[]"
+      else
+        UNADDRESSED_JSON="$(printf '%s' "$rids" \
+          | awk 'BEGIN{printf "["} {printf (NR>1?",":"") "\"" $0 "\""} END{printf "]"}')"
+      fi
+    fi
+  fi
+
+  # Build receipt; inject optional fn-29.2/fn-29.3/fn-29.4 signals only when present
   EXTRA_FIELDS=""
   if [[ -n "$SUPPRESSED_JSON" && "$SUPPRESSED_JSON" != "{}" ]]; then
     EXTRA_FIELDS+=",\"suppressed_count\":$SUPPRESSED_JSON"
   fi
   if [[ -n "$INTRODUCED_COUNT" && -n "$PRE_EXISTING_COUNT" ]]; then
     EXTRA_FIELDS+=",\"introduced_count\":$INTRODUCED_COUNT,\"pre_existing_count\":$PRE_EXISTING_COUNT"
+  fi
+  if [[ -n "$UNADDRESSED_JSON" ]]; then
+    EXTRA_FIELDS+=",\"unaddressed\":$UNADDRESSED_JSON"
   fi
 
   cat > "$REVIEW_RECEIPT_PATH" <<EOF

--- a/plugins/flow-next/codex/skills/flow-next-impl-review/workflow.md
+++ b/plugins/flow-next/codex/skills/flow-next-impl-review/workflow.md
@@ -352,19 +352,69 @@ Example:
 
 > Suppressed findings: 3 at anchor 50, 7 at anchor 25, 2 at anchor 0.
 
+## Introduced vs pre-existing classification
+
+For each finding, classify whether this branch's diff caused it:
+
+- **introduced** — this branch caused the issue (new code, or a pre-existing bug that this diff amplified/exposed in a way that now matters)
+- **pre_existing** — the issue was already present on the base branch; this diff did not touch it
+
+Evidence methods (use whatever is cheapest):
+- `git blame <file> <line>` to see when the line was last touched
+- Read the base-branch version of the file directly
+- Infer from diff context: a finding on an unchanged line in an unchanged file is `pre_existing` by default
+
+**Verdict gate:** only `introduced` findings affect the verdict. A review whose sole surviving findings are all `pre_existing` MUST ship.
+
+Report pre-existing findings in a dedicated non-blocking section:
+
+```
+## Pre-existing issues (not blocking this verdict)
+
+- [P1, confidence 75, introduced=false] src/legacy.ts:102 — null dereference on empty array
+- ...
+```
+
+Never delete pre-existing findings from the report — they stay visible for future prioritization.
+
+## Protected artifacts
+
+The following paths are flow-next / project-pipeline artifacts. Any finding recommending their deletion, gitignore, or removal MUST be discarded during synthesis. Do not flag these paths for cleanup under any circumstances:
+
+- `.flow/*` — flow-next state, specs, tasks, epics, runtime
+- `.flow/bin/*` — bundled flowctl
+- `.flow/memory/*` — learnings store (pitfalls, conventions, decisions)
+- `.flow/specs/*.md` — epic specs (decision artifacts)
+- `.flow/tasks/*.md` — task specs (decision artifacts)
+- `docs/plans/*` — plan artifacts (if project uses this convention)
+- `docs/solutions/*` — solutions artifacts (if project uses this convention)
+- `scripts/ralph/*` — Ralph harness (when present)
+
+These files are intentionally committed. They are the pipeline's state, not clutter. An agent that deletes them destroys the project's planning trail and breaks Ralph autonomous runs.
+
+If you notice genuine issues with content INSIDE these files (e.g., a spec that contradicts itself, a stale runtime value, a memory entry that's wrong), flag the content — not the file's existence.
+
+**Protected-path filter.** Before emitting findings, scan each for recommendations to delete, gitignore, or `rm -rf` any path matching the protected list above. Drop those findings. If you drop any, report the drop count in a `Protected-path filter:` line in the review output (e.g. `Protected-path filter: dropped 2 findings`). Omit the line when nothing was dropped.
+
 ## Output Format
 
-For each surviving finding:
+For each surviving `introduced` finding:
 - **Severity**: Critical / Major / Minor / Nitpick (P0 / P1 / P2 / P3 accepted)
 - **Confidence**: 0 / 25 / 50 / 75 / 100 (one of the five discrete anchors)
+- **Classification**: introduced
 - **File:Line**: Exact location
 - **Problem**: What's wrong
 - **Suggestion**: How to fix
 
-After the findings list, emit a `Suppressed findings:` line tallying anchors dropped by the gate (omit when nothing was suppressed).
+Then list each `pre_existing` finding under a separate `## Pre-existing issues (not blocking this verdict)` heading using the compact form `[severity, confidence N, introduced=false] file:line — summary`.
+
+After the findings list, emit:
+- A `Suppressed findings:` line tallying anchors dropped by the gate (omit when nothing was suppressed).
+- A `Classification counts:` line tallying `introduced` vs `pre_existing` survivors, e.g. `Classification counts: 2 introduced, 4 pre_existing.`.
+- A `Protected-path filter:` line tallying findings dropped by the protected-path filter (omit when nothing was dropped).
 
 **REQUIRED**: You MUST end your response with exactly one verdict tag. This is mandatory:
-`<verdict>SHIP</verdict>` or `<verdict>NEEDS_WORK</verdict>` or `<verdict>MAJOR_RETHINK</verdict>`
+`<verdict>SHIP</verdict>` (no blocking `introduced` findings) or `<verdict>NEEDS_WORK</verdict>` (introduced findings to fix) or `<verdict>MAJOR_RETHINK</verdict>`
 
 Do NOT skip this tag. The automation depends on it.
 EOF
@@ -422,16 +472,43 @@ if [[ -n "${REVIEW_RECEIPT_PATH:-}" ]]; then
       }
       END { printf "}" }')"
 
-  # Build receipt; inject suppressed_count only when non-empty
-  if [[ -n "$SUPPRESSED_JSON" && "$SUPPRESSED_JSON" != "{}" ]]; then
-    cat > "$REVIEW_RECEIPT_PATH" <<EOF
-{"type":"impl_review","id":"<TASK_ID>","mode":"rp","verdict":"$VERDICT","suppressed_count":$SUPPRESSED_JSON,"timestamp":"$ts"}
-EOF
-  else
-    cat > "$REVIEW_RECEIPT_PATH" <<EOF
-{"type":"impl_review","id":"<TASK_ID>","mode":"rp","verdict":"$VERDICT","timestamp":"$ts"}
-EOF
+  # Optional: capture introduced vs pre_existing classification tally (fn-29.4).
+  # Reviewer emits a line like "Classification counts: 2 introduced, 4 pre_existing."
+  # Uses portable grep -Eio so this works on BSD awk / mawk / gawk alike.
+  CLASSIFICATION_LINE="$(printf '%s' "$REVIEW_RESPONSE" \
+    | grep -iE '^[>*_` ]*classification counts[ *_`]*:' \
+    | head -n 1 \
+    | sed -E 's/^[^:]+:[[:space:]]*//; s/\.$//')"
+  INTRODUCED_COUNT=""
+  PRE_EXISTING_COUNT=""
+  if [[ -n "$CLASSIFICATION_LINE" ]]; then
+    INTRODUCED_COUNT="$(printf '%s' "$CLASSIFICATION_LINE" \
+      | grep -Eio '[0-9]+[[:space:]]+introduced' \
+      | head -n 1 \
+      | grep -Eo '^[0-9]+')"
+    PRE_EXISTING_COUNT="$(printf '%s' "$CLASSIFICATION_LINE" \
+      | grep -Eio '[0-9]+[[:space:]]+pre[-_ ]?existing' \
+      | head -n 1 \
+      | grep -Eo '^[0-9]+')"
+    # Default the missing bucket to 0 when the other is present
+    if [[ -n "$INTRODUCED_COUNT" || -n "$PRE_EXISTING_COUNT" ]]; then
+      INTRODUCED_COUNT="${INTRODUCED_COUNT:-0}"
+      PRE_EXISTING_COUNT="${PRE_EXISTING_COUNT:-0}"
+    fi
   fi
+
+  # Build receipt; inject optional fn-29.3/fn-29.4 signals only when present
+  EXTRA_FIELDS=""
+  if [[ -n "$SUPPRESSED_JSON" && "$SUPPRESSED_JSON" != "{}" ]]; then
+    EXTRA_FIELDS+=",\"suppressed_count\":$SUPPRESSED_JSON"
+  fi
+  if [[ -n "$INTRODUCED_COUNT" && -n "$PRE_EXISTING_COUNT" ]]; then
+    EXTRA_FIELDS+=",\"introduced_count\":$INTRODUCED_COUNT,\"pre_existing_count\":$PRE_EXISTING_COUNT"
+  fi
+
+  cat > "$REVIEW_RECEIPT_PATH" <<EOF
+{"type":"impl_review","id":"<TASK_ID>","mode":"rp","verdict":"$VERDICT"$EXTRA_FIELDS,"timestamp":"$ts"}
+EOF
   echo "REVIEW_RECEIPT_WRITTEN: $REVIEW_RECEIPT_PATH"
 fi
 ```

--- a/plugins/flow-next/codex/skills/flow-next-plan-review/workflow.md
+++ b/plugins/flow-next/codex/skills/flow-next-plan-review/workflow.md
@@ -315,6 +315,25 @@ Conduct a John Carmack-level review:
 9. **Testability** - How will we verify this works?
 10. **Consistency** - Do task specs align with epic spec?
 
+## Protected artifacts
+
+The following paths are flow-next / project-pipeline artifacts. Any finding recommending their deletion, gitignore, or removal MUST be discarded during synthesis. Do not flag these paths for cleanup under any circumstances:
+
+- `.flow/*` — flow-next state, specs, tasks, epics, runtime
+- `.flow/bin/*` — bundled flowctl
+- `.flow/memory/*` — learnings store (pitfalls, conventions, decisions)
+- `.flow/specs/*.md` — epic specs (decision artifacts)
+- `.flow/tasks/*.md` — task specs (decision artifacts)
+- `docs/plans/*` — plan artifacts (if project uses this convention)
+- `docs/solutions/*` — solutions artifacts (if project uses this convention)
+- `scripts/ralph/*` — Ralph harness (when present)
+
+These files are intentionally committed. They are the pipeline's state, not clutter. An agent that deletes them destroys the project's planning trail and breaks Ralph autonomous runs.
+
+If you notice genuine issues with content INSIDE these files (e.g., a spec that contradicts itself, a stale entry), flag the content — not the file's existence.
+
+**Protected-path filter.** Before emitting findings, scan each for recommendations to delete, gitignore, or `rm -rf` any path matching the protected list above. Drop those findings. If you drop any, report the drop count in a `Protected-path filter:` line in the review output (e.g. `Protected-path filter: dropped 2 findings`). Omit the line when nothing was dropped.
+
 ## Output Format
 
 For each issue:
@@ -322,6 +341,8 @@ For each issue:
 - **Location**: Which task or section (e.g., "fn-1.3 Description" or "Epic Acceptance #2")
 - **Problem**: What's wrong
 - **Suggestion**: How to fix
+
+After the issues list, emit a `Protected-path filter:` line tallying findings dropped by the protected-path filter (omit when nothing was dropped).
 
 **REQUIRED**: You MUST end your response with exactly one verdict tag. This is mandatory:
 `<verdict>SHIP</verdict>` or `<verdict>NEEDS_WORK</verdict>` or `<verdict>MAJOR_RETHINK</verdict>`

--- a/plugins/flow-next/codex/skills/flow-next-plan/SKILL.md
+++ b/plugins/flow-next/codex/skills/flow-next-plan/SKILL.md
@@ -168,3 +168,4 @@ All plans go into `.flow/`:
 - Only create/update epics and tasks via flowctl
 - No code changes
 - No plan files outside `.flow/`
+- R-IDs are mandatory on new epic spec acceptance criteria — use `- **Rn:** ...` prose prefix format; never renumber after first review cycle (see `steps.md` R-ID rule)

--- a/plugins/flow-next/codex/skills/flow-next-plan/steps.md
+++ b/plugins/flow-next/codex/skills/flow-next-plan/steps.md
@@ -225,8 +225,9 @@ Default to standard unless complexity demands more or less.
    ```
 
    ## Acceptance
-   - [ ] Criterion 1
-   - [ ] Criterion 2
+   - **R1:** <testable criterion>
+   - **R2:** <testable criterion>
+   - **R3:** <testable criterion>
 
    ## Early proof point
    Task fn-N-slug.1 validates the core approach (<what it proves>).
@@ -253,6 +254,13 @@ Default to standard unless complexity demands more or less.
    - Every requirement must map to at least one task OR have a gap justification
    - Table goes at the bottom of the epic spec (after Acceptance + Early proof point)
    - Keep Req IDs simple (R1, R2...) — they're local to this epic
+
+   **R-ID rule (MANDATORY for new epic specs):**
+   - Number acceptance criteria as `R1`, `R2`, `R3`, ... in creation order using the `- **Rn:** ...` prose prefix format shown in the template above.
+   - Once a review cycle has run against an R-ID, **never renumber**. Reordering is fine (R1, R3, R5 after R2/R4 deletion is correct).
+   - New criteria take the next unused number. Gaps are fine — do not compact.
+   - R-IDs in `## Acceptance` and `## Requirement coverage` must match (same IDs, same meanings).
+   - R-IDs are plain markdown prose, not YAML — the reviewer matches them via LLM reasoning, not strict parsing.
 
 4. Set epic dependencies (from epic-scout findings):
 
@@ -287,8 +295,27 @@ Default to standard unless complexity demands more or less.
    $FLOWCTL task set-spec <task-id> --description /tmp/desc.md --acceptance /tmp/acc.md --json
    ```
 
+   **When the task needs `satisfies:` frontmatter**, use `--file` mode instead (frontmatter lives above the sections, not inside them):
+   ```bash
+   $FLOWCTL task set-spec <task-id> --file - --json <<'EOF'
+   ---
+   satisfies: [R1, R3]
+   ---
+
+   ## Description
+   ...
+
+   ## Acceptance
+   - [ ] ...
+   EOF
+   ```
+
    **Task spec content** (remember: NO implementation code):
    ```markdown
+   ---
+   satisfies: [R1, R3]
+   ---
+
    ## Description
    [What to build, not how to build it]
 
@@ -339,6 +366,12 @@ Default to standard unless complexity demands more or less.
    - Validate paths exist at plan time (repo-scout/context-scout already found them)
    - "Required" = must read before implementing. "Optional" = helpful reference
    - Targets come from repo-scout/context-scout findings in Step 1
+
+   **`satisfies` frontmatter rules (optional, additive):**
+   - Populate `satisfies: [R1, R3]` only when the task obviously advances specific R-IDs from the epic's `## Acceptance` section.
+   - Tasks that do infrastructure, refactoring, shared plumbing, or docs-only work may legitimately have **no** `satisfies` entry — omit the frontmatter entirely.
+   - Use bare R-ID tokens (`[R1, R3]`), not quoted strings.
+   - Frontmatter is additive — tasks created without it parse unchanged.
 
 7. Add task dependencies (if not already set via `--deps`):
 

--- a/plugins/flow-next/scripts/flowctl.py
+++ b/plugins/flow-next/scripts/flowctl.py
@@ -1647,6 +1647,52 @@ def parse_codex_verdict(output: str) -> Optional[str]:
     return match.group(1) if match else None
 
 
+def parse_suppressed_count(output: str) -> Optional[dict[str, int]]:
+    """Extract suppression-gate counts from review output (fn-29.3).
+
+    Looks for a line like:
+        Suppressed findings: 3 at anchor 50, 7 at anchor 25, 2 at anchor 0.
+
+    Returns a {anchor: count} dict (keys are stringified anchor ints so the
+    resulting JSON receipt field stays stable across json.dumps round-trips).
+    Returns None when no such line is present (nothing suppressed, or reviewer
+    skipped the summary). An empty dict is never returned — callers can treat
+    None as "no data".
+    """
+    if not output:
+        return None
+    # Accept "Suppressed findings:" anywhere in the text, case-insensitive.
+    # Tolerate bold markers and trailing punctuation.
+    line_match = re.search(
+        r"(?im)^[\s>*_`]*suppressed\s+findings[\s*_`]*:\s*(.+?)\s*$", output
+    )
+    if not line_match:
+        return None
+    payload = line_match.group(1).strip().rstrip(".")
+    if not payload or payload.lower() in {"none", "n/a", "0"}:
+        return None
+    counts: dict[str, int] = {}
+    # Match fragments like "3 at anchor 50" or "50: 3".
+    # Accept only the 5 canonical anchors to stay aligned with the rubric.
+    valid_anchors = {"0", "25", "50", "75", "100"}
+    for frag_match in re.finditer(
+        r"(\d+)\s*(?:at\s+anchor|@|:)\s*(\d+)|anchor\s*(\d+)[^\d]+(\d+)",
+        payload,
+        re.IGNORECASE,
+    ):
+        if frag_match.group(1) and frag_match.group(2):
+            count, anchor = frag_match.group(1), frag_match.group(2)
+        else:
+            anchor, count = frag_match.group(3), frag_match.group(4)
+        if anchor not in valid_anchors:
+            continue
+        try:
+            counts[anchor] = counts.get(anchor, 0) + int(count)
+        except ValueError:
+            continue
+    return counts or None
+
+
 def is_sandbox_failure(exit_code: int, stdout: str, stderr: str) -> bool:
     """Detect if codex failure is due to sandbox restrictions.
 
@@ -2194,6 +2240,40 @@ def run_copilot_exec(
                 pass
 
 
+# --- Confidence calibration (fn-29.3) ---
+#
+# Shared rubric + suppression gate injected into review prompts so rp, codex,
+# and copilot all emit the same discrete confidence anchors. Keep synchronized
+# with the RP workflow.md files and quality-auditor.md — if you change the
+# wording, update those copies too.
+
+CONFIDENCE_RUBRIC_BLOCK = """## Confidence calibration
+
+Rate each finding on exactly one of these 5 discrete anchors. Do not use interpolated values (no 33, 80, 90).
+
+| Anchor | Meaning |
+|--------|---------|
+| 100 | Verifiable from the code alone, zero interpretation. A definitive logic error (off-by-one in a tested algorithm, wrong return type, swapped arguments, clear type error). The bug is mechanical. |
+| 75 | Full execution path traced: "input X enters here, takes this branch, reaches line Z, produces wrong result." Reproducible from the code alone. A normal caller will hit it. |
+| 50 | Depends on conditions visible but not fully confirmable from this diff — e.g., whether a value can actually be null depends on callers not in the diff. Surfaces only as P0-escape or via soft-bucket routing. |
+| 25 | Requires runtime conditions with no direct evidence — specific timing, specific input shapes, specific external state. |
+| 0 | Speculative. Not worth filing. |
+
+## Suppression gate
+
+After all findings are collected:
+1. Suppress findings below anchor 75.
+2. **Exception:** P0 severity findings at anchor 50+ survive the gate. Critical-but-uncertain issues must not be silently dropped.
+3. Report the suppressed count by anchor in a `Suppressed findings` section of the review output.
+
+Example:
+
+> Suppressed findings: 3 at anchor 50, 7 at anchor 25, 2 at anchor 0.
+
+Each surviving finding carries a `Confidence: <N>` field alongside severity, file, and line.
+"""
+
+
 def build_review_prompt(
     review_type: str,
     spec_content: str,
@@ -2307,13 +2387,19 @@ Do NOT mark NEEDS_WORK for:
 
 You MAY mention these as "FYI" observations without affecting the verdict.
 
+"""
+            + CONFIDENCE_RUBRIC_BLOCK
+            + """
 ## Output Format
 
-For each issue found:
-- **Severity**: Critical / Major / Minor / Nitpick
+For each surviving finding:
+- **Severity**: Critical / Major / Minor / Nitpick (P0 / P1 / P2 / P3 accepted)
+- **Confidence**: 0 / 25 / 50 / 75 / 100 (one of the five discrete anchors)
 - **File:Line**: Exact location
 - **Problem**: What's wrong
 - **Suggestion**: How to fix
+
+After the findings list, emit a `Suppressed findings:` line tallying anchors dropped by the gate (omit when nothing was suppressed).
 
 Be critical. Find real issues.
 
@@ -6791,13 +6877,17 @@ Do NOT mark NEEDS_WORK for:
 
 You MAY mention these as "FYI" observations without affecting the verdict.
 
+{CONFIDENCE_RUBRIC_BLOCK}
 ## Output Format
 
-For each issue found:
-- **Severity**: Critical / Major / Minor / Nitpick
+For each surviving finding:
+- **Severity**: Critical / Major / Minor / Nitpick (P0 / P1 / P2 / P3 accepted)
+- **Confidence**: 0 / 25 / 50 / 75 / 100 (one of the five discrete anchors)
 - **File:Line**: Exact location
 - **Problem**: What's wrong
 - **Suggestion**: How to fix
+
+After the findings list, emit a `Suppressed findings:` line tallying anchors dropped by the gate (omit when nothing was suppressed).
 
 Be critical. Find real issues.
 
@@ -6994,6 +7084,9 @@ def cmd_codex_impl_review(args: argparse.Namespace) -> None:
     # Determine review id (task_id for task reviews, "branch" for standalone)
     review_id = task_id if task_id else "branch"
 
+    # Parse optional review-rigor signals from output (fn-29.3)
+    suppressed_count = parse_suppressed_count(output)
+
     # Write receipt if path provided (Ralph-compatible schema)
     if receipt_path:
         receipt_data = {
@@ -7018,25 +7111,30 @@ def cmd_codex_impl_review(args: argparse.Namespace) -> None:
                 pass
         if focus:
             receipt_data["focus"] = focus
+        if suppressed_count:
+            receipt_data["suppressed_count"] = suppressed_count
         Path(receipt_path).write_text(
             json.dumps(receipt_data, indent=2) + "\n", encoding="utf-8"
         )
 
     # Output
     if args.json:
+        json_payload = {
+            "type": "impl_review",
+            "id": review_id,
+            "verdict": verdict,
+            "session_id": thread_id,
+            "mode": "codex",
+            "model": resolved_spec.model,
+            "effort": resolved_spec.effort,
+            "spec": str(resolved_spec),
+            "standalone": standalone,
+            "review": output,  # Full review feedback for fix loop
+        }
+        if suppressed_count:
+            json_payload["suppressed_count"] = suppressed_count
         json_output(
-            {
-                "type": "impl_review",
-                "id": review_id,
-                "verdict": verdict,
-                "session_id": thread_id,
-                "mode": "codex",
-                "model": resolved_spec.model,
-                "effort": resolved_spec.effort,
-                "spec": str(resolved_spec),
-                "standalone": standalone,
-                "review": output,  # Full review feedback for fix loop
-            }
+            json_payload
         )
     else:
         print(output)
@@ -7373,6 +7471,9 @@ For EACH requirement from Phase 1:
 - Scope drift (task marked done without fully addressing spec intent)
 - Missing doc updates mentioned in spec
 
+"""
+        + CONFIDENCE_RUBRIC_BLOCK
+        + """
 ## Output Format
 
 ```
@@ -7390,8 +7491,10 @@ For EACH requirement from Phase 1:
 
 ## Gaps Found
 
-[For each GAP, describe what's missing and suggest fix]
+[For each GAP, describe what's missing and suggest fix. Include `Confidence: <0|25|50|75|100>`.]
 ```
+
+After the findings list, emit a `Suppressed findings:` line tallying anchors dropped by the gate (omit when nothing was suppressed).
 
 ## Verdict
 
@@ -7603,6 +7706,9 @@ def cmd_codex_completion_review(args: argparse.Namespace) -> None:
     # Preserve session_id for continuity (avoid clobbering on resumed sessions)
     session_id_to_write = thread_id or session_id
 
+    # Parse optional review-rigor signals from output (fn-29.3)
+    suppressed_count = parse_suppressed_count(output)
+
     # Write receipt if path provided (Ralph-compatible schema)
     if receipt_path:
         receipt_data = {
@@ -7625,26 +7731,29 @@ def cmd_codex_completion_review(args: argparse.Namespace) -> None:
                 receipt_data["iteration"] = int(ralph_iter)
             except ValueError:
                 pass
+        if suppressed_count:
+            receipt_data["suppressed_count"] = suppressed_count
         Path(receipt_path).write_text(
             json.dumps(receipt_data, indent=2) + "\n", encoding="utf-8"
         )
 
     # Output
     if args.json:
-        json_output(
-            {
-                "type": "completion_review",
-                "id": epic_id,
-                "base": base_branch,
-                "verdict": verdict,
-                "session_id": session_id_to_write,
-                "mode": "codex",
-                "model": resolved_spec.model,
-                "effort": resolved_spec.effort,
-                "spec": str(resolved_spec),
-                "review": output,
-            }
-        )
+        json_payload = {
+            "type": "completion_review",
+            "id": epic_id,
+            "base": base_branch,
+            "verdict": verdict,
+            "session_id": session_id_to_write,
+            "mode": "codex",
+            "model": resolved_spec.model,
+            "effort": resolved_spec.effort,
+            "spec": str(resolved_spec),
+            "review": output,
+        }
+        if suppressed_count:
+            json_payload["suppressed_count"] = suppressed_count
+        json_output(json_payload)
     else:
         print(output)
         print(f"\nVERDICT={verdict or 'UNKNOWN'}")
@@ -7842,6 +7951,9 @@ def cmd_copilot_impl_review(args: argparse.Namespace) -> None:
 
     review_id = task_id if task_id else "branch"
 
+    # Parse optional review-rigor signals from output (fn-29.3)
+    suppressed_count = parse_suppressed_count(output)
+
     if receipt_path:
         receipt_data = {
             "type": "impl_review",
@@ -7864,25 +7976,28 @@ def cmd_copilot_impl_review(args: argparse.Namespace) -> None:
                 pass
         if focus:
             receipt_data["focus"] = focus
+        if suppressed_count:
+            receipt_data["suppressed_count"] = suppressed_count
         Path(receipt_path).write_text(
             json.dumps(receipt_data, indent=2) + "\n", encoding="utf-8"
         )
 
     if args.json:
-        json_output(
-            {
-                "type": "impl_review",
-                "id": review_id,
-                "verdict": verdict,
-                "session_id": returned_session_id,
-                "mode": "copilot",
-                "model": effective_model,
-                "effort": effective_effort,
-                "spec": str(resolved_spec),
-                "standalone": standalone,
-                "review": output,
-            }
-        )
+        json_payload = {
+            "type": "impl_review",
+            "id": review_id,
+            "verdict": verdict,
+            "session_id": returned_session_id,
+            "mode": "copilot",
+            "model": effective_model,
+            "effort": effective_effort,
+            "spec": str(resolved_spec),
+            "standalone": standalone,
+            "review": output,
+        }
+        if suppressed_count:
+            json_payload["suppressed_count"] = suppressed_count
+        json_output(json_payload)
     else:
         print(output)
         print(f"\nVERDICT={verdict or 'UNKNOWN'}")
@@ -8213,6 +8328,9 @@ def cmd_copilot_completion_review(args: argparse.Namespace) -> None:
     # Preserve session_id for continuity (avoid clobbering on resumed sessions)
     session_id_to_write = returned_session_id or session_id
 
+    # Parse optional review-rigor signals from output (fn-29.3)
+    suppressed_count = parse_suppressed_count(output)
+
     if receipt_path:
         receipt_data = {
             "type": "completion_review",
@@ -8233,25 +8351,28 @@ def cmd_copilot_completion_review(args: argparse.Namespace) -> None:
                 receipt_data["iteration"] = int(ralph_iter)
             except ValueError:
                 pass
+        if suppressed_count:
+            receipt_data["suppressed_count"] = suppressed_count
         Path(receipt_path).write_text(
             json.dumps(receipt_data, indent=2) + "\n", encoding="utf-8"
         )
 
     if args.json:
-        json_output(
-            {
-                "type": "completion_review",
-                "id": epic_id,
-                "base": base_branch,
-                "verdict": verdict,
-                "session_id": session_id_to_write,
-                "mode": "copilot",
-                "model": effective_model,
-                "effort": effective_effort,
-                "spec": str(resolved_spec),
-                "review": output,
-            }
-        )
+        json_payload = {
+            "type": "completion_review",
+            "id": epic_id,
+            "base": base_branch,
+            "verdict": verdict,
+            "session_id": session_id_to_write,
+            "mode": "copilot",
+            "model": effective_model,
+            "effort": effective_effort,
+            "spec": str(resolved_spec),
+            "review": output,
+        }
+        if suppressed_count:
+            json_payload["suppressed_count"] = suppressed_count
+        json_output(json_payload)
     else:
         print(output)
         print(f"\nVERDICT={verdict or 'UNKNOWN'}")

--- a/plugins/flow-next/scripts/flowctl.py
+++ b/plugins/flow-next/scripts/flowctl.py
@@ -1762,6 +1762,95 @@ def parse_classification_counts(output: str) -> Optional[dict[str, int]]:
     return per_finding if saw_any else None
 
 
+def parse_unaddressed_rids(output: str) -> Optional[list[str]]:
+    """Extract unaddressed R-IDs from review output (fn-29.2).
+
+    Primary signal: a summary line the reviewer is asked to emit, e.g.
+        Unaddressed R-IDs: [R3, R5]
+        Unaddressed R-ID: R3
+        Unaddressed: [R3, R5]
+
+    Fallback: scan a `## Requirements coverage` markdown table for rows whose
+    Status column is `not-addressed` (or `not addressed`). Deferred R-IDs are
+    never returned. Returns a de-duplicated list preserving first-seen order.
+    Returns None when no R-ID coverage signal is present at all (legacy specs
+    without R-IDs, or reviewer skipped the block). Returns ``[]`` when the
+    reviewer explicitly reported zero unaddressed R-IDs (`Unaddressed R-IDs: []`
+    or `none`).
+
+    Flowctl does not enforce the verdict gate here — the reviewer LLM is
+    instructed to flip NEEDS_WORK when any non-deferred R-ID is unaddressed.
+    This helper just stores the array so downstream fix loops can target
+    specific requirements.
+    """
+    if not output:
+        return None
+
+    def _extract_rids(text: str) -> list[str]:
+        """Return R-ID tokens found in ``text`` (de-duped, order-preserving)."""
+        seen: set[str] = set()
+        ordered: list[str] = []
+        for match in re.finditer(r"\bR(\d+)\b", text):
+            rid = f"R{match.group(1)}"
+            if rid not in seen:
+                seen.add(rid)
+                ordered.append(rid)
+        return ordered
+
+    # Primary: `Unaddressed R-IDs: [R3, R5]` / `Unaddressed: R3, R5` / `Unaddressed R-ID: R3`
+    summary_match = re.search(
+        r"(?im)^[\s>*_`]*unaddressed(?:\s+r[-_ ]?ids?)?[\s*_`]*:\s*(.+?)\s*$",
+        output,
+    )
+    if summary_match:
+        payload = summary_match.group(1).strip()
+        # Strip markdown emphasis / brackets / trailing punctuation.
+        stripped = payload.strip("[]`*_ ").rstrip(".")
+        if stripped.lower() in {"", "none", "n/a", "[]"}:
+            return []
+        rids = _extract_rids(payload)
+        return rids  # may be empty if the payload had text but no R-ID tokens
+
+    # Fallback: look for a requirements coverage markdown table and extract
+    # rows with not-addressed status. Deferred rows are skipped.
+    coverage_match = re.search(
+        r"(?is)##\s*Requirements?\s+coverage[^\n]*\n(.+?)(?:\n##\s|\nUnaddressed\s|\Z)",
+        output,
+    )
+    if not coverage_match:
+        return None
+    table_text = coverage_match.group(1)
+    unaddressed: list[str] = []
+    seen: set[str] = set()
+    for line in table_text.splitlines():
+        stripped = line.strip()
+        if not stripped.startswith("|"):
+            continue
+        # Skip separator rows like | --- | --- | --- |
+        if re.fullmatch(r"\|[\s:\-|]+\|?", stripped):
+            continue
+        cols = [c.strip() for c in stripped.strip("|").split("|")]
+        if len(cols) < 2:
+            continue
+        rid_token = cols[0]
+        status = cols[1].lower()
+        # Header row detection
+        if rid_token.lower() in {"r-id", "rid", "r id", "r"}:
+            continue
+        rid_match = re.search(r"\bR(\d+)\b", rid_token)
+        if not rid_match:
+            continue
+        rid = f"R{rid_match.group(1)}"
+        # Normalize status: strip markdown emphasis; accept "not-addressed",
+        # "not addressed", "not_addressed", "unaddressed".
+        status_norm = re.sub(r"[`*_\s]+", "", status).lower()
+        if status_norm in {"not-addressed", "notaddressed", "unaddressed"}:
+            if rid not in seen:
+                seen.add(rid)
+                unaddressed.append(rid)
+    return unaddressed  # may be empty when table exists but all rows met/deferred
+
+
 def is_sandbox_failure(exit_code: int, stdout: str, stderr: str) -> bool:
     """Detect if codex failure is due to sandbox restrictions.
 
@@ -2410,6 +2499,58 @@ If you notice genuine issues with content INSIDE these files (e.g., a spec that 
 """
 
 
+# --- Per-R-ID requirements coverage (fn-29.2) ---
+#
+# Shared prompt block that instructs reviewers to emit a per-R-ID coverage table
+# whenever the epic spec numbers its acceptance criteria (`- **R1:** ...`). The
+# reviewer parses the heading in either `## Acceptance` or the legacy
+# `## Acceptance criteria` form (plan skill writes the former; older epic specs
+# may use the latter). Missing R-IDs flip the verdict to NEEDS_WORK unless the
+# spec marks the requirement deferred. The block is injected into impl-review
+# and epic-review (completion-review) prompts. Keep synchronized with the RP
+# workflow.md files.
+
+R_ID_COVERAGE_BLOCK = """## Requirements coverage (if spec has R-IDs)
+
+If the task or epic spec references an epic spec with numbered acceptance
+criteria like `- **R1:** ...`, `- **R2:** ...`, produce a per-R-ID coverage
+table. Read the epic spec's `## Acceptance` section (or the legacy
+`## Acceptance criteria` heading — reviewer MUST tolerate both). If no R-IDs
+are present anywhere, skip this block entirely — the rest of the review is
+unchanged.
+
+For each R-ID, classify status:
+
+| Status | Meaning |
+|--------|---------|
+| met | Diff clearly implements the requirement with appropriate tests/evidence |
+| partial | Diff advances the requirement but leaves gaps (missing tests, missing edge case, missing integration point) |
+| not-addressed | Diff does not advance this requirement at all |
+| deferred | Spec explicitly defers this requirement to a later task/PR |
+
+Report as a markdown table in the review output:
+
+| R-ID | Status | Evidence |
+|------|--------|----------|
+| R1 | met | src/auth.ts:42 + tests/auth.test.ts:17 |
+| R2 | partial | implementation exists but no error-path tests |
+| R3 | not-addressed | — |
+
+After the table, emit one line listing every `not-addressed` R-ID that is NOT
+explicitly deferred in the spec:
+
+> Unaddressed R-IDs: [R3, R5]
+
+If there are zero unaddressed R-IDs, emit `Unaddressed R-IDs: []` or omit the
+line entirely — both forms are valid. Deferred R-IDs are never listed here.
+
+**Verdict gate:** any `not-addressed` R-ID that is NOT marked `deferred` in the
+spec MUST flip the verdict to `NEEDS_WORK`. A clean coverage table (all `met`
+or `deferred`) does not by itself force SHIP — the other review gates still
+apply.
+"""
+
+
 def build_review_prompt(
     review_type: str,
     spec_content: str,
@@ -2524,6 +2665,8 @@ Do NOT mark NEEDS_WORK for:
 You MAY mention these as "FYI" observations without affecting the verdict.
 
 """
+            + R_ID_COVERAGE_BLOCK
+            + "\n"
             + CONFIDENCE_RUBRIC_BLOCK
             + "\n"
             + CLASSIFICATION_RUBRIC_BLOCK
@@ -2543,17 +2686,18 @@ For each surviving `introduced` finding:
 Then, under a separate `## Pre-existing issues (not blocking this verdict)` heading, list each `pre_existing` finding using the compact form `[severity, confidence N, introduced=false] file:line — summary`. Never silently drop pre-existing findings.
 
 After the findings list, emit:
+- The `## Requirements coverage` table and `Unaddressed R-IDs:` line (only when the spec uses R-IDs; otherwise skip).
 - A `Suppressed findings:` line tallying anchors dropped by the gate (omit when nothing was suppressed).
 - A `Classification counts:` line tallying `introduced` vs `pre_existing` survivors, e.g. `Classification counts: 2 introduced, 4 pre_existing.`.
 - A `Protected-path filter:` line tallying findings dropped by the protected-path filter (omit when nothing was dropped).
 
 Be critical. Find real issues.
 
-**Verdict gate:** only `introduced` findings affect the verdict. A review whose sole surviving findings are all `pre_existing` MUST ship.
+**Verdict gate:** only `introduced` findings affect the verdict. A review whose sole surviving findings are all `pre_existing` MUST ship. Any non-deferred `not-addressed` R-ID also forces NEEDS_WORK regardless of other findings.
 
 **REQUIRED**: End your response with exactly one verdict tag:
-<verdict>SHIP</verdict> - Ready to merge (no blocking `introduced` findings)
-<verdict>NEEDS_WORK</verdict> - `introduced` issues must be fixed
+<verdict>SHIP</verdict> - Ready to merge (no blocking `introduced` findings, all R-IDs met or deferred)
+<verdict>NEEDS_WORK</verdict> - `introduced` issues or unaddressed R-IDs must be fixed
 <verdict>MAJOR_RETHINK</verdict> - Fundamental approach problems
 
 Do NOT skip this tag. The automation depends on it."""
@@ -7030,6 +7174,7 @@ Do NOT mark NEEDS_WORK for:
 
 You MAY mention these as "FYI" observations without affecting the verdict.
 
+{R_ID_COVERAGE_BLOCK}
 {CONFIDENCE_RUBRIC_BLOCK}
 {CLASSIFICATION_RUBRIC_BLOCK}
 {PROTECTED_ARTIFACTS_BLOCK}
@@ -7046,17 +7191,18 @@ For each surviving `introduced` finding:
 Then, under a separate `## Pre-existing issues (not blocking this verdict)` heading, list each `pre_existing` finding as `[severity, confidence N, introduced=false] file:line — summary`. Never silently drop pre-existing findings.
 
 After the findings list, emit:
+- The `## Requirements coverage` table and `Unaddressed R-IDs:` line (only when the spec uses R-IDs; otherwise skip).
 - A `Suppressed findings:` line tallying anchors dropped by the gate (omit when nothing was suppressed).
 - A `Classification counts:` line tallying `introduced` vs `pre_existing` survivors, e.g. `Classification counts: 2 introduced, 4 pre_existing.`.
 - A `Protected-path filter:` line tallying findings dropped by the protected-path filter (omit when nothing was dropped).
 
 Be critical. Find real issues.
 
-**Verdict gate:** only `introduced` findings affect the verdict. A review whose sole surviving findings are all `pre_existing` MUST ship.
+**Verdict gate:** only `introduced` findings affect the verdict. A review whose sole surviving findings are all `pre_existing` MUST ship. Any non-deferred `not-addressed` R-ID also forces NEEDS_WORK regardless of other findings.
 
 **REQUIRED**: End your response with exactly one verdict tag:
-- `<verdict>SHIP</verdict>` - Ready to merge (no blocking `introduced` findings)
-- `<verdict>NEEDS_WORK</verdict>` - `introduced` issues must be fixed first
+- `<verdict>SHIP</verdict>` - Ready to merge (no blocking `introduced` findings, all R-IDs met or deferred)
+- `<verdict>NEEDS_WORK</verdict>` - `introduced` issues or unaddressed R-IDs must be fixed first
 - `<verdict>MAJOR_RETHINK</verdict>` - Fundamental problems, reconsider approach
 """
 
@@ -7247,9 +7393,10 @@ def cmd_codex_impl_review(args: argparse.Namespace) -> None:
     # Determine review id (task_id for task reviews, "branch" for standalone)
     review_id = task_id if task_id else "branch"
 
-    # Parse optional review-rigor signals from output (fn-29.3, fn-29.4)
+    # Parse optional review-rigor signals from output (fn-29.2, fn-29.3, fn-29.4)
     suppressed_count = parse_suppressed_count(output)
     classification_counts = parse_classification_counts(output)
+    unaddressed_rids = parse_unaddressed_rids(output)
 
     # Write receipt if path provided (Ralph-compatible schema)
     if receipt_path:
@@ -7280,6 +7427,8 @@ def cmd_codex_impl_review(args: argparse.Namespace) -> None:
         if classification_counts is not None:
             receipt_data["introduced_count"] = classification_counts["introduced"]
             receipt_data["pre_existing_count"] = classification_counts["pre_existing"]
+        if unaddressed_rids is not None:
+            receipt_data["unaddressed"] = unaddressed_rids
         Path(receipt_path).write_text(
             json.dumps(receipt_data, indent=2) + "\n", encoding="utf-8"
         )
@@ -7303,6 +7452,8 @@ def cmd_codex_impl_review(args: argparse.Namespace) -> None:
         if classification_counts is not None:
             json_payload["introduced_count"] = classification_counts["introduced"]
             json_payload["pre_existing_count"] = classification_counts["pre_existing"]
+        if unaddressed_rids is not None:
+            json_payload["unaddressed"] = unaddressed_rids
         json_output(
             json_payload
         )
@@ -7642,6 +7793,8 @@ For EACH requirement from Phase 1:
 - Missing doc updates mentioned in spec
 
 """
+        + R_ID_COVERAGE_BLOCK
+        + "\n"
         + CONFIDENCE_RUBRIC_BLOCK
         + "\n"
         + CLASSIFICATION_RUBRIC_BLOCK
@@ -7671,18 +7824,19 @@ For EACH requirement from Phase 1:
 Pre-existing gaps (code smells or missing features that predate this epic's branch) go under a separate `## Pre-existing issues (not blocking this verdict)` heading and do not gate the verdict.
 
 After the findings list, emit:
+- The `## Requirements coverage` table and `Unaddressed R-IDs:` line (only when the epic spec uses R-IDs; otherwise skip).
 - A `Suppressed findings:` line tallying anchors dropped by the gate (omit when nothing was suppressed).
 - A `Classification counts:` line tallying `introduced` vs `pre_existing` gaps, e.g. `Classification counts: 1 introduced, 0 pre_existing.`.
 - A `Protected-path filter:` line tallying gaps dropped by the protected-path filter (omit when nothing was dropped).
 
 ## Verdict
 
-**SHIP** - All requirements covered. Epic can close.
-**NEEDS_WORK** - Gaps found. Must fix before closing.
+**SHIP** - All requirements covered (all R-IDs met or deferred). Epic can close.
+**NEEDS_WORK** - Gaps found (or unaddressed R-IDs). Must fix before closing.
 
 **REQUIRED**: End your response with exactly one verdict tag:
-<verdict>SHIP</verdict> - All requirements implemented
-<verdict>NEEDS_WORK</verdict> - Gaps need addressing
+<verdict>SHIP</verdict> - All requirements implemented (R-IDs all met or deferred)
+<verdict>NEEDS_WORK</verdict> - Gaps or unaddressed R-IDs need addressing
 
 Do NOT skip this tag. The automation depends on it."""
     )
@@ -7885,9 +8039,10 @@ def cmd_codex_completion_review(args: argparse.Namespace) -> None:
     # Preserve session_id for continuity (avoid clobbering on resumed sessions)
     session_id_to_write = thread_id or session_id
 
-    # Parse optional review-rigor signals from output (fn-29.3, fn-29.4)
+    # Parse optional review-rigor signals from output (fn-29.2, fn-29.3, fn-29.4)
     suppressed_count = parse_suppressed_count(output)
     classification_counts = parse_classification_counts(output)
+    unaddressed_rids = parse_unaddressed_rids(output)
 
     # Write receipt if path provided (Ralph-compatible schema)
     if receipt_path:
@@ -7916,6 +8071,8 @@ def cmd_codex_completion_review(args: argparse.Namespace) -> None:
         if classification_counts is not None:
             receipt_data["introduced_count"] = classification_counts["introduced"]
             receipt_data["pre_existing_count"] = classification_counts["pre_existing"]
+        if unaddressed_rids is not None:
+            receipt_data["unaddressed"] = unaddressed_rids
         Path(receipt_path).write_text(
             json.dumps(receipt_data, indent=2) + "\n", encoding="utf-8"
         )
@@ -7939,6 +8096,8 @@ def cmd_codex_completion_review(args: argparse.Namespace) -> None:
         if classification_counts is not None:
             json_payload["introduced_count"] = classification_counts["introduced"]
             json_payload["pre_existing_count"] = classification_counts["pre_existing"]
+        if unaddressed_rids is not None:
+            json_payload["unaddressed"] = unaddressed_rids
         json_output(json_payload)
     else:
         print(output)
@@ -8137,9 +8296,10 @@ def cmd_copilot_impl_review(args: argparse.Namespace) -> None:
 
     review_id = task_id if task_id else "branch"
 
-    # Parse optional review-rigor signals from output (fn-29.3, fn-29.4)
+    # Parse optional review-rigor signals from output (fn-29.2, fn-29.3, fn-29.4)
     suppressed_count = parse_suppressed_count(output)
     classification_counts = parse_classification_counts(output)
+    unaddressed_rids = parse_unaddressed_rids(output)
 
     if receipt_path:
         receipt_data = {
@@ -8168,6 +8328,8 @@ def cmd_copilot_impl_review(args: argparse.Namespace) -> None:
         if classification_counts is not None:
             receipt_data["introduced_count"] = classification_counts["introduced"]
             receipt_data["pre_existing_count"] = classification_counts["pre_existing"]
+        if unaddressed_rids is not None:
+            receipt_data["unaddressed"] = unaddressed_rids
         Path(receipt_path).write_text(
             json.dumps(receipt_data, indent=2) + "\n", encoding="utf-8"
         )
@@ -8190,6 +8352,8 @@ def cmd_copilot_impl_review(args: argparse.Namespace) -> None:
         if classification_counts is not None:
             json_payload["introduced_count"] = classification_counts["introduced"]
             json_payload["pre_existing_count"] = classification_counts["pre_existing"]
+        if unaddressed_rids is not None:
+            json_payload["unaddressed"] = unaddressed_rids
         json_output(json_payload)
     else:
         print(output)
@@ -8521,9 +8685,10 @@ def cmd_copilot_completion_review(args: argparse.Namespace) -> None:
     # Preserve session_id for continuity (avoid clobbering on resumed sessions)
     session_id_to_write = returned_session_id or session_id
 
-    # Parse optional review-rigor signals from output (fn-29.3, fn-29.4)
+    # Parse optional review-rigor signals from output (fn-29.2, fn-29.3, fn-29.4)
     suppressed_count = parse_suppressed_count(output)
     classification_counts = parse_classification_counts(output)
+    unaddressed_rids = parse_unaddressed_rids(output)
 
     if receipt_path:
         receipt_data = {
@@ -8550,6 +8715,8 @@ def cmd_copilot_completion_review(args: argparse.Namespace) -> None:
         if classification_counts is not None:
             receipt_data["introduced_count"] = classification_counts["introduced"]
             receipt_data["pre_existing_count"] = classification_counts["pre_existing"]
+        if unaddressed_rids is not None:
+            receipt_data["unaddressed"] = unaddressed_rids
         Path(receipt_path).write_text(
             json.dumps(receipt_data, indent=2) + "\n", encoding="utf-8"
         )
@@ -8572,6 +8739,8 @@ def cmd_copilot_completion_review(args: argparse.Namespace) -> None:
         if classification_counts is not None:
             json_payload["introduced_count"] = classification_counts["introduced"]
             json_payload["pre_existing_count"] = classification_counts["pre_existing"]
+        if unaddressed_rids is not None:
+            json_payload["unaddressed"] = unaddressed_rids
         json_output(json_payload)
     else:
         print(output)

--- a/plugins/flow-next/scripts/flowctl.py
+++ b/plugins/flow-next/scripts/flowctl.py
@@ -1693,6 +1693,75 @@ def parse_suppressed_count(output: str) -> Optional[dict[str, int]]:
     return counts or None
 
 
+def parse_classification_counts(output: str) -> Optional[dict[str, int]]:
+    """Extract introduced/pre_existing tallies from review output (fn-29.4).
+
+    Primary signal: a summary line the reviewer is asked to emit, e.g.
+        Classification counts: 2 introduced, 4 pre_existing.
+
+    Fallback: count `Classification: introduced | pre_existing` fragments in
+    per-finding blocks. Either path returns `{"introduced": int, "pre_existing": int}`
+    with zero counts preserved when the other bucket is non-zero — so callers
+    can compute a verdict gate from `introduced_count`. Returns None when no
+    classification signal is present at all (legacy reviews, pre-migration).
+    """
+    if not output:
+        return None
+
+    # Canonical summary line (preferred — reviewer reports tallies directly).
+    summary_match = re.search(
+        r"(?im)^[\s>*_`]*classification\s+counts[\s*_`]*:\s*(.+?)\s*$",
+        output,
+    )
+    if summary_match:
+        payload = summary_match.group(1).strip().rstrip(".")
+        if payload and payload.lower() not in {"none", "n/a"}:
+            found: dict[str, int] = {}
+            for frag_match in re.finditer(
+                r"(\d+)\s*(introduced|pre[-_ ]existing)",
+                payload,
+                re.IGNORECASE,
+            ):
+                raw_bucket = frag_match.group(2).lower().replace("-", "_").replace(
+                    " ", "_"
+                )
+                bucket = "pre_existing" if "pre" in raw_bucket else "introduced"
+                try:
+                    found[bucket] = found.get(bucket, 0) + int(frag_match.group(1))
+                except ValueError:
+                    continue
+            if found:
+                # Fill missing bucket with 0 so downstream always has both keys.
+                found.setdefault("introduced", 0)
+                found.setdefault("pre_existing", 0)
+                return found
+
+    # Fallback: tally per-finding Classification: lines.
+    per_finding: dict[str, int] = {"introduced": 0, "pre_existing": 0}
+    saw_any = False
+    for frag_match in re.finditer(
+        r"(?im)classification[\s*_`]*[:=][\s*_`]*(introduced|pre[-_ ]existing)",
+        output,
+    ):
+        raw_bucket = frag_match.group(1).lower().replace("-", "_").replace(" ", "_")
+        bucket = "pre_existing" if "pre" in raw_bucket else "introduced"
+        per_finding[bucket] += 1
+        saw_any = True
+
+    # Also catch the inline `[..., introduced=false]` / `introduced=true` markers
+    # that appear in the pre-existing-issues report format.
+    for frag_match in re.finditer(
+        r"introduced\s*=\s*(true|false)",
+        output,
+        re.IGNORECASE,
+    ):
+        bucket = "introduced" if frag_match.group(1).lower() == "true" else "pre_existing"
+        per_finding[bucket] += 1
+        saw_any = True
+
+    return per_finding if saw_any else None
+
+
 def is_sandbox_failure(exit_code: int, stdout: str, stderr: str) -> bool:
     """Detect if codex failure is due to sandbox restrictions.
 
@@ -2274,6 +2343,43 @@ Each surviving finding carries a `Confidence: <N>` field alongside severity, fil
 """
 
 
+# --- Introduced-vs-pre_existing classification (fn-29.4) ---
+#
+# Shared classification rubric injected alongside CONFIDENCE_RUBRIC_BLOCK. Only
+# `introduced` findings gate the verdict; `pre_existing` surface in a separate
+# non-blocking section. Keep synchronized with the RP workflow.md files.
+
+CLASSIFICATION_RUBRIC_BLOCK = """## Introduced vs pre-existing classification
+
+For each finding, classify whether this branch's diff caused it:
+
+- **introduced** — this branch caused the issue (new code, or a pre-existing bug that this diff amplified/exposed in a way that now matters)
+- **pre_existing** — the issue was already present on the base branch; this diff did not touch it
+
+Evidence methods (use whatever is cheapest for this diff):
+- `git blame <file> <line>` to see when the line was last touched
+- Read the base-branch version of the file directly
+- Infer from diff context: a finding on an unchanged line in an unchanged file is `pre_existing` by default
+
+**Verdict gate:** only `introduced` findings affect the verdict. A review whose only surviving findings are all `pre_existing` ships.
+
+Report pre-existing findings in a dedicated non-blocking section:
+
+```
+## Pre-existing issues (not blocking this verdict)
+
+- [P1, confidence 75, introduced=false] src/legacy.ts:102 — null dereference on empty array
+- ...
+```
+
+Never delete pre-existing findings from the report — they stay visible for future prioritization. After the lists, emit a `Classification counts:` line tallying both buckets, e.g.:
+
+> Classification counts: 2 introduced, 4 pre_existing.
+
+Each surviving finding carries a `Classification: introduced | pre_existing` field alongside severity, confidence, file, and line.
+"""
+
+
 def build_review_prompt(
     review_type: str,
     spec_content: str,
@@ -2389,23 +2495,32 @@ You MAY mention these as "FYI" observations without affecting the verdict.
 
 """
             + CONFIDENCE_RUBRIC_BLOCK
+            + "\n"
+            + CLASSIFICATION_RUBRIC_BLOCK
             + """
 ## Output Format
 
-For each surviving finding:
+For each surviving `introduced` finding:
 - **Severity**: Critical / Major / Minor / Nitpick (P0 / P1 / P2 / P3 accepted)
 - **Confidence**: 0 / 25 / 50 / 75 / 100 (one of the five discrete anchors)
+- **Classification**: introduced
 - **File:Line**: Exact location
 - **Problem**: What's wrong
 - **Suggestion**: How to fix
 
-After the findings list, emit a `Suppressed findings:` line tallying anchors dropped by the gate (omit when nothing was suppressed).
+Then, under a separate `## Pre-existing issues (not blocking this verdict)` heading, list each `pre_existing` finding using the compact form `[severity, confidence N, introduced=false] file:line — summary`. Never silently drop pre-existing findings.
+
+After the findings list, emit:
+- A `Suppressed findings:` line tallying anchors dropped by the gate (omit when nothing was suppressed).
+- A `Classification counts:` line tallying `introduced` vs `pre_existing` survivors, e.g. `Classification counts: 2 introduced, 4 pre_existing.`.
 
 Be critical. Find real issues.
 
+**Verdict gate:** only `introduced` findings affect the verdict. A review whose sole surviving findings are all `pre_existing` MUST ship.
+
 **REQUIRED**: End your response with exactly one verdict tag:
-<verdict>SHIP</verdict> - Ready to merge
-<verdict>NEEDS_WORK</verdict> - Has issues that must be fixed
+<verdict>SHIP</verdict> - Ready to merge (no blocking `introduced` findings)
+<verdict>NEEDS_WORK</verdict> - `introduced` issues must be fixed
 <verdict>MAJOR_RETHINK</verdict> - Fundamental approach problems
 
 Do NOT skip this tag. The automation depends on it."""
@@ -6878,22 +6993,30 @@ Do NOT mark NEEDS_WORK for:
 You MAY mention these as "FYI" observations without affecting the verdict.
 
 {CONFIDENCE_RUBRIC_BLOCK}
+{CLASSIFICATION_RUBRIC_BLOCK}
 ## Output Format
 
-For each surviving finding:
+For each surviving `introduced` finding:
 - **Severity**: Critical / Major / Minor / Nitpick (P0 / P1 / P2 / P3 accepted)
 - **Confidence**: 0 / 25 / 50 / 75 / 100 (one of the five discrete anchors)
+- **Classification**: introduced
 - **File:Line**: Exact location
 - **Problem**: What's wrong
 - **Suggestion**: How to fix
 
-After the findings list, emit a `Suppressed findings:` line tallying anchors dropped by the gate (omit when nothing was suppressed).
+Then, under a separate `## Pre-existing issues (not blocking this verdict)` heading, list each `pre_existing` finding as `[severity, confidence N, introduced=false] file:line — summary`. Never silently drop pre-existing findings.
+
+After the findings list, emit:
+- A `Suppressed findings:` line tallying anchors dropped by the gate (omit when nothing was suppressed).
+- A `Classification counts:` line tallying `introduced` vs `pre_existing` survivors, e.g. `Classification counts: 2 introduced, 4 pre_existing.`.
 
 Be critical. Find real issues.
 
+**Verdict gate:** only `introduced` findings affect the verdict. A review whose sole surviving findings are all `pre_existing` MUST ship.
+
 **REQUIRED**: End your response with exactly one verdict tag:
-- `<verdict>SHIP</verdict>` - Ready to merge
-- `<verdict>NEEDS_WORK</verdict>` - Issues must be fixed first
+- `<verdict>SHIP</verdict>` - Ready to merge (no blocking `introduced` findings)
+- `<verdict>NEEDS_WORK</verdict>` - `introduced` issues must be fixed first
 - `<verdict>MAJOR_RETHINK</verdict>` - Fundamental problems, reconsider approach
 """
 
@@ -7084,8 +7207,9 @@ def cmd_codex_impl_review(args: argparse.Namespace) -> None:
     # Determine review id (task_id for task reviews, "branch" for standalone)
     review_id = task_id if task_id else "branch"
 
-    # Parse optional review-rigor signals from output (fn-29.3)
+    # Parse optional review-rigor signals from output (fn-29.3, fn-29.4)
     suppressed_count = parse_suppressed_count(output)
+    classification_counts = parse_classification_counts(output)
 
     # Write receipt if path provided (Ralph-compatible schema)
     if receipt_path:
@@ -7113,6 +7237,9 @@ def cmd_codex_impl_review(args: argparse.Namespace) -> None:
             receipt_data["focus"] = focus
         if suppressed_count:
             receipt_data["suppressed_count"] = suppressed_count
+        if classification_counts is not None:
+            receipt_data["introduced_count"] = classification_counts["introduced"]
+            receipt_data["pre_existing_count"] = classification_counts["pre_existing"]
         Path(receipt_path).write_text(
             json.dumps(receipt_data, indent=2) + "\n", encoding="utf-8"
         )
@@ -7133,6 +7260,9 @@ def cmd_codex_impl_review(args: argparse.Namespace) -> None:
         }
         if suppressed_count:
             json_payload["suppressed_count"] = suppressed_count
+        if classification_counts is not None:
+            json_payload["introduced_count"] = classification_counts["introduced"]
+            json_payload["pre_existing_count"] = classification_counts["pre_existing"]
         json_output(
             json_payload
         )
@@ -7473,6 +7603,8 @@ For EACH requirement from Phase 1:
 
 """
         + CONFIDENCE_RUBRIC_BLOCK
+        + "\n"
+        + CLASSIFICATION_RUBRIC_BLOCK
         + """
 ## Output Format
 
@@ -7491,10 +7623,14 @@ For EACH requirement from Phase 1:
 
 ## Gaps Found
 
-[For each GAP, describe what's missing and suggest fix. Include `Confidence: <0|25|50|75|100>`.]
+[For each GAP, describe what's missing and suggest fix. Include `Confidence: <0|25|50|75|100>` and `Classification: introduced | pre_existing` — `pre_existing` means the gap existed before this epic's branch touched the code and is therefore not blocking.]
 ```
 
-After the findings list, emit a `Suppressed findings:` line tallying anchors dropped by the gate (omit when nothing was suppressed).
+Pre-existing gaps (code smells or missing features that predate this epic's branch) go under a separate `## Pre-existing issues (not blocking this verdict)` heading and do not gate the verdict.
+
+After the findings list, emit:
+- A `Suppressed findings:` line tallying anchors dropped by the gate (omit when nothing was suppressed).
+- A `Classification counts:` line tallying `introduced` vs `pre_existing` gaps, e.g. `Classification counts: 1 introduced, 0 pre_existing.`.
 
 ## Verdict
 
@@ -7706,8 +7842,9 @@ def cmd_codex_completion_review(args: argparse.Namespace) -> None:
     # Preserve session_id for continuity (avoid clobbering on resumed sessions)
     session_id_to_write = thread_id or session_id
 
-    # Parse optional review-rigor signals from output (fn-29.3)
+    # Parse optional review-rigor signals from output (fn-29.3, fn-29.4)
     suppressed_count = parse_suppressed_count(output)
+    classification_counts = parse_classification_counts(output)
 
     # Write receipt if path provided (Ralph-compatible schema)
     if receipt_path:
@@ -7733,6 +7870,9 @@ def cmd_codex_completion_review(args: argparse.Namespace) -> None:
                 pass
         if suppressed_count:
             receipt_data["suppressed_count"] = suppressed_count
+        if classification_counts is not None:
+            receipt_data["introduced_count"] = classification_counts["introduced"]
+            receipt_data["pre_existing_count"] = classification_counts["pre_existing"]
         Path(receipt_path).write_text(
             json.dumps(receipt_data, indent=2) + "\n", encoding="utf-8"
         )
@@ -7753,6 +7893,9 @@ def cmd_codex_completion_review(args: argparse.Namespace) -> None:
         }
         if suppressed_count:
             json_payload["suppressed_count"] = suppressed_count
+        if classification_counts is not None:
+            json_payload["introduced_count"] = classification_counts["introduced"]
+            json_payload["pre_existing_count"] = classification_counts["pre_existing"]
         json_output(json_payload)
     else:
         print(output)
@@ -7951,8 +8094,9 @@ def cmd_copilot_impl_review(args: argparse.Namespace) -> None:
 
     review_id = task_id if task_id else "branch"
 
-    # Parse optional review-rigor signals from output (fn-29.3)
+    # Parse optional review-rigor signals from output (fn-29.3, fn-29.4)
     suppressed_count = parse_suppressed_count(output)
+    classification_counts = parse_classification_counts(output)
 
     if receipt_path:
         receipt_data = {
@@ -7978,6 +8122,9 @@ def cmd_copilot_impl_review(args: argparse.Namespace) -> None:
             receipt_data["focus"] = focus
         if suppressed_count:
             receipt_data["suppressed_count"] = suppressed_count
+        if classification_counts is not None:
+            receipt_data["introduced_count"] = classification_counts["introduced"]
+            receipt_data["pre_existing_count"] = classification_counts["pre_existing"]
         Path(receipt_path).write_text(
             json.dumps(receipt_data, indent=2) + "\n", encoding="utf-8"
         )
@@ -7997,6 +8144,9 @@ def cmd_copilot_impl_review(args: argparse.Namespace) -> None:
         }
         if suppressed_count:
             json_payload["suppressed_count"] = suppressed_count
+        if classification_counts is not None:
+            json_payload["introduced_count"] = classification_counts["introduced"]
+            json_payload["pre_existing_count"] = classification_counts["pre_existing"]
         json_output(json_payload)
     else:
         print(output)
@@ -8328,8 +8478,9 @@ def cmd_copilot_completion_review(args: argparse.Namespace) -> None:
     # Preserve session_id for continuity (avoid clobbering on resumed sessions)
     session_id_to_write = returned_session_id or session_id
 
-    # Parse optional review-rigor signals from output (fn-29.3)
+    # Parse optional review-rigor signals from output (fn-29.3, fn-29.4)
     suppressed_count = parse_suppressed_count(output)
+    classification_counts = parse_classification_counts(output)
 
     if receipt_path:
         receipt_data = {
@@ -8353,6 +8504,9 @@ def cmd_copilot_completion_review(args: argparse.Namespace) -> None:
                 pass
         if suppressed_count:
             receipt_data["suppressed_count"] = suppressed_count
+        if classification_counts is not None:
+            receipt_data["introduced_count"] = classification_counts["introduced"]
+            receipt_data["pre_existing_count"] = classification_counts["pre_existing"]
         Path(receipt_path).write_text(
             json.dumps(receipt_data, indent=2) + "\n", encoding="utf-8"
         )
@@ -8372,6 +8526,9 @@ def cmd_copilot_completion_review(args: argparse.Namespace) -> None:
         }
         if suppressed_count:
             json_payload["suppressed_count"] = suppressed_count
+        if classification_counts is not None:
+            json_payload["introduced_count"] = classification_counts["introduced"]
+            json_payload["pre_existing_count"] = classification_counts["pre_existing"]
         json_output(json_payload)
     else:
         print(output)

--- a/plugins/flow-next/scripts/flowctl.py
+++ b/plugins/flow-next/scripts/flowctl.py
@@ -2380,6 +2380,36 @@ Each surviving finding carries a `Classification: introduced | pre_existing` fie
 """
 
 
+# --- Protected artifacts (fn-29.5) ---
+#
+# Safety rail: external reviewers (codex/copilot on unfamiliar projects) routinely
+# look at committed `.flow/*` JSONs/specs and naturally suggest "why are these
+# committed?" Ralph in autofix mode could then apply that finding and destroy its
+# own state. This block is injected alongside the confidence + classification
+# rubrics so every review backend (rp, codex, copilot) honors the same hard list.
+# Keep synchronized with the three workflow.md files + quality-auditor.md.
+
+PROTECTED_ARTIFACTS_BLOCK = """## Protected artifacts
+
+The following paths are flow-next / project-pipeline artifacts. Any finding recommending their deletion, gitignore, or removal MUST be discarded during synthesis. Do not flag these paths for cleanup under any circumstances:
+
+- `.flow/*` — flow-next state, specs, tasks, epics, runtime
+- `.flow/bin/*` — bundled flowctl
+- `.flow/memory/*` — learnings store (pitfalls, conventions, decisions)
+- `.flow/specs/*.md` — epic specs (decision artifacts)
+- `.flow/tasks/*.md` — task specs (decision artifacts)
+- `docs/plans/*` — plan artifacts (if project uses this convention)
+- `docs/solutions/*` — solutions artifacts (if project uses this convention)
+- `scripts/ralph/*` — Ralph harness (when present)
+
+These files are intentionally committed. They are the pipeline's state, not clutter. An agent that deletes them destroys the project's planning trail and breaks Ralph autonomous runs.
+
+If you notice genuine issues with content INSIDE these files (e.g., a spec that contradicts itself, a stale runtime value, a memory entry that's wrong), flag the content — not the file's existence.
+
+**Protected-path filter.** Before emitting findings, scan each for recommendations to delete, gitignore, or `rm -rf` any path matching the protected list above. Drop those findings. If you drop any, report the drop count in a `Protected-path filter:` line in the review output (e.g. `Protected-path filter: dropped 2 findings`). Omit the line when nothing was dropped.
+"""
+
+
 def build_review_prompt(
     review_type: str,
     spec_content: str,
@@ -2497,6 +2527,8 @@ You MAY mention these as "FYI" observations without affecting the verdict.
             + CONFIDENCE_RUBRIC_BLOCK
             + "\n"
             + CLASSIFICATION_RUBRIC_BLOCK
+            + "\n"
+            + PROTECTED_ARTIFACTS_BLOCK
             + """
 ## Output Format
 
@@ -2513,6 +2545,7 @@ Then, under a separate `## Pre-existing issues (not blocking this verdict)` head
 After the findings list, emit:
 - A `Suppressed findings:` line tallying anchors dropped by the gate (omit when nothing was suppressed).
 - A `Classification counts:` line tallying `introduced` vs `pre_existing` survivors, e.g. `Classification counts: 2 introduced, 4 pre_existing.`.
+- A `Protected-path filter:` line tallying findings dropped by the protected-path filter (omit when nothing was dropped).
 
 Be critical. Find real issues.
 
@@ -2568,6 +2601,9 @@ Do NOT mark NEEDS_WORK for:
 
 You MAY mention these as "FYI" observations without affecting the verdict.
 
+"""
+            + PROTECTED_ARTIFACTS_BLOCK
+            + """
 ## Output Format
 
 For each issue found:
@@ -2575,6 +2611,8 @@ For each issue found:
 - **Location**: Which task or section (e.g., "fn-1.3 Description" or "Epic Acceptance #2")
 - **Problem**: What's wrong
 - **Suggestion**: How to fix
+
+After the issues list, emit a `Protected-path filter:` line tallying findings dropped by the protected-path filter (omit when nothing was dropped).
 
 Be critical. Find real issues.
 
@@ -6994,6 +7032,7 @@ You MAY mention these as "FYI" observations without affecting the verdict.
 
 {CONFIDENCE_RUBRIC_BLOCK}
 {CLASSIFICATION_RUBRIC_BLOCK}
+{PROTECTED_ARTIFACTS_BLOCK}
 ## Output Format
 
 For each surviving `introduced` finding:
@@ -7009,6 +7048,7 @@ Then, under a separate `## Pre-existing issues (not blocking this verdict)` head
 After the findings list, emit:
 - A `Suppressed findings:` line tallying anchors dropped by the gate (omit when nothing was suppressed).
 - A `Classification counts:` line tallying `introduced` vs `pre_existing` survivors, e.g. `Classification counts: 2 introduced, 4 pre_existing.`.
+- A `Protected-path filter:` line tallying findings dropped by the protected-path filter (omit when nothing was dropped).
 
 Be critical. Find real issues.
 
@@ -7605,6 +7645,8 @@ For EACH requirement from Phase 1:
         + CONFIDENCE_RUBRIC_BLOCK
         + "\n"
         + CLASSIFICATION_RUBRIC_BLOCK
+        + "\n"
+        + PROTECTED_ARTIFACTS_BLOCK
         + """
 ## Output Format
 
@@ -7631,6 +7673,7 @@ Pre-existing gaps (code smells or missing features that predate this epic's bran
 After the findings list, emit:
 - A `Suppressed findings:` line tallying anchors dropped by the gate (omit when nothing was suppressed).
 - A `Classification counts:` line tallying `introduced` vs `pre_existing` gaps, e.g. `Classification counts: 1 introduced, 0 pre_existing.`.
+- A `Protected-path filter:` line tallying gaps dropped by the protected-path filter (omit when nothing was dropped).
 
 ## Verdict
 

--- a/plugins/flow-next/scripts/flowctl.py
+++ b/plugins/flow-next/scripts/flowctl.py
@@ -8886,9 +8886,12 @@ def _classify_triage_path(path: str) -> str:
         return "other"
 
     # Generated / vendored wins over extension match — e.g. a .ts file under
-    # node_modules/ is still "generated" for our purposes.
+    # node_modules/ is still "generated" for our purposes. Match only at the
+    # repo-root prefix; git diff output is always repo-root-relative, and a
+    # loose substring match would false-positive paths like `scripts/build/…`
+    # against the `build/` prefix.
     for prefix in TRIAGE_GENERATED_PREFIXES:
-        if p.startswith(prefix) or f"/{prefix}" in f"/{p}":
+        if p.startswith(prefix):
             return "generated"
 
     base = p.rsplit("/", 1)[-1]
@@ -8919,13 +8922,88 @@ def _classify_triage_path(path: str) -> str:
     return "other"
 
 
-def _triage_deterministic(changed_files: list[str]) -> tuple[Optional[str], str]:
+_TRIAGE_VERSION_JSON_RE = re.compile(r'^\s*"version"\s*:\s*"[^"]*"\s*,?\s*$')
+_TRIAGE_VERSION_TOML_RE = re.compile(r'^\s*version\s*=\s*"[^"]*"\s*$')
+
+
+def _triage_chore_is_version_only(
+    path: str, base: str, repo_root: str
+) -> bool:
+    """Verify a chore-classified file's diff only touches version-like fields.
+
+    A file is basename-matched as ``chore`` (``package.json``, ``plugin.json``,
+    ``Cargo.toml``, ``pyproject.toml``, ``CHANGELOG.md``) but that alone does
+    not prove the edit is trivial — changing ``package.json`` dependencies or
+    scripts must still route through a full review. This helper inspects the
+    actual diff hunks and returns True only when every +/- content line is:
+
+    - a ``"version": "..."`` line (JSON manifests), or
+    - a ``version = "..."`` line (TOML manifests), or
+    - any addition-only line for ``CHANGELOG.md`` (prose content).
+
+    Any other modification (dependency bumps, script edits, CHANGELOG
+    deletions, etc.) disqualifies the file and the triage-skip layer falls
+    through to full review.
+    """
+    try:
+        proc = subprocess.run(
+            ["git", "diff", "--unified=0", f"{base}..HEAD", "--", path],
+            capture_output=True,
+            text=True,
+            check=False,
+            cwd=repo_root,
+        )
+    except OSError:
+        return False
+    if proc.returncode != 0 or not proc.stdout:
+        return False
+
+    base_name = path.rsplit("/", 1)[-1]
+    is_changelog = base_name == "CHANGELOG.md"
+    is_json = base_name.endswith(".json")
+    is_toml = base_name.endswith(".toml")
+
+    saw_change = False
+    for line in proc.stdout.splitlines():
+        if line.startswith(("+++", "---", "diff ", "index ", "@@", "Binary ")):
+            continue
+        if not (line.startswith("+") or line.startswith("-")):
+            continue
+        content = line[1:]
+        if not content.strip():
+            continue
+        saw_change = True
+        if is_changelog:
+            # CHANGELOG-only edits are safe when purely additive. Removals
+            # (history rewrites, entry deletions) warrant a full review.
+            if line.startswith("-"):
+                return False
+            continue
+        if is_json and _TRIAGE_VERSION_JSON_RE.match(content):
+            continue
+        if is_toml and _TRIAGE_VERSION_TOML_RE.match(content):
+            continue
+        return False
+    return saw_change
+
+
+def _triage_deterministic(
+    changed_files: list[str],
+    base: Optional[str] = None,
+    repo_root: Optional[str] = None,
+) -> tuple[Optional[str], str]:
     """Run the deterministic layer of triage.
 
     Returns ``(verdict_or_none, reason)``:
       - ``("SKIP", reason)`` — whitelist match, safe to skip
       - ``("REVIEW", reason)`` — hard override (code change, empty diff, etc.)
       - ``(None, reason)`` — ambiguous; caller may run LLM judge or default REVIEW
+
+    When ``chore``-classified files (manifests, CHANGELOG) are present, a
+    content-level check is required: callers must pass ``base`` + ``repo_root``
+    so the helper can inspect diff hunks. Without git context the chore path
+    falls through to ambiguous to prevent non-trivial ``package.json`` edits
+    from bypassing full review.
 
     ``reason`` is always a one-line human-readable string.
     """
@@ -8957,6 +9035,22 @@ def _triage_deterministic(changed_files: list[str]) -> tuple[Optional[str], str]
     # At this point every file is in {lockfile, docs, chore, generated}.
     kinds = set(buckets.keys())
 
+    # Chore-containing shapes require content verification before SKIP.
+    if "chore" in buckets:
+        if base is None or repo_root is None:
+            return (
+                None,
+                "manifest change (needs content verification — no git context)",
+            )
+        unverified = [
+            f
+            for f in buckets["chore"]
+            if not _triage_chore_is_version_only(f, base, repo_root)
+        ]
+        if unverified:
+            example = unverified[0]
+            return None, f"manifest edit beyond version field: {example}"
+
     if kinds == {"lockfile"}:
         if len(changed_files) == 1:
             return "SKIP", f"lockfile-only ({changed_files[0]})"
@@ -8973,24 +9067,17 @@ def _triage_deterministic(changed_files: list[str]) -> tuple[Optional[str], str]
         return "SKIP", f"generated-only ({len(changed_files)} files)"
 
     if kinds <= {"chore"}:
-        # pure manifest-only — allow (version bumps without CHANGELOG still count)
         return "SKIP", f"release-chore ({len(changed_files)} manifest files)"
 
     if kinds <= {"chore", "docs"}:
-        # Release chore with CHANGELOG + version bumps. Keep a tight cap so
-        # "one line of chore + a whole docs rewrite" doesn't silently slip.
         chore_files = buckets.get("chore", [])
         doc_files = buckets.get("docs", [])
-        # Only allow SKIP when the manifest file(s) look like version bumps —
-        # we trust the basename whitelist here and rely on the conservative
-        # default.
         return (
             "SKIP",
             f"release-chore ({len(chore_files)} manifest + {len(doc_files)} doc file(s))",
         )
 
     if kinds <= {"lockfile", "chore"}:
-        # dep update that also bumps package.json — common shape, safe.
         return (
             "SKIP",
             f"dep-update ({len(buckets.get('lockfile', []))} lock + "
@@ -9232,8 +9319,11 @@ def cmd_triage_skip(args: argparse.Namespace) -> None:
     except OSError:
         pass
 
-    # Deterministic layer.
-    det_verdict, det_reason = _triage_deterministic(changed_files)
+    # Deterministic layer. Pass git context so the chore-path content check
+    # can inspect diff hunks and reject non-trivial manifest edits.
+    det_verdict, det_reason = _triage_deterministic(
+        changed_files, base=base, repo_root=repo_root
+    )
 
     verdict: Optional[str] = det_verdict
     reason: str = det_reason

--- a/plugins/flow-next/scripts/flowctl.py
+++ b/plugins/flow-next/scripts/flowctl.py
@@ -8578,6 +8578,597 @@ def cmd_copilot_completion_review(args: argparse.Namespace) -> None:
         print(f"\nVERDICT={verdict or 'UNKNOWN'}")
 
 
+# --- Trivial-diff triage (fn-29.6) ---
+#
+# Fast pre-check before full impl-review: judges whether the diff is worth
+# a Carmack-level review. Saves rp/codex/copilot calls on lockfile-only /
+# release-chore / docs-only / generated-only commits. Conservative:
+# "when in doubt, REVIEW" — false SKIPs are strictly worse than false REVIEWs.
+#
+# Strategy (hybrid, deterministic-first):
+#   1. Deterministic REVIEW-override: any file that matches a code path
+#      (src/, flowctl.py, *.py/.ts/.js/.go/.rs/.sh/..., etc.) forces REVIEW
+#      without an LLM call. This is AC9.
+#   2. Deterministic SKIP whitelist: lockfile-only / docs-only / release-
+#      chore / generated-only diffs. Tight, narrow match — everything else
+#      falls through.
+#   3. Optional LLM judge (`--backend codex|copilot`) for ambiguous diffs.
+#      When tooling is unavailable, falls through to REVIEW (exit 1).
+#
+# Exit codes:
+#   0  SKIP (verdict=SHIP)
+#   1  proceed to full review (verdict not set by triage)
+#   2+ error (bad args, tooling unavailable when required, malformed output)
+
+TRIAGE_LOCKFILES: frozenset[str] = frozenset({
+    # Exact basenames only; matching is case-sensitive on basename.
+    "package-lock.json",
+    "bun.lock",
+    "bun.lockb",
+    "pnpm-lock.yaml",
+    "yarn.lock",
+    "Gemfile.lock",
+    "poetry.lock",
+    "Cargo.lock",
+    "uv.lock",
+    "composer.lock",
+    "mix.lock",
+    "go.sum",
+})
+
+TRIAGE_RELEASE_CHORE_BASENAMES: frozenset[str] = frozenset({
+    "plugin.json",
+    "package.json",
+    "Cargo.toml",
+    "pyproject.toml",
+    "CHANGELOG.md",
+})
+
+# Generated / vendored path prefixes. Matched against POSIX-normalized path
+# substrings. Keep this list tight — overly broad matches silently skip real
+# review work.
+TRIAGE_GENERATED_PREFIXES: tuple[str, ...] = (
+    "plugins/flow-next/codex/",
+    "node_modules/",
+    "vendor/",
+    "third_party/",
+    "dist/",
+    "build/",
+    ".next/",
+)
+
+# Extensions treated as executable code. A single match forces REVIEW.
+# Keep synchronized with common code files the reviewer actually needs to see.
+TRIAGE_CODE_EXTS: frozenset[str] = frozenset({
+    ".py",
+    ".pyi",
+    ".js",
+    ".jsx",
+    ".mjs",
+    ".cjs",
+    ".ts",
+    ".tsx",
+    ".go",
+    ".rs",
+    ".rb",
+    ".java",
+    ".kt",
+    ".scala",
+    ".swift",
+    ".cs",
+    ".c",
+    ".cc",
+    ".cpp",
+    ".cxx",
+    ".h",
+    ".hh",
+    ".hpp",
+    ".hxx",
+    ".sh",
+    ".bash",
+    ".zsh",
+    ".fish",
+    ".lua",
+    ".pl",
+    ".php",
+    ".ex",
+    ".exs",
+    ".erl",
+    ".elm",
+    ".clj",
+    ".sql",
+})
+
+# Docs-only extensions. A diff of only these (outside .flow/specs or
+# .flow/tasks — those are artifacts, not pure docs) may SKIP.
+TRIAGE_DOC_EXTS: frozenset[str] = frozenset({
+    ".md",
+    ".mdx",
+    ".txt",
+    ".rst",
+    ".adoc",
+})
+
+# Paths that are artifacts (not code, not docs). Changes here can be
+# semantically important (task status etc.) — conservative: treat as REVIEW
+# when present without other SKIP-category files.
+TRIAGE_ARTIFACT_PREFIXES: tuple[str, ...] = (
+    ".flow/specs/",
+    ".flow/tasks/",
+    ".flow/epics/",
+)
+
+
+def _classify_triage_path(path: str) -> str:
+    """Classify a changed file into one triage bucket.
+
+    Returns one of:
+      - ``code``      — forces REVIEW
+      - ``lockfile``  — SKIP candidate
+      - ``docs``      — SKIP candidate
+      - ``chore``     — release-chore SKIP candidate
+      - ``generated`` — SKIP candidate
+      - ``artifact``  — flow state spec/task (do not SKIP on these alone)
+      - ``other``     — unknown; forces REVIEW by fallthrough
+    """
+    # Normalize to POSIX for stable prefix matching even on Windows checkouts.
+    p = path.replace("\\", "/").strip()
+    if not p:
+        return "other"
+
+    # Generated / vendored wins over extension match — e.g. a .ts file under
+    # node_modules/ is still "generated" for our purposes.
+    for prefix in TRIAGE_GENERATED_PREFIXES:
+        if p.startswith(prefix) or f"/{prefix}" in f"/{p}":
+            return "generated"
+
+    base = p.rsplit("/", 1)[-1]
+    if base in TRIAGE_LOCKFILES:
+        return "lockfile"
+
+    # Artifacts (flow state) before release-chore — plugin.json inside
+    # .flow/epics/ isn't a chore.
+    for prefix in TRIAGE_ARTIFACT_PREFIXES:
+        if p.startswith(prefix):
+            return "artifact"
+
+    if base in TRIAGE_RELEASE_CHORE_BASENAMES:
+        return "chore"
+
+    # Extension-based classification. ``os.path.splitext`` handles multi-dot
+    # filenames (``foo.test.ts`` → ``.ts``).
+    ext = ""
+    dot = base.rfind(".")
+    if dot > 0:
+        ext = base[dot:].lower()
+
+    if ext in TRIAGE_CODE_EXTS:
+        return "code"
+    if ext in TRIAGE_DOC_EXTS:
+        return "docs"
+
+    return "other"
+
+
+def _triage_deterministic(changed_files: list[str]) -> tuple[Optional[str], str]:
+    """Run the deterministic layer of triage.
+
+    Returns ``(verdict_or_none, reason)``:
+      - ``("SKIP", reason)`` — whitelist match, safe to skip
+      - ``("REVIEW", reason)`` — hard override (code change, empty diff, etc.)
+      - ``(None, reason)`` — ambiguous; caller may run LLM judge or default REVIEW
+
+    ``reason`` is always a one-line human-readable string.
+    """
+    if not changed_files:
+        # No diff at all — nothing to review. Conservative: REVIEW so the
+        # caller sees this as an odd case (empty diff usually means bad base).
+        return "REVIEW", "no changed files (empty diff — refusing to skip)"
+
+    buckets: dict[str, list[str]] = {}
+    for f in changed_files:
+        kind = _classify_triage_path(f)
+        buckets.setdefault(kind, []).append(f)
+
+    # Any code file → REVIEW (AC9: src/, flowctl.py always reviewed).
+    if "code" in buckets:
+        example = buckets["code"][0]
+        return "REVIEW", f"code change detected: {example}"
+
+    # Any artifact file → REVIEW (flow state can carry semantic intent).
+    if "artifact" in buckets:
+        example = buckets["artifact"][0]
+        return "REVIEW", f"flow artifact change detected: {example}"
+
+    # Any unknown/other file → REVIEW (conservative fallthrough).
+    if "other" in buckets:
+        example = buckets["other"][0]
+        return "REVIEW", f"unclassified path: {example}"
+
+    # At this point every file is in {lockfile, docs, chore, generated}.
+    kinds = set(buckets.keys())
+
+    if kinds == {"lockfile"}:
+        if len(changed_files) == 1:
+            return "SKIP", f"lockfile-only ({changed_files[0]})"
+        return "SKIP", f"lockfile-only ({len(changed_files)} lock files)"
+
+    if kinds == {"docs"}:
+        if len(changed_files) == 1:
+            return "SKIP", f"docs-only ({changed_files[0]})"
+        return "SKIP", f"docs-only ({len(changed_files)} files)"
+
+    if kinds == {"generated"}:
+        if len(changed_files) == 1:
+            return "SKIP", f"generated-only ({changed_files[0]})"
+        return "SKIP", f"generated-only ({len(changed_files)} files)"
+
+    if kinds <= {"chore"}:
+        # pure manifest-only — allow (version bumps without CHANGELOG still count)
+        return "SKIP", f"release-chore ({len(changed_files)} manifest files)"
+
+    if kinds <= {"chore", "docs"}:
+        # Release chore with CHANGELOG + version bumps. Keep a tight cap so
+        # "one line of chore + a whole docs rewrite" doesn't silently slip.
+        chore_files = buckets.get("chore", [])
+        doc_files = buckets.get("docs", [])
+        # Only allow SKIP when the manifest file(s) look like version bumps —
+        # we trust the basename whitelist here and rely on the conservative
+        # default.
+        return (
+            "SKIP",
+            f"release-chore ({len(chore_files)} manifest + {len(doc_files)} doc file(s))",
+        )
+
+    if kinds <= {"lockfile", "chore"}:
+        # dep update that also bumps package.json — common shape, safe.
+        return (
+            "SKIP",
+            f"dep-update ({len(buckets.get('lockfile', []))} lock + "
+            f"{len(buckets.get('chore', []))} manifest file(s))",
+        )
+
+    if kinds <= {"lockfile", "generated"}:
+        return (
+            "SKIP",
+            f"lockfile+generated ({len(changed_files)} files)",
+        )
+
+    # Anything else — mixed or unknown combo — fall through to LLM / default REVIEW.
+    return None, f"mixed non-code categories: {sorted(kinds)}"
+
+
+def _triage_build_llm_prompt(
+    diff_stat: str, changed_files: list[str]
+) -> str:
+    """Build the one-shot triage prompt for fast-model judgment."""
+    # Cap the file list + stat to keep the prompt cheap.
+    files_preview = "\n".join(changed_files[:50])
+    if len(changed_files) > 50:
+        files_preview += f"\n... ({len(changed_files) - 50} more)"
+    stat = diff_stat.strip() or "(diff stat unavailable)"
+    return f"""Diff summary:
+{stat}
+
+Changed files:
+{files_preview}
+
+Is this diff worth a full code review?
+
+Answer SKIP only if the diff matches one of:
+- Lockfile-only bumps: package-lock.json, bun.lock, pnpm-lock.yaml, yarn.lock, Gemfile.lock, poetry.lock, Cargo.lock, uv.lock (and nothing else)
+- Pure release chore: version bump in plugin.json / package.json / Cargo.toml + CHANGELOG entry, no other code
+- Pure documentation: only *.md files changed, no executable code
+- Pure generated-file regeneration: plugins/flow-next/codex/ (from sync-codex.sh), or other clearly-generated paths
+- Pure vendored-asset changes: files under /vendor/, /third_party/, or similarly designated paths
+
+When in doubt, answer REVIEW. A missed review is worse than a skipped chore.
+
+Output exactly one line:
+SKIP: <one-line reason>
+or
+REVIEW: <one-line reason>
+"""
+
+
+def _triage_parse_llm_output(text: str) -> tuple[Optional[str], str]:
+    """Parse SKIP/REVIEW line from LLM output. Conservative on malformed."""
+    if not text:
+        return None, "empty LLM response"
+    # Prefer the last matching line so trailing reasoning doesn't win.
+    verdict: Optional[str] = None
+    reason: str = ""
+    for raw in text.splitlines():
+        line = raw.strip().lstrip(">*_ `").rstrip()
+        if not line:
+            continue
+        m = re.match(r"^(SKIP|REVIEW)\s*:\s*(.+?)\s*$", line, re.IGNORECASE)
+        if m:
+            verdict = m.group(1).upper()
+            reason = m.group(2).strip()
+    if verdict is None:
+        return None, "malformed LLM response (no SKIP:/REVIEW: line)"
+    return verdict, reason
+
+
+def _triage_run_codex_judge(
+    prompt: str, model: Optional[str], effort: Optional[str]
+) -> tuple[Optional[str], str, Optional[str]]:
+    """Invoke codex as the triage judge. Returns (verdict, reason, model_used).
+
+    verdict is ``SKIP`` / ``REVIEW`` / ``None`` (on tooling failure or malformed).
+    """
+    codex = shutil.which("codex")
+    if not codex:
+        return None, "codex CLI not available for triage", None
+    effective_model = model or "gpt-5-mini"
+    effective_effort = effort or "low"
+    cmd = [
+        codex,
+        "exec",
+        "--model",
+        effective_model,
+        "-c",
+        f'model_reasoning_effort="{effective_effort}"',
+        "--sandbox",
+        "read-only" if os.name != "nt" else "danger-full-access",
+        "--skip-git-repo-check",
+        "-",
+    ]
+    try:
+        result = subprocess.run(
+            cmd,
+            input=prompt,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=120,
+        )
+    except subprocess.TimeoutExpired:
+        return None, "codex triage timed out (120s)", effective_model
+    except OSError as e:
+        return None, f"codex triage OS error: {e}", effective_model
+    if result.returncode != 0:
+        msg = (result.stderr or "codex triage exited non-zero").strip().splitlines()[-1]
+        return None, f"codex triage failed: {msg}", effective_model
+    verdict, reason = _triage_parse_llm_output(result.stdout)
+    return verdict, reason, effective_model
+
+
+def _triage_run_copilot_judge(
+    prompt: str, model: Optional[str], effort: Optional[str]
+) -> tuple[Optional[str], str, Optional[str]]:
+    """Invoke copilot as the triage judge."""
+    copilot = shutil.which("copilot")
+    if not copilot:
+        return None, "copilot CLI not available for triage", None
+    effective_model = model or "claude-haiku-4.5"
+    effective_effort = effort or "low"
+    repo_root = get_repo_root()
+    cmd = [
+        copilot,
+        "-p",
+        prompt,
+        f"--resume={uuid.uuid4()}",
+        "--output-format",
+        "text",
+        "-s",
+        "--no-ask-user",
+        "--allow-all-tools",
+        "--add-dir",
+        str(repo_root),
+        "--disable-builtin-mcps",
+        "--no-custom-instructions",
+        "--log-level",
+        "error",
+        "--no-auto-update",
+        "--model",
+        effective_model,
+    ]
+    if not effective_model.startswith("claude-"):
+        cmd += ["--effort", effective_effort]
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=120,
+        )
+    except subprocess.TimeoutExpired:
+        return None, "copilot triage timed out (120s)", effective_model
+    except OSError as e:
+        return None, f"copilot triage OS error: {e}", effective_model
+    if result.returncode != 0:
+        msg = (result.stderr or "copilot triage exited non-zero").strip().splitlines()[-1]
+        return None, f"copilot triage failed: {msg}", effective_model
+    verdict, reason = _triage_parse_llm_output(result.stdout)
+    return verdict, reason, effective_model
+
+
+def cmd_triage_skip(args: argparse.Namespace) -> None:
+    """Trivial-diff triage pre-check.
+
+    Decides whether the diff between ``--base`` and HEAD is worth a full
+    Carmack-level review. Uses a deterministic whitelist first (lockfiles,
+    docs-only, generated, release-chore) and an optional LLM judge only for
+    ambiguous cases. When in doubt, falls through to exit 1 (proceed to
+    full review) — false SKIPs are strictly worse than false REVIEWs.
+
+    Exit codes:
+        0   SKIP (verdict=SHIP, receipt written if --receipt)
+        1   proceed to full review
+        2+  error (invalid arguments, malformed state)
+    """
+    base = args.base or "main"
+    # Resolve 'main' vs 'master' when caller didn't specify --base.
+    if not args.base:
+        repo_root = get_repo_root()
+        try:
+            subprocess.run(
+                ["git", "rev-parse", "--verify", "main"],
+                capture_output=True,
+                check=True,
+                cwd=repo_root,
+            )
+        except (subprocess.CalledProcessError, OSError):
+            try:
+                subprocess.run(
+                    ["git", "rev-parse", "--verify", "master"],
+                    capture_output=True,
+                    check=True,
+                    cwd=repo_root,
+                )
+                base = "master"
+            except (subprocess.CalledProcessError, OSError):
+                # Leave base="main"; git diff will fail below and we'll surface
+                # that as an error exit.
+                pass
+
+    repo_root = get_repo_root()
+    # Gather changed file list.
+    try:
+        proc = subprocess.run(
+            ["git", "diff", "--name-only", f"{base}..HEAD"],
+            capture_output=True,
+            text=True,
+            check=False,
+            cwd=repo_root,
+        )
+    except OSError as e:
+        error_exit(f"git diff failed: {e}", use_json=args.json, code=2)
+    if proc.returncode != 0:
+        stderr = (proc.stderr or "").strip()
+        error_exit(
+            f"git diff --name-only {base}..HEAD failed: {stderr}",
+            use_json=args.json,
+            code=2,
+        )
+    changed_files = [
+        line.strip() for line in proc.stdout.splitlines() if line.strip()
+    ]
+
+    # Gather --stat for the LLM prompt (best-effort).
+    diff_stat = ""
+    try:
+        stat_proc = subprocess.run(
+            ["git", "diff", "--stat", f"{base}..HEAD"],
+            capture_output=True,
+            text=True,
+            check=False,
+            cwd=repo_root,
+        )
+        if stat_proc.returncode == 0:
+            diff_stat = stat_proc.stdout.strip()
+    except OSError:
+        pass
+
+    # Deterministic layer.
+    det_verdict, det_reason = _triage_deterministic(changed_files)
+
+    verdict: Optional[str] = det_verdict
+    reason: str = det_reason
+    model_used: Optional[str] = None
+    judge_source = "deterministic"
+
+    # Optional LLM judge for ambiguous cases. ``--no-llm`` skips the call and
+    # defaults to REVIEW so tests / offline runs remain deterministic.
+    if det_verdict is None and not args.no_llm:
+        backend = (args.backend or "codex").strip().lower()
+        if backend == "codex":
+            v, r, m = _triage_run_codex_judge(
+                _triage_build_llm_prompt(diff_stat, changed_files),
+                args.model,
+                args.effort,
+            )
+        elif backend == "copilot":
+            v, r, m = _triage_run_copilot_judge(
+                _triage_build_llm_prompt(diff_stat, changed_files),
+                args.model,
+                args.effort,
+            )
+        else:
+            error_exit(
+                f"Unknown triage backend: {backend!r}. Valid: codex, copilot",
+                use_json=args.json,
+                code=2,
+            )
+        model_used = m
+        judge_source = f"{backend}-judge"
+        if v is None:
+            # Judge failed or malformed — conservative fallthrough to REVIEW.
+            verdict = "REVIEW"
+            reason = f"{r} (defaulting to REVIEW)"
+        else:
+            verdict = v
+            reason = r
+    elif det_verdict is None:
+        # No LLM path and deterministic was ambiguous → REVIEW (conservative).
+        verdict = "REVIEW"
+        reason = f"{det_reason} (no LLM, defaulting to REVIEW)"
+
+    # Write receipt on SKIP (only when requested). REVIEW path leaves receipt
+    # untouched so the downstream impl-review can write its own receipt.
+    receipt_written: Optional[str] = None
+    if verdict == "SKIP" and args.receipt:
+        receipt_data = {
+            "type": "impl_review",
+            "id": args.task or "branch",
+            "mode": "triage_skip",
+            "base": base,
+            "verdict": "SHIP",
+            "reason": reason,
+            "source": judge_source,
+            "changed_file_count": len(changed_files),
+            "timestamp": now_iso(),
+        }
+        if model_used:
+            receipt_data["model"] = model_used
+        ralph_iter = os.environ.get("RALPH_ITERATION")
+        if ralph_iter:
+            try:
+                receipt_data["iteration"] = int(ralph_iter)
+            except ValueError:
+                pass
+        try:
+            Path(args.receipt).parent.mkdir(parents=True, exist_ok=True)
+            Path(args.receipt).write_text(
+                json.dumps(receipt_data, indent=2) + "\n", encoding="utf-8"
+            )
+            receipt_written = args.receipt
+        except OSError as e:
+            error_exit(
+                f"failed to write receipt {args.receipt}: {e}",
+                use_json=args.json,
+                code=2,
+            )
+
+    # Output + exit.
+    if args.json:
+        payload = {
+            "verdict": "SHIP" if verdict == "SKIP" else "REVIEW",
+            "mode": "triage_skip" if verdict == "SKIP" else "triage_review",
+            "reason": reason,
+            "source": judge_source,
+            "base": base,
+            "changed_file_count": len(changed_files),
+        }
+        if model_used:
+            payload["model"] = model_used
+        if receipt_written:
+            payload["receipt"] = receipt_written
+        json_output(payload)
+    else:
+        if verdict == "SKIP":
+            print(f"SKIP: {reason}")
+            if receipt_written:
+                print(f"REVIEW_RECEIPT_WRITTEN: {receipt_written}")
+        else:
+            print(f"REVIEW: {reason}")
+
+    sys.exit(0 if verdict == "SKIP" else 1)
+
+
 # --- Checkpoint commands ---
 
 
@@ -9321,6 +9912,43 @@ def main() -> None:
     )
     p_validate.add_argument("--json", action="store_true", help="JSON output")
     p_validate.set_defaults(func=cmd_validate)
+
+    # triage-skip (fn-29.6)
+    p_triage = subparsers.add_parser(
+        "triage-skip",
+        help="Trivial-diff triage pre-check (exit 0=SKIP, 1=REVIEW, 2+=error)",
+    )
+    p_triage.add_argument(
+        "--base", help="Base ref to diff against (default: main, fallback master)"
+    )
+    p_triage.add_argument(
+        "--task", help="Task ID for receipt id field (default: 'branch')"
+    )
+    p_triage.add_argument(
+        "--backend",
+        choices=["codex", "copilot"],
+        default="codex",
+        help="LLM judge backend for ambiguous diffs (default: codex)",
+    )
+    p_triage.add_argument(
+        "--model",
+        help="Fast model override (default: gpt-5-mini for codex, claude-haiku-4.5 for copilot)",
+    )
+    p_triage.add_argument(
+        "--effort",
+        help="Reasoning effort for LLM judge (default: low)",
+    )
+    p_triage.add_argument(
+        "--receipt",
+        help="Path to write triage-skip receipt (only on SKIP verdict)",
+    )
+    p_triage.add_argument(
+        "--no-llm",
+        action="store_true",
+        help="Skip LLM judge; rely on deterministic whitelist only (ambiguous → REVIEW)",
+    )
+    p_triage.add_argument("--json", action="store_true", help="JSON output")
+    p_triage.set_defaults(func=cmd_triage_skip)
 
     # checkpoint
     p_checkpoint = subparsers.add_parser("checkpoint", help="Checkpoint commands")

--- a/plugins/flow-next/scripts/smoke_test.sh
+++ b/plugins/flow-next/scripts/smoke_test.sh
@@ -757,6 +757,128 @@ PY
 echo -e "${GREEN}✓${NC} parse_classification_counts handles summary + per-finding fallback"
 PASS=$((PASS + 1))
 
+echo -e "${YELLOW}--- triage-skip classifier (fn-29.6) ---${NC}"
+"$PYTHON_BIN" - "$SCRIPT_DIR" <<'PY'
+import sys
+sys.path.insert(0, sys.argv[1])
+from flowctl import _classify_triage_path, _triage_deterministic, _triage_parse_llm_output
+
+# Path classification
+assert _classify_triage_path("bun.lock") == "lockfile"
+assert _classify_triage_path("package-lock.json") == "lockfile"
+assert _classify_triage_path("Cargo.lock") == "lockfile"
+assert _classify_triage_path("src/main.py") == "code"
+assert _classify_triage_path("plugins/flow-next/scripts/flowctl.py") == "code"
+assert _classify_triage_path("README.md") == "docs"
+assert _classify_triage_path("docs/guide.md") == "docs"
+assert _classify_triage_path("plugins/flow-next/codex/hooks.json") == "generated"
+assert _classify_triage_path("node_modules/pkg/index.js") == "generated"
+assert _classify_triage_path("vendor/lib.go") == "generated"
+assert _classify_triage_path("plugin/plugin.json") == "chore"
+assert _classify_triage_path("CHANGELOG.md") == "chore"
+assert _classify_triage_path("pyproject.toml") == "chore"
+assert _classify_triage_path(".flow/specs/fn-1.md") == "artifact"
+assert _classify_triage_path(".flow/tasks/fn-1.1.md") == "artifact"
+assert _classify_triage_path("random.xyz") == "other"
+
+# AC6: lockfile-only → SKIP
+v, r = _triage_deterministic(["bun.lock"])
+assert v == "SKIP" and "lockfile" in r.lower(), (v, r)
+
+# AC7: version bump + CHANGELOG → SKIP
+v, r = _triage_deterministic(["plugin/plugin.json", "CHANGELOG.md"])
+assert v == "SKIP", (v, r)
+
+# AC8: docs-only → SKIP
+v, r = _triage_deterministic(["README.md", "docs/guide.md"])
+assert v == "SKIP" and "docs" in r.lower(), (v, r)
+
+# AC9: any code → REVIEW (even alone)
+v, r = _triage_deterministic(["plugins/flow-next/scripts/flowctl.py"])
+assert v == "REVIEW", (v, r)
+v, r = _triage_deterministic(["src/main.ts", "README.md"])
+assert v == "REVIEW", (v, r)
+
+# Empty diff → REVIEW (conservative)
+v, r = _triage_deterministic([])
+assert v == "REVIEW", (v, r)
+
+# Generated-only → SKIP
+v, r = _triage_deterministic(["plugins/flow-next/codex/skills/x.md", "plugins/flow-next/codex/hooks.json"])
+assert v == "SKIP", (v, r)
+
+# Artifact alone → REVIEW (conservative — flow state carries intent)
+v, r = _triage_deterministic([".flow/specs/fn-29.md"])
+assert v == "REVIEW", (v, r)
+
+# Lockfile + manifest combo → SKIP
+v, r = _triage_deterministic(["bun.lock", "package.json"])
+assert v == "SKIP", (v, r)
+
+# Lockfile + generated → SKIP
+v, r = _triage_deterministic(["bun.lock", "node_modules/x.js"])
+assert v == "SKIP", (v, r)
+
+# LLM output parser
+v, r = _triage_parse_llm_output("SKIP: lockfile only")
+assert v == "SKIP" and r == "lockfile only"
+v, r = _triage_parse_llm_output("REVIEW: touches auth logic")
+assert v == "REVIEW"
+v, r = _triage_parse_llm_output("> **SKIP: docs only**")
+assert v == "SKIP"
+v, r = _triage_parse_llm_output("reasoning blah\nSKIP: trivial")
+assert v == "SKIP" and r == "trivial"
+v, r = _triage_parse_llm_output("no verdict here")
+assert v is None
+v, r = _triage_parse_llm_output("")
+assert v is None
+PY
+echo -e "${GREEN}✓${NC} triage-skip classifier + deterministic layer + LLM parser"
+PASS=$((PASS + 1))
+
+echo -e "${YELLOW}--- triage-skip e2e (fn-29.6) ---${NC}"
+# End-to-end: tiny git repo, three scenarios (SKIP, REVIEW, receipt).
+TRIAGE_TEST_DIR="$TEST_DIR/triage-e2e"
+rm -rf "$TRIAGE_TEST_DIR"
+mkdir -p "$TRIAGE_TEST_DIR"
+(
+  cd "$TRIAGE_TEST_DIR"
+  git init -q
+  git config user.email test@test.com
+  git config user.name test
+  echo "base" > base.txt
+  git add base.txt
+  git commit -qm init
+  git checkout -qb feature
+
+  # AC6: lockfile-only → SKIP exit 0, receipt written
+  echo "{}" > bun.lock
+  git add bun.lock
+  git commit -qm "dep bump"
+  RECEIPT="$TRIAGE_TEST_DIR/r1.json"
+  "$PYTHON_BIN" "$SCRIPT_DIR/flowctl.py" triage-skip --base main --no-llm --receipt "$RECEIPT" --task fn-9-test.1 --json > "$TRIAGE_TEST_DIR/out1.json"
+  EXIT1=$?
+  [ "$EXIT1" = "0" ] || { echo "FAIL: expected exit 0 on lockfile SKIP, got $EXIT1"; exit 1; }
+  grep -q '"mode": "triage_skip"' "$RECEIPT" || { echo "FAIL: receipt missing triage_skip mode"; cat "$RECEIPT"; exit 1; }
+  grep -q '"verdict": "SHIP"' "$RECEIPT" || { echo "FAIL: receipt missing SHIP verdict"; cat "$RECEIPT"; exit 1; }
+  grep -q '"id": "fn-9-test.1"' "$RECEIPT" || { echo "FAIL: receipt missing task id"; cat "$RECEIPT"; exit 1; }
+
+  # AC9: add code → REVIEW exit 1, no receipt overwrite
+  echo "print('x')" > script.py
+  git add script.py
+  git commit -qm "add script"
+  RECEIPT2="$TRIAGE_TEST_DIR/r2.json"
+  set +e
+  "$PYTHON_BIN" "$SCRIPT_DIR/flowctl.py" triage-skip --base main --no-llm --receipt "$RECEIPT2" --json > "$TRIAGE_TEST_DIR/out2.json"
+  EXIT2=$?
+  set -e
+  [ "$EXIT2" = "1" ] || { echo "FAIL: expected exit 1 on code REVIEW, got $EXIT2"; exit 1; }
+  [ ! -f "$RECEIPT2" ] || { echo "FAIL: receipt should not exist on REVIEW"; exit 1; }
+  grep -q '"verdict": "REVIEW"' "$TRIAGE_TEST_DIR/out2.json" || { echo "FAIL: REVIEW verdict missing from json"; cat "$TRIAGE_TEST_DIR/out2.json"; exit 1; }
+)
+echo -e "${GREEN}✓${NC} triage-skip e2e: lockfile→SKIP+receipt, code→REVIEW+no-receipt"
+PASS=$((PASS + 1))
+
 echo -e "${YELLOW}--- parse_receipt_path ---${NC}"
 # Test receipt path parsing for Ralph gating (both legacy and new fn-N-xxx formats)
 "$PYTHON_BIN" - "$SCRIPT_DIR/hooks" <<'PY'

--- a/plugins/flow-next/scripts/smoke_test.sh
+++ b/plugins/flow-next/scripts/smoke_test.sh
@@ -780,14 +780,24 @@ assert _classify_triage_path("pyproject.toml") == "chore"
 assert _classify_triage_path(".flow/specs/fn-1.md") == "artifact"
 assert _classify_triage_path(".flow/tasks/fn-1.1.md") == "artifact"
 assert _classify_triage_path("random.xyz") == "other"
+# Generated-prefix must only match repo-root, not substring anywhere
+# (e.g. scripts/build/release.sh must stay as code, not "generated").
+assert _classify_triage_path("scripts/build/release.sh") == "code"
+assert _classify_triage_path("packages/dist/util.ts") == "code"
+assert _classify_triage_path("vendor_notes/README.md") == "docs"
 
 # AC6: lockfile-only → SKIP
 v, r = _triage_deterministic(["bun.lock"])
 assert v == "SKIP" and "lockfile" in r.lower(), (v, r)
 
-# AC7: version bump + CHANGELOG → SKIP
+# AC7: chore-containing shapes require git context — without it, ambiguous.
+# This prevents package.json dep edits from silently bypassing full review.
 v, r = _triage_deterministic(["plugin/plugin.json", "CHANGELOG.md"])
-assert v == "SKIP", (v, r)
+assert v is None, (v, r)
+v, r = _triage_deterministic(["package.json"])
+assert v is None, (v, r)
+v, r = _triage_deterministic(["bun.lock", "package.json"])
+assert v is None, (v, r)
 
 # AC8: docs-only → SKIP
 v, r = _triage_deterministic(["README.md", "docs/guide.md"])
@@ -811,11 +821,7 @@ assert v == "SKIP", (v, r)
 v, r = _triage_deterministic([".flow/specs/fn-29.md"])
 assert v == "REVIEW", (v, r)
 
-# Lockfile + manifest combo → SKIP
-v, r = _triage_deterministic(["bun.lock", "package.json"])
-assert v == "SKIP", (v, r)
-
-# Lockfile + generated → SKIP
+# Lockfile + generated → SKIP (no chore, no content check needed)
 v, r = _triage_deterministic(["bun.lock", "node_modules/x.js"])
 assert v == "SKIP", (v, r)
 
@@ -877,6 +883,63 @@ mkdir -p "$TRIAGE_TEST_DIR"
   grep -q '"verdict": "REVIEW"' "$TRIAGE_TEST_DIR/out2.json" || { echo "FAIL: REVIEW verdict missing from json"; cat "$TRIAGE_TEST_DIR/out2.json"; exit 1; }
 )
 echo -e "${GREEN}✓${NC} triage-skip e2e: lockfile→SKIP+receipt, code→REVIEW+no-receipt"
+PASS=$((PASS + 1))
+
+echo -e "${YELLOW}--- triage-skip chore content verification (fn-29.6 fix) ---${NC}"
+# Chore classification (package.json etc.) must verify diff content — version
+# bumps SKIP, dependency/script edits fall through to REVIEW.
+CHORE_TEST_DIR="$TEST_DIR/triage-chore"
+rm -rf "$CHORE_TEST_DIR"
+mkdir -p "$CHORE_TEST_DIR"
+(
+  cd "$CHORE_TEST_DIR"
+  git init -q
+  git config user.email test@test.com
+  git config user.name test
+  printf '{\n  "name": "pkg",\n  "version": "0.1.0"\n}\n' > package.json
+  printf '# Changelog\n' > CHANGELOG.md
+  git add package.json CHANGELOG.md
+  git commit -qm init
+  git checkout -qb feature
+
+  # Scenario A: pure version bump + CHANGELOG addition → SKIP
+  printf '{\n  "name": "pkg",\n  "version": "0.1.1"\n}\n' > package.json
+  printf '# Changelog\n\n## [0.1.1]\n- bump\n' > CHANGELOG.md
+  git add -A
+  git commit -qm "bump"
+  set +e
+  "$PYTHON_BIN" "$SCRIPT_DIR/flowctl.py" triage-skip --base main --no-llm --json > "$CHORE_TEST_DIR/outA.json"
+  EXITA=$?
+  set -e
+  [ "$EXITA" = "0" ] || { echo "FAIL: version bump should SKIP (exit 0), got $EXITA"; cat "$CHORE_TEST_DIR/outA.json"; exit 1; }
+  grep -q '"verdict": "SHIP"' "$CHORE_TEST_DIR/outA.json" || { echo "FAIL: expected SHIP on version bump"; cat "$CHORE_TEST_DIR/outA.json"; exit 1; }
+
+  # Scenario B: dependency edit in package.json → must REVIEW
+  git reset --hard main -q
+  git checkout -qb feature-deps
+  printf '{\n  "name": "pkg",\n  "version": "0.1.0",\n  "dependencies": {\n    "lodash": "^4.0.0"\n  }\n}\n' > package.json
+  git add package.json
+  git commit -qm "add dep"
+  set +e
+  "$PYTHON_BIN" "$SCRIPT_DIR/flowctl.py" triage-skip --base main --no-llm --json > "$CHORE_TEST_DIR/outB.json"
+  EXITB=$?
+  set -e
+  [ "$EXITB" = "1" ] || { echo "FAIL: dep edit must REVIEW (exit 1), got $EXITB"; cat "$CHORE_TEST_DIR/outB.json"; exit 1; }
+  grep -q '"verdict": "REVIEW"' "$CHORE_TEST_DIR/outB.json" || { echo "FAIL: expected REVIEW on dep edit"; cat "$CHORE_TEST_DIR/outB.json"; exit 1; }
+
+  # Scenario C: CHANGELOG-only addition → SKIP
+  git reset --hard main -q
+  git checkout -qb feature-changelog
+  printf '# Changelog\n\n## [0.1.1]\n- note\n' > CHANGELOG.md
+  git add CHANGELOG.md
+  git commit -qm "changelog"
+  set +e
+  "$PYTHON_BIN" "$SCRIPT_DIR/flowctl.py" triage-skip --base main --no-llm --json > "$CHORE_TEST_DIR/outC.json"
+  EXITC=$?
+  set -e
+  [ "$EXITC" = "0" ] || { echo "FAIL: CHANGELOG-only should SKIP (exit 0), got $EXITC"; cat "$CHORE_TEST_DIR/outC.json"; exit 1; }
+)
+echo -e "${GREEN}✓${NC} triage-skip chore verify: version→SKIP, deps→REVIEW, CHANGELOG→SKIP"
 PASS=$((PASS + 1))
 
 echo -e "${YELLOW}--- parse_receipt_path ---${NC}"

--- a/plugins/flow-next/scripts/smoke_test.sh
+++ b/plugins/flow-next/scripts/smoke_test.sh
@@ -665,6 +665,17 @@ assert "Confidence calibration" in impl_prompt
 assert "Suppression gate" in impl_prompt
 assert "0 / 25 / 50 / 75 / 100" in impl_prompt
 assert "Suppressed findings" in impl_prompt
+
+# fn-29.4: introduced vs pre_existing classification baked into impl prompt
+assert "Introduced vs pre-existing classification" in impl_prompt
+assert "introduced" in impl_prompt
+assert "pre_existing" in impl_prompt
+assert "Pre-existing issues (not blocking this verdict)" in impl_prompt
+assert "Classification counts" in impl_prompt
+assert "Verdict gate" in impl_prompt
+
+# fn-29.4: plan review does NOT need classification (plans don't have diffs to classify against)
+assert "Introduced vs pre-existing classification" not in plan_prompt
 PY
 echo -e "${GREEN}✓${NC} build_review_prompt has full criteria"
 PASS=$((PASS + 1))
@@ -699,6 +710,51 @@ r = parse_suppressed_count("Suppressed findings: 5 at anchor 100, 2 at anchor 75
 assert r == {"100": 5, "75": 2}, r
 PY
 echo -e "${GREEN}✓${NC} parse_suppressed_count handles canonical + edge cases"
+PASS=$((PASS + 1))
+
+echo -e "${YELLOW}--- parse_classification_counts (fn-29.4) ---${NC}"
+"$PYTHON_BIN" - "$SCRIPT_DIR" <<'PY'
+import sys
+sys.path.insert(0, sys.argv[1])
+from flowctl import parse_classification_counts
+
+# Canonical summary line
+r = parse_classification_counts("blah\nClassification counts: 2 introduced, 4 pre_existing.\n")
+assert r == {"introduced": 2, "pre_existing": 4}, r
+
+# Blockquote prefix + reversed order
+r = parse_classification_counts("> Classification counts: 3 pre_existing, 1 introduced")
+assert r == {"introduced": 1, "pre_existing": 3}, r
+
+# Bold markdown wrappers
+r = parse_classification_counts("**Classification counts:** 0 introduced, 5 pre-existing.")
+assert r == {"introduced": 0, "pre_existing": 5}, r
+
+# Summary with only one bucket → missing bucket defaults to 0
+r = parse_classification_counts("Classification counts: 3 introduced.")
+assert r == {"introduced": 3, "pre_existing": 0}, r
+
+# Fallback: count per-finding Classification: lines when no summary
+body = """Some review
+**Classification**: introduced
+blah
+Classification: pre_existing
+more
+**Classification:** introduced
+"""
+r = parse_classification_counts(body)
+assert r == {"introduced": 2, "pre_existing": 1}, r
+
+# Fallback: inline introduced=true/false markers
+body = "[P1, confidence 75, introduced=false] foo\n[P0, confidence 100, introduced=true] bar"
+r = parse_classification_counts(body)
+assert r == {"introduced": 1, "pre_existing": 1}, r
+
+# Empty → None
+assert parse_classification_counts("no classification anywhere") is None
+assert parse_classification_counts("") is None
+PY
+echo -e "${GREEN}✓${NC} parse_classification_counts handles summary + per-finding fallback"
 PASS=$((PASS + 1))
 
 echo -e "${YELLOW}--- parse_receipt_path ---${NC}"

--- a/plugins/flow-next/scripts/smoke_test.sh
+++ b/plugins/flow-next/scripts/smoke_test.sh
@@ -659,8 +659,46 @@ assert "<diff_summary>" in impl_prompt
 assert "Test diff" in impl_prompt
 assert "<spec>" in impl_prompt
 assert "Test spec" in impl_prompt
+
+# fn-29.3: confidence rubric + suppression gate baked into impl prompt
+assert "Confidence calibration" in impl_prompt
+assert "Suppression gate" in impl_prompt
+assert "0 / 25 / 50 / 75 / 100" in impl_prompt
+assert "Suppressed findings" in impl_prompt
 PY
 echo -e "${GREEN}✓${NC} build_review_prompt has full criteria"
+PASS=$((PASS + 1))
+
+echo -e "${YELLOW}--- parse_suppressed_count (fn-29.3) ---${NC}"
+"$PYTHON_BIN" - "$SCRIPT_DIR" <<'PY'
+import sys
+sys.path.insert(0, sys.argv[1])
+from flowctl import parse_suppressed_count
+
+# Canonical line
+r = parse_suppressed_count("blah\nSuppressed findings: 3 at anchor 50, 7 at anchor 25, 2 at anchor 0.\n")
+assert r == {"50": 3, "25": 7, "0": 2}, r
+
+# Blockquote + partial anchors
+r = parse_suppressed_count("> Suppressed findings: 1 at anchor 50, 5 at anchor 25")
+assert r == {"50": 1, "25": 5}, r
+
+# Bold markdown wrappers
+r = parse_suppressed_count("**Suppressed findings:** 2 at anchor 25, 1 at anchor 0.")
+assert r == {"25": 2, "0": 1}, r
+
+# Empty / none payload → None
+assert parse_suppressed_count("Suppressed findings: none.") is None
+assert parse_suppressed_count("no suppression line here") is None
+
+# Invalid anchors are rejected (e.g. 42 is not one of {0,25,50,75,100})
+assert parse_suppressed_count("Suppressed findings: 3 at anchor 42") is None
+
+# High anchors still recognized
+r = parse_suppressed_count("Suppressed findings: 5 at anchor 100, 2 at anchor 75")
+assert r == {"100": 5, "75": 2}, r
+PY
+echo -e "${GREEN}✓${NC} parse_suppressed_count handles canonical + edge cases"
 PASS=$((PASS + 1))
 
 echo -e "${YELLOW}--- parse_receipt_path ---${NC}"

--- a/plugins/flow-next/skills/flow-next-epic-review/workflow.md
+++ b/plugins/flow-next/skills/flow-next-epic-review/workflow.md
@@ -298,6 +298,46 @@ Report untraced changes but don't auto-reject. UNDOCUMENTED_ADDITION is a flag f
 - Performance (impl-review covers this)
 - Legitimate refactoring needed to implement requirements (flag as LEGITIMATE_SUPPORT but don't block)
 
+## Requirements coverage (if epic spec has R-IDs)
+
+If the epic spec numbers its acceptance criteria like `- **R1:** ...`, `- **R2:** ...`,
+produce a per-R-ID coverage table. Read the epic spec's `## Acceptance` section
+(or the legacy `## Acceptance criteria` heading — reviewer MUST tolerate both).
+If no R-IDs are present, skip this block entirely — Phase 2 and Phase 3 above
+still apply.
+
+This forward coverage (spec → code) is **additive to Phase 3 reverse coverage
+(code → spec)**. Both phases feed the final verdict.
+
+For each R-ID, classify status:
+
+| Status | Meaning |
+|--------|---------|
+| met | Implementation delivers the requirement with appropriate tests/evidence |
+| partial | Implementation advances the requirement but leaves gaps |
+| not-addressed | Implementation does not advance this requirement at all |
+| deferred | Spec explicitly defers this requirement to a later epic/PR |
+
+Report as a markdown table in the review output:
+
+| R-ID | Status | Evidence |
+|------|--------|----------|
+| R1 | met | src/auth.ts:42 + tests/auth.test.ts:17 |
+| R2 | partial | implementation exists but no error-path tests |
+| R3 | not-addressed | — |
+
+After the table, emit one line listing every `not-addressed` R-ID that is NOT
+explicitly deferred in the spec:
+
+> Unaddressed R-IDs: [R3, R5]
+
+If there are zero unaddressed R-IDs, emit `Unaddressed R-IDs: []` or omit the
+line entirely. Deferred R-IDs are never listed here.
+
+**Verdict gate:** any `not-addressed` R-ID that is NOT marked `deferred` in the
+spec MUST flip the verdict to `NEEDS_WORK`, regardless of reverse-coverage
+findings.
+
 ## Confidence calibration
 
 Rate each gap on exactly one of these 5 discrete anchors. Do not use interpolated values (no 33, 80, 90).
@@ -384,6 +424,7 @@ For each untraced change:
 (Note: the reverse-coverage `Classification` uses untraced-change labels, distinct from the `introduced` / `pre_existing` per-gap classification above.)
 
 After the findings list, emit:
+- The `## Requirements coverage` table and `Unaddressed R-IDs:` line (only when the epic spec uses R-IDs; otherwise skip).
 - A `Suppressed findings:` line tallying anchors dropped by the gate (omit when nothing was suppressed).
 - A `Classification counts:` line tallying `introduced` vs `pre_existing` gaps, e.g. `Classification counts: 1 introduced, 0 pre_existing.`.
 - A `Protected-path filter:` line tallying gaps dropped by the protected-path filter (omit when nothing was dropped).
@@ -391,8 +432,8 @@ After the findings list, emit:
 **REQUIRED**: You MUST end your response with exactly one verdict tag. This is mandatory:
 `<verdict>SHIP</verdict>` or `<verdict>NEEDS_WORK</verdict>`
 
-- SHIP: All `introduced` spec requirements are implemented (pre-existing gaps do not block)
-- NEEDS_WORK: One or more `introduced` requirements are missing, partial, or wrong
+- SHIP: All `introduced` spec requirements are implemented and every R-ID is `met` or `deferred` (pre-existing gaps do not block)
+- NEEDS_WORK: One or more `introduced` requirements are missing, partial, or wrong — or any non-deferred R-ID is `not-addressed`
 
 Do NOT skip this tag. The automation depends on it.
 EOF
@@ -482,12 +523,41 @@ if [[ -n "${REVIEW_RECEIPT_PATH:-}" ]]; then
     fi
   fi
 
+  # Optional: capture unaddressed R-IDs (fn-29.2).
+  # Reviewer emits `Unaddressed R-IDs: [R3, R5]` (or `[]` / `none` for empty).
+  # Absent line => epic spec has no R-IDs — leave field off the receipt entirely.
+  UNADDRESSED_JSON=""
+  UNADDRESSED_LINE="$(printf '%s' "$REVIEW_RESPONSE" \
+    | grep -iE '^[>*_` ]*unaddressed([[:space:]]+r[-_ ]?ids?)?[ *_`]*:' \
+    | head -n 1 \
+    | sed -E 's/^[^:]+:[[:space:]]*//; s/[[:space:]]*$//; s/\.$//')"
+  if [[ -n "$UNADDRESSED_LINE" ]]; then
+    normalized="$(printf '%s' "$UNADDRESSED_LINE" | sed -E 's/^[[:space:]]*\[|\][[:space:]]*$//g; s/[[:space:]]+//g')"
+    lower="$(printf '%s' "$normalized" | tr '[:upper:]' '[:lower:]')"
+    if [[ "$lower" == "none" || "$lower" == "n/a" || -z "$lower" ]]; then
+      UNADDRESSED_JSON="[]"
+    else
+      rids="$(printf '%s' "$UNADDRESSED_LINE" \
+        | grep -oE '\bR[0-9]+\b' \
+        | awk '!seen[$0]++')"
+      if [[ -z "$rids" ]]; then
+        UNADDRESSED_JSON="[]"
+      else
+        UNADDRESSED_JSON="$(printf '%s' "$rids" \
+          | awk 'BEGIN{printf "["} {printf (NR>1?",":"") "\"" $0 "\""} END{printf "]"}')"
+      fi
+    fi
+  fi
+
   EXTRA_FIELDS=""
   if [[ -n "$SUPPRESSED_JSON" && "$SUPPRESSED_JSON" != "{}" ]]; then
     EXTRA_FIELDS+=",\"suppressed_count\":$SUPPRESSED_JSON"
   fi
   if [[ -n "$INTRODUCED_COUNT" && -n "$PRE_EXISTING_COUNT" ]]; then
     EXTRA_FIELDS+=",\"introduced_count\":$INTRODUCED_COUNT,\"pre_existing_count\":$PRE_EXISTING_COUNT"
+  fi
+  if [[ -n "$UNADDRESSED_JSON" ]]; then
+    EXTRA_FIELDS+=",\"unaddressed\":$UNADDRESSED_JSON"
   fi
 
   cat > "$REVIEW_RECEIPT_PATH" <<EOF

--- a/plugins/flow-next/skills/flow-next-epic-review/workflow.md
+++ b/plugins/flow-next/skills/flow-next-epic-review/workflow.md
@@ -298,12 +298,36 @@ Report untraced changes but don't auto-reject. UNDOCUMENTED_ADDITION is a flag f
 - Performance (impl-review covers this)
 - Legitimate refactoring needed to implement requirements (flag as LEGITIMATE_SUPPORT but don't block)
 
+## Confidence calibration
+
+Rate each gap on exactly one of these 5 discrete anchors. Do not use interpolated values (no 33, 80, 90).
+
+| Anchor | Meaning |
+|--------|---------|
+| 100 | Verifiable from the code alone, zero interpretation. A definitive logic error (off-by-one in a tested algorithm, wrong return type, swapped arguments, clear type error). The bug is mechanical. |
+| 75 | Full execution path traced: "input X enters here, takes this branch, reaches line Z, produces wrong result." Reproducible from the code alone. A normal caller will hit it. |
+| 50 | Depends on conditions visible but not fully confirmable from this diff — e.g., whether a value can actually be null depends on callers not in the diff. Surfaces only as P0-escape or via soft-bucket routing. |
+| 25 | Requires runtime conditions with no direct evidence — specific timing, specific input shapes, specific external state. |
+| 0 | Speculative. Not worth filing. |
+
+## Suppression gate
+
+After all gaps/findings are collected:
+1. Suppress findings below anchor 75.
+2. **Exception:** P0 severity findings at anchor 50+ survive the gate. Critical-but-uncertain issues must not be silently dropped.
+3. Report the suppressed count by anchor in a `Suppressed findings` section of the review output.
+
+Example:
+
+> Suppressed findings: 3 at anchor 50, 7 at anchor 25, 2 at anchor 0.
+
 ## Output Format
 
 **Forward coverage (Spec → Code):**
 For each gap found:
 - **Requirement**: What the spec says
 - **Status**: Missing / Partial / Wrong
+- **Confidence**: 0 / 25 / 50 / 75 / 100 (one of the five discrete anchors)
 - **Evidence**: What you found (or didn't find) in the code
 
 **Reverse coverage (Code → Spec):**
@@ -311,6 +335,8 @@ For each untraced change:
 - **File**: Changed file path
 - **Classification**: UNDOCUMENTED_ADDITION / LEGITIMATE_SUPPORT / UNRELATED_CHANGE
 - **Note**: Brief explanation
+
+After the findings list, emit a `Suppressed findings:` line tallying anchors dropped by the gate (omit when nothing was suppressed).
 
 **REQUIRED**: You MUST end your response with exactly one verdict tag. This is mandatory:
 `<verdict>SHIP</verdict>` or `<verdict>NEEDS_WORK</verdict>`
@@ -361,9 +387,36 @@ Receipt written after SHIP verdict (not on NEEDS_WORK):
 if [[ -n "${REVIEW_RECEIPT_PATH:-}" ]]; then
   ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
   mkdir -p "$(dirname "$REVIEW_RECEIPT_PATH")"
-  cat > "$REVIEW_RECEIPT_PATH" <<EOF
+
+  # Optional: capture suppression-gate tally (fn-29.3).
+  # Reviewer emits a line like "Suppressed findings: 3 at anchor 50, 7 at anchor 25, 2 at anchor 0."
+  SUPPRESSED_JSON="$(printf '%s' "$REVIEW_RESPONSE" \
+    | grep -iE '^[>*_` ]*suppressed findings[ *_`]*:' \
+    | head -n 1 \
+    | sed -E 's/^[^:]+:[[:space:]]*//; s/\.$//' \
+    | awk '
+      BEGIN { first=1; printf "{" }
+      {
+        n=split($0, parts, /,[[:space:]]*/)
+        for (i=1; i<=n; i++) {
+          if (match(parts[i], /([0-9]+)[[:space:]]+at[[:space:]]+anchor[[:space:]]+(0|25|50|75|100)/, m)) {
+            if (!first) printf ","
+            printf "\"%s\":%s", m[2], m[1]
+            first=0
+          }
+        }
+      }
+      END { printf "}" }')"
+
+  if [[ -n "$SUPPRESSED_JSON" && "$SUPPRESSED_JSON" != "{}" ]]; then
+    cat > "$REVIEW_RECEIPT_PATH" <<EOF
+{"type":"completion_review","id":"$EPIC_ID","mode":"rp","verdict":"SHIP","suppressed_count":$SUPPRESSED_JSON,"timestamp":"$ts"}
+EOF
+  else
+    cat > "$REVIEW_RECEIPT_PATH" <<EOF
 {"type":"completion_review","id":"$EPIC_ID","mode":"rp","verdict":"SHIP","timestamp":"$ts"}
 EOF
+  fi
   echo "REVIEW_RECEIPT_WRITTEN: $REVIEW_RECEIPT_PATH"
 fi
 ```

--- a/plugins/flow-next/skills/flow-next-epic-review/workflow.md
+++ b/plugins/flow-next/skills/flow-next-epic-review/workflow.md
@@ -321,14 +321,40 @@ Example:
 
 > Suppressed findings: 3 at anchor 50, 7 at anchor 25, 2 at anchor 0.
 
+## Introduced vs pre-existing classification
+
+For each gap, classify whether this branch's diff caused it:
+
+- **introduced** — this epic's branch is responsible for the gap (new requirement not implemented, or a requirement this epic was supposed to satisfy and did not)
+- **pre_existing** — the gap predates this epic's branch (the requirement was already not satisfied on the base branch; this epic did not touch the relevant code). Pre-existing gaps do not block this verdict.
+
+Evidence methods:
+- `git blame <file> <line>` to see when the line was last touched
+- Read the base-branch version of the file directly
+- Check the epic scope: a gap about an area this epic never claimed to touch is `pre_existing`
+
+**Verdict gate:** only `introduced` gaps affect the verdict. An epic-review whose sole surviving gaps are all `pre_existing` MUST ship.
+
+Pre-existing gaps go under a separate `## Pre-existing issues (not blocking this verdict)` heading:
+
+```
+## Pre-existing issues (not blocking this verdict)
+
+- [confidence 75, introduced=false] missing migration docs in README — predates this epic
+```
+
+Never delete pre-existing gaps from the report — they stay visible for future prioritization.
+
 ## Output Format
 
-**Forward coverage (Spec → Code):**
-For each gap found:
+**Forward coverage (Spec → Code):** for each `introduced` gap:
 - **Requirement**: What the spec says
 - **Status**: Missing / Partial / Wrong
 - **Confidence**: 0 / 25 / 50 / 75 / 100 (one of the five discrete anchors)
+- **Classification**: introduced
 - **Evidence**: What you found (or didn't find) in the code
+
+List each `pre_existing` gap under the dedicated non-blocking section above using the compact form `[confidence N, introduced=false] requirement — summary`.
 
 **Reverse coverage (Code → Spec):**
 For each untraced change:
@@ -336,13 +362,17 @@ For each untraced change:
 - **Classification**: UNDOCUMENTED_ADDITION / LEGITIMATE_SUPPORT / UNRELATED_CHANGE
 - **Note**: Brief explanation
 
-After the findings list, emit a `Suppressed findings:` line tallying anchors dropped by the gate (omit when nothing was suppressed).
+(Note: the reverse-coverage `Classification` uses untraced-change labels, distinct from the `introduced` / `pre_existing` per-gap classification above.)
+
+After the findings list, emit:
+- A `Suppressed findings:` line tallying anchors dropped by the gate (omit when nothing was suppressed).
+- A `Classification counts:` line tallying `introduced` vs `pre_existing` gaps, e.g. `Classification counts: 1 introduced, 0 pre_existing.`.
 
 **REQUIRED**: You MUST end your response with exactly one verdict tag. This is mandatory:
 `<verdict>SHIP</verdict>` or `<verdict>NEEDS_WORK</verdict>`
 
-- SHIP: All spec requirements are implemented
-- NEEDS_WORK: One or more requirements are missing, partial, or wrong
+- SHIP: All `introduced` spec requirements are implemented (pre-existing gaps do not block)
+- NEEDS_WORK: One or more `introduced` requirements are missing, partial, or wrong
 
 Do NOT skip this tag. The automation depends on it.
 EOF
@@ -408,15 +438,41 @@ if [[ -n "${REVIEW_RECEIPT_PATH:-}" ]]; then
       }
       END { printf "}" }')"
 
-  if [[ -n "$SUPPRESSED_JSON" && "$SUPPRESSED_JSON" != "{}" ]]; then
-    cat > "$REVIEW_RECEIPT_PATH" <<EOF
-{"type":"completion_review","id":"$EPIC_ID","mode":"rp","verdict":"SHIP","suppressed_count":$SUPPRESSED_JSON,"timestamp":"$ts"}
-EOF
-  else
-    cat > "$REVIEW_RECEIPT_PATH" <<EOF
-{"type":"completion_review","id":"$EPIC_ID","mode":"rp","verdict":"SHIP","timestamp":"$ts"}
-EOF
+  # Optional: capture introduced vs pre_existing classification tally (fn-29.4).
+  # Reviewer emits a line like "Classification counts: 1 introduced, 0 pre_existing."
+  # Uses portable grep -Eio so this works on BSD awk / mawk / gawk alike.
+  CLASSIFICATION_LINE="$(printf '%s' "$REVIEW_RESPONSE" \
+    | grep -iE '^[>*_` ]*classification counts[ *_`]*:' \
+    | head -n 1 \
+    | sed -E 's/^[^:]+:[[:space:]]*//; s/\.$//')"
+  INTRODUCED_COUNT=""
+  PRE_EXISTING_COUNT=""
+  if [[ -n "$CLASSIFICATION_LINE" ]]; then
+    INTRODUCED_COUNT="$(printf '%s' "$CLASSIFICATION_LINE" \
+      | grep -Eio '[0-9]+[[:space:]]+introduced' \
+      | head -n 1 \
+      | grep -Eo '^[0-9]+')"
+    PRE_EXISTING_COUNT="$(printf '%s' "$CLASSIFICATION_LINE" \
+      | grep -Eio '[0-9]+[[:space:]]+pre[-_ ]?existing' \
+      | head -n 1 \
+      | grep -Eo '^[0-9]+')"
+    if [[ -n "$INTRODUCED_COUNT" || -n "$PRE_EXISTING_COUNT" ]]; then
+      INTRODUCED_COUNT="${INTRODUCED_COUNT:-0}"
+      PRE_EXISTING_COUNT="${PRE_EXISTING_COUNT:-0}"
+    fi
   fi
+
+  EXTRA_FIELDS=""
+  if [[ -n "$SUPPRESSED_JSON" && "$SUPPRESSED_JSON" != "{}" ]]; then
+    EXTRA_FIELDS+=",\"suppressed_count\":$SUPPRESSED_JSON"
+  fi
+  if [[ -n "$INTRODUCED_COUNT" && -n "$PRE_EXISTING_COUNT" ]]; then
+    EXTRA_FIELDS+=",\"introduced_count\":$INTRODUCED_COUNT,\"pre_existing_count\":$PRE_EXISTING_COUNT"
+  fi
+
+  cat > "$REVIEW_RECEIPT_PATH" <<EOF
+{"type":"completion_review","id":"$EPIC_ID","mode":"rp","verdict":"SHIP"$EXTRA_FIELDS,"timestamp":"$ts"}
+EOF
   echo "REVIEW_RECEIPT_WRITTEN: $REVIEW_RECEIPT_PATH"
 fi
 ```

--- a/plugins/flow-next/skills/flow-next-epic-review/workflow.md
+++ b/plugins/flow-next/skills/flow-next-epic-review/workflow.md
@@ -345,6 +345,25 @@ Pre-existing gaps go under a separate `## Pre-existing issues (not blocking this
 
 Never delete pre-existing gaps from the report — they stay visible for future prioritization.
 
+## Protected artifacts
+
+The following paths are flow-next / project-pipeline artifacts. Any gap/finding recommending their deletion, gitignore, or removal MUST be discarded during synthesis. Do not flag these paths for cleanup under any circumstances:
+
+- `.flow/*` — flow-next state, specs, tasks, epics, runtime
+- `.flow/bin/*` — bundled flowctl
+- `.flow/memory/*` — learnings store (pitfalls, conventions, decisions)
+- `.flow/specs/*.md` — epic specs (decision artifacts)
+- `.flow/tasks/*.md` — task specs (decision artifacts)
+- `docs/plans/*` — plan artifacts (if project uses this convention)
+- `docs/solutions/*` — solutions artifacts (if project uses this convention)
+- `scripts/ralph/*` — Ralph harness (when present)
+
+These files are intentionally committed. They are the pipeline's state, not clutter. An agent that deletes them destroys the project's planning trail and breaks Ralph autonomous runs.
+
+If you notice genuine issues with content INSIDE these files (e.g., a spec that contradicts itself, a stale runtime value, a memory entry that's wrong), flag the content — not the file's existence.
+
+**Protected-path filter.** Before emitting findings, scan each for recommendations to delete, gitignore, or `rm -rf` any path matching the protected list above. Drop those findings. If you drop any, report the drop count in a `Protected-path filter:` line in the review output (e.g. `Protected-path filter: dropped 2 findings`). Omit the line when nothing was dropped.
+
 ## Output Format
 
 **Forward coverage (Spec → Code):** for each `introduced` gap:
@@ -367,6 +386,7 @@ For each untraced change:
 After the findings list, emit:
 - A `Suppressed findings:` line tallying anchors dropped by the gate (omit when nothing was suppressed).
 - A `Classification counts:` line tallying `introduced` vs `pre_existing` gaps, e.g. `Classification counts: 1 introduced, 0 pre_existing.`.
+- A `Protected-path filter:` line tallying gaps dropped by the protected-path filter (omit when nothing was dropped).
 
 **REQUIRED**: You MUST end your response with exactly one verdict tag. This is mandatory:
 `<verdict>SHIP</verdict>` or `<verdict>NEEDS_WORK</verdict>`

--- a/plugins/flow-next/skills/flow-next-impl-review/SKILL.md
+++ b/plugins/flow-next/skills/flow-next-impl-review/SKILL.md
@@ -114,10 +114,47 @@ REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 
 Parse $ARGUMENTS for:
 - `--base <commit>` → `BASE_COMMIT` (if provided, use for scoped diff)
+- `--no-triage` → set `TRIAGE_DISABLED=1` (skip trivial-diff pre-check)
 - First positional arg matching `fn-*` → `TASK_ID`
 - Remaining args → focus areas
 
 If `--base` not provided, `BASE_COMMIT` stays empty (will fall back to main/master).
+
+### Step 0.5: Trivial-diff triage (fn-29.6)
+
+Before invoking the configured backend, run a fast pre-check that short-circuits
+lockfile-only, docs-only, release-chore, and generated-file diffs. On SKIP, the
+receipt is written with `mode: "triage_skip"` / `verdict: "SHIP"` and the
+expensive backend call is skipped entirely.
+
+Opt-out: `--no-triage` argument or `FLOW_RALPH_NO_TRIAGE=1` env var.
+
+```bash
+if [[ -z "${TRIAGE_DISABLED:-}" && -z "${FLOW_RALPH_NO_TRIAGE:-}" ]]; then
+  RECEIPT_PATH="${REVIEW_RECEIPT_PATH:-/tmp/impl-review-receipt.json}"
+  TRIAGE_ARGS=(triage-skip --receipt "$RECEIPT_PATH" --json)
+  [[ -n "$BASE_COMMIT" ]] && TRIAGE_ARGS+=(--base "$BASE_COMMIT")
+  [[ -n "$TASK_ID" ]] && TRIAGE_ARGS+=(--task "$TASK_ID")
+  # Deterministic-only by default; set FLOW_TRIAGE_LLM=1 to enable LLM judge
+  # for ambiguous diffs. Deterministic is conservative — ambiguous → REVIEW.
+  [[ -z "${FLOW_TRIAGE_LLM:-}" ]] && TRIAGE_ARGS+=(--no-llm)
+
+  if TRIAGE_OUT=$($FLOWCTL "${TRIAGE_ARGS[@]}" 2>/dev/null); then
+    # Exit 0 = SKIP. Receipt already written by flowctl.
+    SKIP_REASON=$(echo "$TRIAGE_OUT" | jq -r '.reason // "trivial diff"' 2>/dev/null || echo "trivial diff")
+    echo "Triage-skip: $SKIP_REASON"
+    echo "VERDICT=SHIP"
+    exit 0
+  fi
+  # Exit 1 = proceed to full review (normal path). Exit >=2 = error, also falls
+  # through so impl-review proceeds safely rather than failing on triage.
+fi
+```
+
+**Opt-out note:** Pass `--no-triage` to force the full backend review (useful
+when explicitly validating a suspicious chore diff, or when the deterministic
+whitelist misclassifies). `FLOW_RALPH_NO_TRIAGE=1` has the same effect for
+Ralph runs.
 
 ### Step 1: Detect Backend
 

--- a/plugins/flow-next/skills/flow-next-impl-review/workflow.md
+++ b/plugins/flow-next/skills/flow-next-impl-review/workflow.md
@@ -54,6 +54,82 @@ Per-task `review` (set via `flowctl task set-backend`) overrides env.
 
 ---
 
+## Phase 0.5: Trivial-diff triage (fn-29.6)
+
+A cheap pre-check that short-circuits lockfile-only, docs-only, release-chore,
+and generated-file diffs. Runs before the configured backend — when it returns
+SKIP, the receipt is written with `mode: "triage_skip"` / `verdict: "SHIP"`
+and no expensive backend review is invoked.
+
+**Default behavior:** deterministic whitelist only (no LLM call). Ambiguous
+diffs default to REVIEW. Opt-in to LLM judge with `FLOW_TRIAGE_LLM=1`.
+
+**Opt-out:**
+- `--no-triage` argument on the skill
+- `FLOW_RALPH_NO_TRIAGE=1` env var (Ralph runs)
+
+**Invocation (from SKILL.md):**
+
+```bash
+if [[ -z "${TRIAGE_DISABLED:-}" && -z "${FLOW_RALPH_NO_TRIAGE:-}" ]]; then
+  RECEIPT_PATH="${REVIEW_RECEIPT_PATH:-/tmp/impl-review-receipt.json}"
+  TRIAGE_ARGS=(triage-skip --receipt "$RECEIPT_PATH" --json)
+  [[ -n "$BASE_COMMIT" ]] && TRIAGE_ARGS+=(--base "$BASE_COMMIT")
+  [[ -n "$TASK_ID" ]] && TRIAGE_ARGS+=(--task "$TASK_ID")
+  [[ -z "${FLOW_TRIAGE_LLM:-}" ]] && TRIAGE_ARGS+=(--no-llm)
+
+  if TRIAGE_OUT=$($FLOWCTL "${TRIAGE_ARGS[@]}" 2>/dev/null); then
+    SKIP_REASON=$(echo "$TRIAGE_OUT" | jq -r '.reason // "trivial diff"' 2>/dev/null)
+    echo "Triage-skip: $SKIP_REASON"
+    echo "VERDICT=SHIP"
+    exit 0
+  fi
+fi
+```
+
+**Exit codes:**
+- `0` → SKIP (verdict=SHIP, receipt written, skill exits early)
+- `1` → proceed to full review (normal fallthrough to backend)
+- `>=2` → error (falls through to full review — never fail closed)
+
+**Receipt shape on SKIP:**
+
+```json
+{
+  "type": "impl_review",
+  "id": "fn-29.6",
+  "mode": "triage_skip",
+  "base": "main",
+  "verdict": "SHIP",
+  "reason": "lockfile-only (bun.lock)",
+  "source": "deterministic",
+  "changed_file_count": 1,
+  "timestamp": "2026-04-24T10:00:00Z"
+}
+```
+
+Ralph reads `verdict` — `SHIP` satisfies the gate regardless of `mode`. No
+Ralph-script changes required.
+
+**Triage rules (deterministic layer):**
+
+| Shape | Action |
+|-------|--------|
+| Any code file (`.py`, `.ts`, `.go`, `.sh`, ...) present | REVIEW (AC9) |
+| Any `.flow/specs/*.md` / `.flow/tasks/*.md` / `.flow/epics/*.json` | REVIEW |
+| All files are lockfiles (`package-lock.json`, `bun.lock`, ...) | SKIP |
+| All files are docs (`.md`, `.mdx`, `.txt`, `.rst`, `.adoc`) | SKIP |
+| All files are under generated paths (`codex/`, `vendor/`, `node_modules/`, ...) | SKIP |
+| Release-chore: `plugin.json` / `package.json` / `Cargo.toml` / `pyproject.toml` + optional `CHANGELOG.md` | SKIP |
+| Lockfile + manifest combo | SKIP |
+| Anything else | REVIEW (conservative fallthrough) |
+
+When `FLOW_TRIAGE_LLM=1`, ambiguous diffs get a one-shot fast-model call
+(`gpt-5-mini` for codex backend, `claude-haiku-4.5` for copilot backend).
+Malformed LLM output falls through to REVIEW.
+
+---
+
 ## Codex Backend Workflow
 
 Use when `BACKEND="codex"`.

--- a/plugins/flow-next/skills/flow-next-impl-review/workflow.md
+++ b/plugins/flow-next/skills/flow-next-impl-review/workflow.md
@@ -348,6 +348,25 @@ Report pre-existing findings in a dedicated non-blocking section:
 
 Never delete pre-existing findings from the report — they stay visible for future prioritization.
 
+## Protected artifacts
+
+The following paths are flow-next / project-pipeline artifacts. Any finding recommending their deletion, gitignore, or removal MUST be discarded during synthesis. Do not flag these paths for cleanup under any circumstances:
+
+- `.flow/*` — flow-next state, specs, tasks, epics, runtime
+- `.flow/bin/*` — bundled flowctl
+- `.flow/memory/*` — learnings store (pitfalls, conventions, decisions)
+- `.flow/specs/*.md` — epic specs (decision artifacts)
+- `.flow/tasks/*.md` — task specs (decision artifacts)
+- `docs/plans/*` — plan artifacts (if project uses this convention)
+- `docs/solutions/*` — solutions artifacts (if project uses this convention)
+- `scripts/ralph/*` — Ralph harness (when present)
+
+These files are intentionally committed. They are the pipeline's state, not clutter. An agent that deletes them destroys the project's planning trail and breaks Ralph autonomous runs.
+
+If you notice genuine issues with content INSIDE these files (e.g., a spec that contradicts itself, a stale runtime value, a memory entry that's wrong), flag the content — not the file's existence.
+
+**Protected-path filter.** Before emitting findings, scan each for recommendations to delete, gitignore, or `rm -rf` any path matching the protected list above. Drop those findings. If you drop any, report the drop count in a `Protected-path filter:` line in the review output (e.g. `Protected-path filter: dropped 2 findings`). Omit the line when nothing was dropped.
+
 ## Output Format
 
 For each surviving `introduced` finding:
@@ -363,6 +382,7 @@ Then list each `pre_existing` finding under a separate `## Pre-existing issues (
 After the findings list, emit:
 - A `Suppressed findings:` line tallying anchors dropped by the gate (omit when nothing was suppressed).
 - A `Classification counts:` line tallying `introduced` vs `pre_existing` survivors, e.g. `Classification counts: 2 introduced, 4 pre_existing.`.
+- A `Protected-path filter:` line tallying findings dropped by the protected-path filter (omit when nothing was dropped).
 
 **REQUIRED**: You MUST end your response with exactly one verdict tag. This is mandatory:
 `<verdict>SHIP</verdict>` (no blocking `introduced` findings) or `<verdict>NEEDS_WORK</verdict>` (introduced findings to fix) or `<verdict>MAJOR_RETHINK</verdict>`

--- a/plugins/flow-next/skills/flow-next-impl-review/workflow.md
+++ b/plugins/flow-next/skills/flow-next-impl-review/workflow.md
@@ -376,6 +376,44 @@ Walk through these scenarios mentally for any new/modified code paths:
 
 Only flag issues that apply to the **changed code** - not pre-existing patterns.
 
+## Requirements coverage (if spec has R-IDs)
+
+If the task spec references an epic spec with numbered acceptance criteria like
+`- **R1:** ...`, `- **R2:** ...`, produce a per-R-ID coverage table. Read the
+epic spec's `## Acceptance` section (or the legacy `## Acceptance criteria`
+heading — reviewer MUST tolerate both). If no R-IDs are present anywhere, skip
+this block entirely — the rest of the review is unchanged.
+
+For each R-ID, classify status:
+
+| Status | Meaning |
+|--------|---------|
+| met | Diff clearly implements the requirement with appropriate tests/evidence |
+| partial | Diff advances the requirement but leaves gaps (missing tests, missing edge case, missing integration point) |
+| not-addressed | Diff does not advance this requirement at all |
+| deferred | Spec explicitly defers this requirement to a later task/PR |
+
+Report as a markdown table in the review output:
+
+| R-ID | Status | Evidence |
+|------|--------|----------|
+| R1 | met | src/auth.ts:42 + tests/auth.test.ts:17 |
+| R2 | partial | implementation exists but no error-path tests |
+| R3 | not-addressed | — |
+
+After the table, emit one line listing every `not-addressed` R-ID that is NOT
+explicitly deferred in the spec:
+
+> Unaddressed R-IDs: [R3, R5]
+
+If there are zero unaddressed R-IDs, emit `Unaddressed R-IDs: []` or omit the
+line entirely — both forms are valid. Deferred R-IDs are never listed here.
+
+**Verdict gate:** any `not-addressed` R-ID that is NOT marked `deferred` in the
+spec MUST flip the verdict to `NEEDS_WORK`. A clean coverage table (all `met`
+or `deferred`) does not by itself force SHIP — the other review gates still
+apply.
+
 ## Confidence calibration
 
 Rate each finding on exactly one of these 5 discrete anchors. Do not use interpolated values (no 33, 80, 90).
@@ -456,12 +494,13 @@ For each surviving `introduced` finding:
 Then list each `pre_existing` finding under a separate `## Pre-existing issues (not blocking this verdict)` heading using the compact form `[severity, confidence N, introduced=false] file:line — summary`.
 
 After the findings list, emit:
+- The `## Requirements coverage` table and `Unaddressed R-IDs:` line (only when the spec uses R-IDs; otherwise skip).
 - A `Suppressed findings:` line tallying anchors dropped by the gate (omit when nothing was suppressed).
 - A `Classification counts:` line tallying `introduced` vs `pre_existing` survivors, e.g. `Classification counts: 2 introduced, 4 pre_existing.`.
 - A `Protected-path filter:` line tallying findings dropped by the protected-path filter (omit when nothing was dropped).
 
 **REQUIRED**: You MUST end your response with exactly one verdict tag. This is mandatory:
-`<verdict>SHIP</verdict>` (no blocking `introduced` findings) or `<verdict>NEEDS_WORK</verdict>` (introduced findings to fix) or `<verdict>MAJOR_RETHINK</verdict>`
+`<verdict>SHIP</verdict>` (no blocking `introduced` findings, all R-IDs met or deferred) or `<verdict>NEEDS_WORK</verdict>` (introduced findings or unaddressed R-IDs to fix) or `<verdict>MAJOR_RETHINK</verdict>`
 
 Do NOT skip this tag. The automation depends on it.
 EOF
@@ -544,13 +583,44 @@ if [[ -n "${REVIEW_RECEIPT_PATH:-}" ]]; then
     fi
   fi
 
-  # Build receipt; inject optional fn-29.3/fn-29.4 signals only when present
+  # Optional: capture unaddressed R-IDs (fn-29.2).
+  # Reviewer emits `Unaddressed R-IDs: [R3, R5]` (or `[]` / `none` for empty).
+  # Absent line => legacy spec (no R-IDs) — leave field off the receipt entirely.
+  UNADDRESSED_JSON=""
+  UNADDRESSED_LINE="$(printf '%s' "$REVIEW_RESPONSE" \
+    | grep -iE '^[>*_` ]*unaddressed([[:space:]]+r[-_ ]?ids?)?[ *_`]*:' \
+    | head -n 1 \
+    | sed -E 's/^[^:]+:[[:space:]]*//; s/[[:space:]]*$//; s/\.$//')"
+  if [[ -n "$UNADDRESSED_LINE" ]]; then
+    # Strip surrounding brackets/quotes; treat "none"/"n/a"/"" as empty list.
+    normalized="$(printf '%s' "$UNADDRESSED_LINE" | sed -E 's/^[[:space:]]*\[|\][[:space:]]*$//g; s/[[:space:]]+//g')"
+    lower="$(printf '%s' "$normalized" | tr '[:upper:]' '[:lower:]')"
+    if [[ "$lower" == "none" || "$lower" == "n/a" || -z "$lower" ]]; then
+      UNADDRESSED_JSON="[]"
+    else
+      # Extract R-ID tokens (R followed by digits), de-dup preserving order.
+      rids="$(printf '%s' "$UNADDRESSED_LINE" \
+        | grep -oE '\bR[0-9]+\b' \
+        | awk '!seen[$0]++')"
+      if [[ -z "$rids" ]]; then
+        UNADDRESSED_JSON="[]"
+      else
+        UNADDRESSED_JSON="$(printf '%s' "$rids" \
+          | awk 'BEGIN{printf "["} {printf (NR>1?",":"") "\"" $0 "\""} END{printf "]"}')"
+      fi
+    fi
+  fi
+
+  # Build receipt; inject optional fn-29.2/fn-29.3/fn-29.4 signals only when present
   EXTRA_FIELDS=""
   if [[ -n "$SUPPRESSED_JSON" && "$SUPPRESSED_JSON" != "{}" ]]; then
     EXTRA_FIELDS+=",\"suppressed_count\":$SUPPRESSED_JSON"
   fi
   if [[ -n "$INTRODUCED_COUNT" && -n "$PRE_EXISTING_COUNT" ]]; then
     EXTRA_FIELDS+=",\"introduced_count\":$INTRODUCED_COUNT,\"pre_existing_count\":$PRE_EXISTING_COUNT"
+  fi
+  if [[ -n "$UNADDRESSED_JSON" ]]; then
+    EXTRA_FIELDS+=",\"unaddressed\":$UNADDRESSED_JSON"
   fi
 
   cat > "$REVIEW_RECEIPT_PATH" <<EOF

--- a/plugins/flow-next/skills/flow-next-impl-review/workflow.md
+++ b/plugins/flow-next/skills/flow-next-impl-review/workflow.md
@@ -323,19 +323,49 @@ Example:
 
 > Suppressed findings: 3 at anchor 50, 7 at anchor 25, 2 at anchor 0.
 
+## Introduced vs pre-existing classification
+
+For each finding, classify whether this branch's diff caused it:
+
+- **introduced** — this branch caused the issue (new code, or a pre-existing bug that this diff amplified/exposed in a way that now matters)
+- **pre_existing** — the issue was already present on the base branch; this diff did not touch it
+
+Evidence methods (use whatever is cheapest):
+- `git blame <file> <line>` to see when the line was last touched
+- Read the base-branch version of the file directly
+- Infer from diff context: a finding on an unchanged line in an unchanged file is `pre_existing` by default
+
+**Verdict gate:** only `introduced` findings affect the verdict. A review whose sole surviving findings are all `pre_existing` MUST ship.
+
+Report pre-existing findings in a dedicated non-blocking section:
+
+```
+## Pre-existing issues (not blocking this verdict)
+
+- [P1, confidence 75, introduced=false] src/legacy.ts:102 — null dereference on empty array
+- ...
+```
+
+Never delete pre-existing findings from the report — they stay visible for future prioritization.
+
 ## Output Format
 
-For each surviving finding:
+For each surviving `introduced` finding:
 - **Severity**: Critical / Major / Minor / Nitpick (P0 / P1 / P2 / P3 accepted)
 - **Confidence**: 0 / 25 / 50 / 75 / 100 (one of the five discrete anchors)
+- **Classification**: introduced
 - **File:Line**: Exact location
 - **Problem**: What's wrong
 - **Suggestion**: How to fix
 
-After the findings list, emit a `Suppressed findings:` line tallying anchors dropped by the gate (omit when nothing was suppressed).
+Then list each `pre_existing` finding under a separate `## Pre-existing issues (not blocking this verdict)` heading using the compact form `[severity, confidence N, introduced=false] file:line — summary`.
+
+After the findings list, emit:
+- A `Suppressed findings:` line tallying anchors dropped by the gate (omit when nothing was suppressed).
+- A `Classification counts:` line tallying `introduced` vs `pre_existing` survivors, e.g. `Classification counts: 2 introduced, 4 pre_existing.`.
 
 **REQUIRED**: You MUST end your response with exactly one verdict tag. This is mandatory:
-`<verdict>SHIP</verdict>` or `<verdict>NEEDS_WORK</verdict>` or `<verdict>MAJOR_RETHINK</verdict>`
+`<verdict>SHIP</verdict>` (no blocking `introduced` findings) or `<verdict>NEEDS_WORK</verdict>` (introduced findings to fix) or `<verdict>MAJOR_RETHINK</verdict>`
 
 Do NOT skip this tag. The automation depends on it.
 EOF
@@ -393,16 +423,43 @@ if [[ -n "${REVIEW_RECEIPT_PATH:-}" ]]; then
       }
       END { printf "}" }')"
 
-  # Build receipt; inject suppressed_count only when non-empty
-  if [[ -n "$SUPPRESSED_JSON" && "$SUPPRESSED_JSON" != "{}" ]]; then
-    cat > "$REVIEW_RECEIPT_PATH" <<EOF
-{"type":"impl_review","id":"<TASK_ID>","mode":"rp","verdict":"$VERDICT","suppressed_count":$SUPPRESSED_JSON,"timestamp":"$ts"}
-EOF
-  else
-    cat > "$REVIEW_RECEIPT_PATH" <<EOF
-{"type":"impl_review","id":"<TASK_ID>","mode":"rp","verdict":"$VERDICT","timestamp":"$ts"}
-EOF
+  # Optional: capture introduced vs pre_existing classification tally (fn-29.4).
+  # Reviewer emits a line like "Classification counts: 2 introduced, 4 pre_existing."
+  # Uses portable grep -Eio so this works on BSD awk / mawk / gawk alike.
+  CLASSIFICATION_LINE="$(printf '%s' "$REVIEW_RESPONSE" \
+    | grep -iE '^[>*_` ]*classification counts[ *_`]*:' \
+    | head -n 1 \
+    | sed -E 's/^[^:]+:[[:space:]]*//; s/\.$//')"
+  INTRODUCED_COUNT=""
+  PRE_EXISTING_COUNT=""
+  if [[ -n "$CLASSIFICATION_LINE" ]]; then
+    INTRODUCED_COUNT="$(printf '%s' "$CLASSIFICATION_LINE" \
+      | grep -Eio '[0-9]+[[:space:]]+introduced' \
+      | head -n 1 \
+      | grep -Eo '^[0-9]+')"
+    PRE_EXISTING_COUNT="$(printf '%s' "$CLASSIFICATION_LINE" \
+      | grep -Eio '[0-9]+[[:space:]]+pre[-_ ]?existing' \
+      | head -n 1 \
+      | grep -Eo '^[0-9]+')"
+    # Default the missing bucket to 0 when the other is present
+    if [[ -n "$INTRODUCED_COUNT" || -n "$PRE_EXISTING_COUNT" ]]; then
+      INTRODUCED_COUNT="${INTRODUCED_COUNT:-0}"
+      PRE_EXISTING_COUNT="${PRE_EXISTING_COUNT:-0}"
+    fi
   fi
+
+  # Build receipt; inject optional fn-29.3/fn-29.4 signals only when present
+  EXTRA_FIELDS=""
+  if [[ -n "$SUPPRESSED_JSON" && "$SUPPRESSED_JSON" != "{}" ]]; then
+    EXTRA_FIELDS+=",\"suppressed_count\":$SUPPRESSED_JSON"
+  fi
+  if [[ -n "$INTRODUCED_COUNT" && -n "$PRE_EXISTING_COUNT" ]]; then
+    EXTRA_FIELDS+=",\"introduced_count\":$INTRODUCED_COUNT,\"pre_existing_count\":$PRE_EXISTING_COUNT"
+  fi
+
+  cat > "$REVIEW_RECEIPT_PATH" <<EOF
+{"type":"impl_review","id":"<TASK_ID>","mode":"rp","verdict":"$VERDICT"$EXTRA_FIELDS,"timestamp":"$ts"}
+EOF
   echo "REVIEW_RECEIPT_WRITTEN: $REVIEW_RECEIPT_PATH"
 fi
 ```

--- a/plugins/flow-next/skills/flow-next-impl-review/workflow.md
+++ b/plugins/flow-next/skills/flow-next-impl-review/workflow.md
@@ -300,13 +300,39 @@ Walk through these scenarios mentally for any new/modified code paths:
 
 Only flag issues that apply to the **changed code** - not pre-existing patterns.
 
+## Confidence calibration
+
+Rate each finding on exactly one of these 5 discrete anchors. Do not use interpolated values (no 33, 80, 90).
+
+| Anchor | Meaning |
+|--------|---------|
+| 100 | Verifiable from the code alone, zero interpretation. A definitive logic error (off-by-one in a tested algorithm, wrong return type, swapped arguments, clear type error). The bug is mechanical. |
+| 75 | Full execution path traced: "input X enters here, takes this branch, reaches line Z, produces wrong result." Reproducible from the code alone. A normal caller will hit it. |
+| 50 | Depends on conditions visible but not fully confirmable from this diff — e.g., whether a value can actually be null depends on callers not in the diff. Surfaces only as P0-escape or via soft-bucket routing. |
+| 25 | Requires runtime conditions with no direct evidence — specific timing, specific input shapes, specific external state. |
+| 0 | Speculative. Not worth filing. |
+
+## Suppression gate
+
+After all findings are collected:
+1. Suppress findings below anchor 75.
+2. **Exception:** P0 severity findings at anchor 50+ survive the gate. Critical-but-uncertain issues must not be silently dropped.
+3. Report the suppressed count by anchor in a `Suppressed findings` section of the review output.
+
+Example:
+
+> Suppressed findings: 3 at anchor 50, 7 at anchor 25, 2 at anchor 0.
+
 ## Output Format
 
-For each issue:
-- **Severity**: Critical / Major / Minor / Nitpick
+For each surviving finding:
+- **Severity**: Critical / Major / Minor / Nitpick (P0 / P1 / P2 / P3 accepted)
+- **Confidence**: 0 / 25 / 50 / 75 / 100 (one of the five discrete anchors)
 - **File:Line**: Exact location
 - **Problem**: What's wrong
 - **Suggestion**: How to fix
+
+After the findings list, emit a `Suppressed findings:` line tallying anchors dropped by the gate (omit when nothing was suppressed).
 
 **REQUIRED**: You MUST end your response with exactly one verdict tag. This is mandatory:
 `<verdict>SHIP</verdict>` or `<verdict>NEEDS_WORK</verdict>` or `<verdict>MAJOR_RETHINK</verdict>`
@@ -346,9 +372,37 @@ fi
 if [[ -n "${REVIEW_RECEIPT_PATH:-}" ]]; then
   ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
   mkdir -p "$(dirname "$REVIEW_RECEIPT_PATH")"
-  cat > "$REVIEW_RECEIPT_PATH" <<EOF
+
+  # Optional: capture suppression-gate tally (fn-29.3).
+  # Reviewer emits a line like "Suppressed findings: 3 at anchor 50, 7 at anchor 25, 2 at anchor 0."
+  SUPPRESSED_JSON="$(printf '%s' "$REVIEW_RESPONSE" \
+    | grep -iE '^[>*_` ]*suppressed findings[ *_`]*:' \
+    | head -n 1 \
+    | sed -E 's/^[^:]+:[[:space:]]*//; s/\.$//' \
+    | awk '
+      BEGIN { first=1; printf "{" }
+      {
+        n=split($0, parts, /,[[:space:]]*/)
+        for (i=1; i<=n; i++) {
+          if (match(parts[i], /([0-9]+)[[:space:]]+at[[:space:]]+anchor[[:space:]]+(0|25|50|75|100)/, m)) {
+            if (!first) printf ","
+            printf "\"%s\":%s", m[2], m[1]
+            first=0
+          }
+        }
+      }
+      END { printf "}" }')"
+
+  # Build receipt; inject suppressed_count only when non-empty
+  if [[ -n "$SUPPRESSED_JSON" && "$SUPPRESSED_JSON" != "{}" ]]; then
+    cat > "$REVIEW_RECEIPT_PATH" <<EOF
+{"type":"impl_review","id":"<TASK_ID>","mode":"rp","verdict":"$VERDICT","suppressed_count":$SUPPRESSED_JSON,"timestamp":"$ts"}
+EOF
+  else
+    cat > "$REVIEW_RECEIPT_PATH" <<EOF
 {"type":"impl_review","id":"<TASK_ID>","mode":"rp","verdict":"$VERDICT","timestamp":"$ts"}
 EOF
+  fi
   echo "REVIEW_RECEIPT_WRITTEN: $REVIEW_RECEIPT_PATH"
 fi
 ```

--- a/plugins/flow-next/skills/flow-next-plan-review/workflow.md
+++ b/plugins/flow-next/skills/flow-next-plan-review/workflow.md
@@ -286,6 +286,25 @@ Conduct a John Carmack-level review:
 9. **Testability** - How will we verify this works?
 10. **Consistency** - Do task specs align with epic spec?
 
+## Protected artifacts
+
+The following paths are flow-next / project-pipeline artifacts. Any finding recommending their deletion, gitignore, or removal MUST be discarded during synthesis. Do not flag these paths for cleanup under any circumstances:
+
+- `.flow/*` — flow-next state, specs, tasks, epics, runtime
+- `.flow/bin/*` — bundled flowctl
+- `.flow/memory/*` — learnings store (pitfalls, conventions, decisions)
+- `.flow/specs/*.md` — epic specs (decision artifacts)
+- `.flow/tasks/*.md` — task specs (decision artifacts)
+- `docs/plans/*` — plan artifacts (if project uses this convention)
+- `docs/solutions/*` — solutions artifacts (if project uses this convention)
+- `scripts/ralph/*` — Ralph harness (when present)
+
+These files are intentionally committed. They are the pipeline's state, not clutter. An agent that deletes them destroys the project's planning trail and breaks Ralph autonomous runs.
+
+If you notice genuine issues with content INSIDE these files (e.g., a spec that contradicts itself, a stale entry), flag the content — not the file's existence.
+
+**Protected-path filter.** Before emitting findings, scan each for recommendations to delete, gitignore, or `rm -rf` any path matching the protected list above. Drop those findings. If you drop any, report the drop count in a `Protected-path filter:` line in the review output (e.g. `Protected-path filter: dropped 2 findings`). Omit the line when nothing was dropped.
+
 ## Output Format
 
 For each issue:
@@ -293,6 +312,8 @@ For each issue:
 - **Location**: Which task or section (e.g., "fn-1.3 Description" or "Epic Acceptance #2")
 - **Problem**: What's wrong
 - **Suggestion**: How to fix
+
+After the issues list, emit a `Protected-path filter:` line tallying findings dropped by the protected-path filter (omit when nothing was dropped).
 
 **REQUIRED**: You MUST end your response with exactly one verdict tag. This is mandatory:
 `<verdict>SHIP</verdict>` or `<verdict>NEEDS_WORK</verdict>` or `<verdict>MAJOR_RETHINK</verdict>`

--- a/plugins/flow-next/skills/flow-next-plan/SKILL.md
+++ b/plugins/flow-next/skills/flow-next-plan/SKILL.md
@@ -167,3 +167,4 @@ All plans go into `.flow/`:
 - Only create/update epics and tasks via flowctl
 - No code changes
 - No plan files outside `.flow/`
+- R-IDs are mandatory on new epic spec acceptance criteria — use `- **Rn:** ...` prose prefix format; never renumber after first review cycle (see `steps.md` R-ID rule)

--- a/plugins/flow-next/skills/flow-next-plan/steps.md
+++ b/plugins/flow-next/skills/flow-next-plan/steps.md
@@ -224,8 +224,9 @@ Default to standard unless complexity demands more or less.
    ```
 
    ## Acceptance
-   - [ ] Criterion 1
-   - [ ] Criterion 2
+   - **R1:** <testable criterion>
+   - **R2:** <testable criterion>
+   - **R3:** <testable criterion>
 
    ## Early proof point
    Task fn-N-slug.1 validates the core approach (<what it proves>).
@@ -252,6 +253,13 @@ Default to standard unless complexity demands more or less.
    - Every requirement must map to at least one task OR have a gap justification
    - Table goes at the bottom of the epic spec (after Acceptance + Early proof point)
    - Keep Req IDs simple (R1, R2...) — they're local to this epic
+
+   **R-ID rule (MANDATORY for new epic specs):**
+   - Number acceptance criteria as `R1`, `R2`, `R3`, ... in creation order using the `- **Rn:** ...` prose prefix format shown in the template above.
+   - Once a review cycle has run against an R-ID, **never renumber**. Reordering is fine (R1, R3, R5 after R2/R4 deletion is correct).
+   - New criteria take the next unused number. Gaps are fine — do not compact.
+   - R-IDs in `## Acceptance` and `## Requirement coverage` must match (same IDs, same meanings).
+   - R-IDs are plain markdown prose, not YAML — the reviewer matches them via LLM reasoning, not strict parsing.
 
 4. Set epic dependencies (from epic-scout findings):
 
@@ -286,8 +294,27 @@ Default to standard unless complexity demands more or less.
    $FLOWCTL task set-spec <task-id> --description /tmp/desc.md --acceptance /tmp/acc.md --json
    ```
 
+   **When the task needs `satisfies:` frontmatter**, use `--file` mode instead (frontmatter lives above the sections, not inside them):
+   ```bash
+   $FLOWCTL task set-spec <task-id> --file - --json <<'EOF'
+   ---
+   satisfies: [R1, R3]
+   ---
+
+   ## Description
+   ...
+
+   ## Acceptance
+   - [ ] ...
+   EOF
+   ```
+
    **Task spec content** (remember: NO implementation code):
    ```markdown
+   ---
+   satisfies: [R1, R3]
+   ---
+
    ## Description
    [What to build, not how to build it]
 
@@ -338,6 +365,12 @@ Default to standard unless complexity demands more or less.
    - Validate paths exist at plan time (repo-scout/context-scout already found them)
    - "Required" = must read before implementing. "Optional" = helpful reference
    - Targets come from repo-scout/context-scout findings in Step 1
+
+   **`satisfies` frontmatter rules (optional, additive):**
+   - Populate `satisfies: [R1, R3]` only when the task obviously advances specific R-IDs from the epic's `## Acceptance` section.
+   - Tasks that do infrastructure, refactoring, shared plumbing, or docs-only work may legitimately have **no** `satisfies` entry — omit the frontmatter entirely.
+   - Use bare R-ID tokens (`[R1, R3]`), not quoted strings.
+   - Frontmatter is additive — tasks created without it parse unchanged.
 
 7. Add task dependencies (if not already set via `--deps`):
 


### PR DESCRIPTION
## Summary

Five prompt-level + minimal-flowctl improvements that raise review signal and cut review cost across all three backends (rp, codex, copilot). Ships as 0.32.1.

- **R-ID traceability** — numbered acceptance criteria (`R1`, `R2`...) in epic specs, optional `satisfies: [R1, R3]` task frontmatter, per-R-ID coverage tables in impl/epic reviews, `unaddressed` receipt field.
- **Confidence anchors** — reviewers score on 5 discrete values (0/25/50/75/100); suppress <75 except P0@50+; receipt carries `suppressed_count`.
- **Introduced vs pre-existing classification** — verdict gate considers only `introduced` findings; pre-existing surfaced in separate non-blocking section; receipt carries `introduced_count` / `pre_existing_count`.
- **Protected artifacts** — hardcoded never-flag list (`.flow/*`, `docs/plans/*`, `scripts/ralph/*`, ...) discarded during review synthesis.
- **Trivial-diff skip** — `flowctl triage-skip` deterministic whitelist short-circuits lockfile-only / docs-only / release-chore diffs with `SHIP`. On by default in Ralph; `--no-triage` to opt out. Optional fast-model LLM judge gated behind `FLOW_TRIAGE_LLM=1`.

All changes additive. Existing receipts without new fields keep working. Carmack-level review remains default. Zero breaking changes.

## Test plan

- [x] `plugins/flow-next/scripts/smoke_test.sh` — 71/71 pass (baseline + post-change)
- [x] `scripts/sync-codex.sh` — zero drift after re-run
- [x] `flowctl.py` ↔ `.flow/bin/flowctl.py` mirror in sync
- [x] Triage-skip e2e: `SHIP` on CHANGELOG-only diff, `REVIEW` on code addition
- [x] Parser smoke: `parse_unaddressed_rids`, `parse_suppressed_count`, `parse_classification_counts`
- [x] Prompt builders carry all five blocks: R-ID coverage, confidence rubric, classification rubric, protected artifacts (impl/completion/standalone; plan omits classification by design)
- [x] Version bump 0.32.0 → 0.32.1 across 3 manifests + 2 README badges
- [x] CHANGELOG 0.32.1 entry covers all five features
- [x] Website page (`mickel.tech/app/apps/flow-next/page.tsx`) updated in separate commit

## Release

Tag `flow-next-v0.32.1` after merge to trigger release + Discord notification.