### PR TITLE
chore(flow-next): align spec acceptance-criteria heading + parser tolerance — 1.1.4

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,13 +6,13 @@
   },
   "metadata": {
     "description": "Plan-first workflows for Claude Code and Factory Droid. Ships flow-next: zero-dep, spec-driven, Ralph autonomous mode.",
-    "version": "1.1.3"
+    "version": "1.1.4"
   },
   "plugins": [
     {
       "name": "flow-next",
       "description": "Zero-dependency planning + execution with .flow/ task tracking and Ralph autonomous mode (multi-model review gates). Worker subagent per task for context isolation. Includes 21 subagents, 19 commands, 23 skills.",
-      "version": "1.1.3",
+      "version": "1.1.4",
       "author": {
         "name": "Gordon Mickel",
         "email": "gordon@mickel.tech",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to the flow-next.
 
+## [flow-next 1.1.4] - 2026-05-20
+
+### Fixed
+- **Spec acceptance-criteria heading alignment.** The canonical scaffold at `plugins/flow-next/templates/spec.md` (fn-44 / 1.1.0+) uses `## Acceptance Criteria`, but the `/flow-next:plan` skill's heredoc template wrote `## Acceptance` — so plan-generated specs (e.g. fn-46) shipped with a heading the `flowctl spec export-cognitive-aid` parser didn't recognize, returning empty `acceptance_criteria` for those specs. Aligned the plan template + supporting prose (5 sites in `flow-next-plan/steps.md`, 1 site in `agents/plan-sync.md`) to write `## Acceptance Criteria` canonically. New plan output matches the bundled template + canonical parser key going forward.
+- **Parser tolerance for legacy heading variants.** `_export_parse_acceptance_criteria` now accepts the canonical `## Acceptance Criteria` (preferred), the legacy `## Acceptance criteria` (older lowercase form), AND the legacy `## Acceptance` (plan template pre-1.1.4 + `flowctl spec skeleton` output locked by R22). Existing specs that ship `## Acceptance` continue to parse cleanly — no migration required for merged specs. Reviewer prompt block updated to declare canonical + tolerate the two legacy forms.
+
+### Internal
+- `flowctl spec skeleton` and `flowctl prospect promote` CLI heredocs intentionally keep `## Acceptance` (R22 byte-for-byte invariant on the fresh-spec skeleton). The parser tolerance covers their output transparently.
+- 5 new unit tests in `test_acceptance_criteria_parser.py` lock the canonical + 2 legacy heading forms; rejects `## Acceptance Tests` (distinct concept) as a non-match.
+- 5 manifest surfaces aligned at 1.1.4 via `scripts/bump.sh patch flow-next`.
+
 ## [flow-next 1.1.3] - 2026-05-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Flow-Next
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Flow-next](https://img.shields.io/badge/Flow--next-v1.1.3-green)](plugins/flow-next/)
+[![Flow-next](https://img.shields.io/badge/Flow--next-v1.1.4-green)](plugins/flow-next/)
 [![Docs](https://img.shields.io/badge/Docs-📖-informational)](plugins/flow-next/README.md)
 
 [![Author](https://img.shields.io/badge/Author-Gordon_Mickel-orange)](https://mickel.tech)

--- a/plugins/flow-next/.claude-plugin/plugin.json
+++ b/plugins/flow-next/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "flow-next",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Zero-dependency planning + execution with .flow/ task tracking and Ralph autonomous mode (multi-model review gates). Worker subagent per task for context isolation. Prime assesses 8 pillars (48 criteria) with GitHub API integration. Includes 21 subagents, 19 commands, 23 skills.",
   "author": {
     "name": "Gordon Mickel",

--- a/plugins/flow-next/.codex-plugin/plugin.json
+++ b/plugins/flow-next/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "flow-next",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Zero-dependency planning + execution with .flow/ task tracking and Ralph autonomous mode. Worker subagent per task for context isolation. Compatible with Codex, Claude Code, and Factory Droid.",
   "author": {
     "name": "Gordon Mickel",

--- a/plugins/flow-next/README.md
+++ b/plugins/flow-next/README.md
@@ -6,7 +6,7 @@
 [![Claude Code](https://img.shields.io/badge/Claude_Code-Plugin-blueviolet)](https://claude.ai/code)
 [![OpenAI Codex](https://img.shields.io/badge/OpenAI_Codex-Plugin-10a37f)](https://developers.openai.com/codex/cli/)
 
-[![Version](https://img.shields.io/badge/Version-1.1.3-green)](../../CHANGELOG.md)
+[![Version](https://img.shields.io/badge/Version-1.1.4-green)](../../CHANGELOG.md)
 
 [![Status](https://img.shields.io/badge/Status-Active_Development-brightgreen)](../../CHANGELOG.md)
 [![Discord](https://img.shields.io/badge/Discord-Join-5865F2?logo=discord&logoColor=white)](https://discord.gg/f3DYq8AAm5)

--- a/plugins/flow-next/agents/plan-sync.md
+++ b/plugins/flow-next/agents/plan-sync.md
@@ -306,7 +306,7 @@ Decision overrides flagged for review:  # Only if DECISIONS_JSON had entries wit
 
 When syncing drift between spec and implementation:
 
-- **Never renumber existing R-IDs** in the parent spec's `## Acceptance` section or `## Requirement coverage` table. Stable IDs are the whole point — renumbering silently breaks review receipts and prior verdicts.
+- **Never renumber existing R-IDs** in the parent spec's `## Acceptance Criteria` section or `## Requirement coverage` table. Stable IDs are the whole point — renumbering silently breaks review receipts and prior verdicts.
 - **New acceptance criteria take the next unused number.** If the spec has `R1, R2, R4` (R3 deleted), a new criterion becomes `R5` — respect the gap, do not compact.
 - **If an acceptance criterion is deleted, leave the gap.** Do not shift `R4` down to `R3`.
 - **When updating task specs, populate `satisfies: [R1, R3]` frontmatter** if the drift clearly advances specific R-IDs. If the task already has `satisfies`, preserve existing entries and only add/remove when drift clearly warrants it.

--- a/plugins/flow-next/codex/agents/plan-sync.toml
+++ b/plugins/flow-next/codex/agents/plan-sync.toml
@@ -306,7 +306,7 @@ Decision overrides flagged for review:  # Only if DECISIONS_JSON had entries wit
 
 When syncing drift between spec and implementation:
 
-- **Never renumber existing R-IDs** in the parent spec's `## Acceptance` section or `## Requirement coverage` table. Stable IDs are the whole point — renumbering silently breaks review receipts and prior verdicts.
+- **Never renumber existing R-IDs** in the parent spec's `## Acceptance Criteria` section or `## Requirement coverage` table. Stable IDs are the whole point — renumbering silently breaks review receipts and prior verdicts.
 - **New acceptance criteria take the next unused number.** If the spec has `R1, R2, R4` (R3 deleted), a new criterion becomes `R5` — respect the gap, do not compact.
 - **If an acceptance criterion is deleted, leave the gap.** Do not shift `R4` down to `R3`.
 - **When updating task specs, populate `satisfies: [R1, R3]` frontmatter** if the drift clearly advances specific R-IDs. If the task already has `satisfies`, preserve existing entries and only add/remove when drift clearly warrants it.

--- a/plugins/flow-next/codex/skills/flow-next-plan/steps.md
+++ b/plugins/flow-next/codex/skills/flow-next-plan/steps.md
@@ -233,8 +233,8 @@ Default to standard unless complexity demands more or less.
  The canonical scaffold lives in [`plugins/flow-next/templates/spec.md`](../../templates/spec.md) — section list, scope-owner annotations, and the `## Decision Context` flat-vs-H3 conditional. At runtime the template is resolved via the 4-tier discovery cascade (first match wins): `<repo_root>/SPEC.md` → `<repo_root>/spec.md` → `.flow/templates/spec.md` → bundled `${PLUGIN_ROOT}/templates/spec.md`. The bundled file is the canonical source of truth; earlier tiers are user-customized overrides. Read the resolved template before authoring; never duplicate its section list inline. The plan skill extends that scaffold with the plan-specific sections shown below (Overview, Quick commands, Strategy Alignment, Strategy drift, Early proof point, Requirement coverage).
 
  ```bash
- # Include: Overview, Scope, Approach, Quick commands (REQUIRED), Acceptance,
- # Early proof point, Requirement coverage, References
+ # Include: Overview, Scope, Approach, Quick commands (REQUIRED),
+ # Acceptance Criteria, Early proof point, Requirement coverage, References
  # Conditional sections: ## Strategy Alignment (when STRATEGY_PRESENT=true from Step 1),
  # ## Strategy drift flagged for review (when plan scope conflicts with an active track)
  # Add mermaid diagram if data model or architecture changes
@@ -275,7 +275,7 @@ Default to standard unless complexity demands more or less.
  ## Decision context
  - <why this approach over alternatives>
 
- ## Acceptance
+ ## Acceptance Criteria
  - **R1:** <testable criterion>
  - **R2:** <testable criterion>
  - **R3:** <testable criterion>
@@ -288,7 +288,7 @@ Default to standard unless complexity demands more or less.
 
  | Req | Description | Task(s) | Gap justification |
  |-----|-------------|---------|-------------------|
- | R1 | <criterion from Acceptance> | fn-N-slug.1, fn-N-slug.2 | — |
+ | R1 | <criterion from Acceptance Criteria> | fn-N-slug.1, fn-N-slug.2 | — |
  | R2 | <another criterion> | fn-N-slug.3 | — |
  | R3 | <deferred item> | — | Deferred to fn-M-slug |
  EOF
@@ -315,14 +315,14 @@ Default to standard unless complexity demands more or less.
  **Requirement coverage rules:**
  - One row per acceptance criterion or distinct requirement from the spec
  - Every requirement must map to at least one task OR have a gap justification
- - Table goes at the bottom of the spec (after Acceptance + Early proof point)
+ - Table goes at the bottom of the spec (after Acceptance Criteria + Early proof point)
  - Keep Req IDs simple (R1, R2...) — they're local to this spec
 
  **R-ID rule (MANDATORY for new specs):**
  - Number acceptance criteria as `R1`, `R2`, `R3`, ... in creation order using the `- **Rn:** ...` prose prefix format shown in the template above.
  - Once a review cycle has run against an R-ID, **never renumber**. Reordering is fine (R1, R3, R5 after R2/R4 deletion is correct).
  - New criteria take the next unused number. Gaps are fine — do not compact.
- - R-IDs in `## Acceptance` and `## Requirement coverage` must match (same IDs, same meanings).
+ - R-IDs in `## Acceptance Criteria` and `## Requirement coverage` must match (same IDs, same meanings).
  - R-IDs are plain markdown prose, not YAML — the reviewer matches them via LLM reasoning, not strict parsing.
 
 4. Set spec dependencies (from spec-scout findings):
@@ -431,7 +431,7 @@ Default to standard unless complexity demands more or less.
  - Targets come from repo-scout/context-scout findings in Step 1
 
  **`satisfies` frontmatter rules (optional, additive):**
- - Populate `satisfies: [R1, R3]` only when the task obviously advances specific R-IDs from the spec's `## Acceptance` section.
+ - Populate `satisfies: [R1, R3]` only when the task obviously advances specific R-IDs from the spec's `## Acceptance Criteria` section.
  - Tasks that do infrastructure, refactoring, shared plumbing, or docs-only work may legitimately have **no** `satisfies` entry — omit the frontmatter entirely.
  - Use bare R-ID tokens (`[R1, R3]`), not quoted strings.
  - Frontmatter is additive — tasks created without it parse unchanged.

--- a/plugins/flow-next/scripts/flowctl.py
+++ b/plugins/flow-next/scripts/flowctl.py
@@ -3393,21 +3393,22 @@ If you notice genuine issues with content INSIDE these files (e.g., a spec that 
 #
 # Shared prompt block that instructs reviewers to emit a per-R-ID coverage table
 # whenever the epic spec numbers its acceptance criteria (`- **R1:** ...`). The
-# reviewer parses the heading in either `## Acceptance` or the legacy
-# `## Acceptance criteria` form (plan skill writes the former; older epic specs
-# may use the latter). Missing R-IDs flip the verdict to NEEDS_WORK unless the
-# spec marks the requirement deferred. The block is injected into impl-review
-# and epic-review (completion-review) prompts. Keep synchronized with the RP
-# workflow.md files.
+# reviewer parses the heading as `## Acceptance Criteria` (canonical since
+# 1.1.4 / fn-46-follow-up) and tolerates the legacy `## Acceptance` (plan
+# template pre-1.1.4) and `## Acceptance criteria` (older lowercase form)
+# variants for back-compat. Missing R-IDs flip the verdict to NEEDS_WORK
+# unless the spec marks the requirement deferred. The block is injected into
+# impl-review and epic-review (completion-review) prompts. Keep synchronized
+# with the RP workflow.md files.
 
 R_ID_COVERAGE_BLOCK = """## Requirements coverage (if spec has R-IDs)
 
 If the task or epic spec references an epic spec with numbered acceptance
 criteria like `- **R1:** ...`, `- **R2:** ...`, produce a per-R-ID coverage
-table. Read the epic spec's `## Acceptance` section (or the legacy
-`## Acceptance criteria` heading — reviewer MUST tolerate both). If no R-IDs
-are present anywhere, skip this block entirely — the rest of the review is
-unchanged.
+table. Read the epic spec's `## Acceptance Criteria` section (canonical;
+reviewer MUST also tolerate the legacy `## Acceptance` and `## Acceptance
+criteria` heading variants for back-compat). If no R-IDs are present
+anywhere, skip this block entirely — the rest of the review is unchanged.
 
 For each R-ID, classify status:
 
@@ -11903,10 +11904,12 @@ def _export_resolve_merge_base(base_ref: str) -> Optional[str]:
 def _export_parse_acceptance_criteria(spec_text: str) -> list[dict[str, Any]]:
     """Extract R-ID acceptance criteria from an epic spec.
 
-    Looks for the `## Acceptance Criteria` (or `## Acceptance criteria`)
-    section and parses bullets matching `- **R<N>:** <text>`. Source-tag
-    suffixes like `[user]` / `[paraphrase]` / `[inferred]` / `[strategy:track]`
-    are extracted into the `tag` field (last `[...]` token in the bullet).
+    Canonical heading is `## Acceptance Criteria` (since 1.1.4). For
+    back-compat, also tolerates `## Acceptance criteria` (older lowercase
+    form) and bare `## Acceptance` (plan template pre-1.1.4). Parses bullets
+    matching `- **R<N>:** <text>`. Source-tag suffixes like `[user]` /
+    `[paraphrase]` / `[inferred]` / `[strategy:track]` are extracted into
+    the `tag` field (last `[...]` token in the bullet).
 
     Returns list of `{"id": "R1", "text": "...", "tag": "..."}`. Empty list
     if no acceptance section or no R-IDs.
@@ -11914,9 +11917,9 @@ def _export_parse_acceptance_criteria(spec_text: str) -> list[dict[str, Any]]:
     if not spec_text:
         return []
 
-    # Find the section heading. Tolerate both casings.
+    # Find the section heading. Tolerate canonical + 2 legacy forms.
     heading_re = re.compile(
-        r"^##\s+Acceptance\s+[Cc]riteria\s*$",
+        r"^##\s+Acceptance(?:\s+[Cc]riteria)?\s*$",
         re.MULTILINE,
     )
     m = heading_re.search(spec_text)

--- a/plugins/flow-next/skills/flow-next-plan/steps.md
+++ b/plugins/flow-next/skills/flow-next-plan/steps.md
@@ -232,8 +232,8 @@ Default to standard unless complexity demands more or less.
    The canonical scaffold lives in [`plugins/flow-next/templates/spec.md`](../../templates/spec.md) — section list, scope-owner annotations, and the `## Decision Context` flat-vs-H3 conditional. At runtime the template is resolved via the 4-tier discovery cascade (first match wins): `<repo_root>/SPEC.md` → `<repo_root>/spec.md` → `.flow/templates/spec.md` → bundled `${PLUGIN_ROOT}/templates/spec.md`. The bundled file is the canonical source of truth; earlier tiers are user-customized overrides. Read the resolved template before authoring; never duplicate its section list inline. The plan skill extends that scaffold with the plan-specific sections shown below (Overview, Quick commands, Strategy Alignment, Strategy drift, Early proof point, Requirement coverage).
 
    ```bash
-   # Include: Overview, Scope, Approach, Quick commands (REQUIRED), Acceptance,
-   # Early proof point, Requirement coverage, References
+   # Include: Overview, Scope, Approach, Quick commands (REQUIRED),
+   # Acceptance Criteria, Early proof point, Requirement coverage, References
    # Conditional sections: ## Strategy Alignment (when STRATEGY_PRESENT=true from Step 1),
    # ## Strategy drift flagged for review (when plan scope conflicts with an active track)
    # Add mermaid diagram if data model or architecture changes
@@ -274,7 +274,7 @@ Default to standard unless complexity demands more or less.
    ## Decision context
    - <why this approach over alternatives>
 
-   ## Acceptance
+   ## Acceptance Criteria
    - **R1:** <testable criterion>
    - **R2:** <testable criterion>
    - **R3:** <testable criterion>
@@ -287,7 +287,7 @@ Default to standard unless complexity demands more or less.
 
    | Req | Description | Task(s) | Gap justification |
    |-----|-------------|---------|-------------------|
-   | R1  | <criterion from Acceptance> | fn-N-slug.1, fn-N-slug.2 | — |
+   | R1  | <criterion from Acceptance Criteria> | fn-N-slug.1, fn-N-slug.2 | — |
    | R2  | <another criterion> | fn-N-slug.3 | — |
    | R3  | <deferred item> | — | Deferred to fn-M-slug |
    EOF
@@ -314,14 +314,14 @@ Default to standard unless complexity demands more or less.
    **Requirement coverage rules:**
    - One row per acceptance criterion or distinct requirement from the spec
    - Every requirement must map to at least one task OR have a gap justification
-   - Table goes at the bottom of the spec (after Acceptance + Early proof point)
+   - Table goes at the bottom of the spec (after Acceptance Criteria + Early proof point)
    - Keep Req IDs simple (R1, R2...) — they're local to this spec
 
    **R-ID rule (MANDATORY for new specs):**
    - Number acceptance criteria as `R1`, `R2`, `R3`, ... in creation order using the `- **Rn:** ...` prose prefix format shown in the template above.
    - Once a review cycle has run against an R-ID, **never renumber**. Reordering is fine (R1, R3, R5 after R2/R4 deletion is correct).
    - New criteria take the next unused number. Gaps are fine — do not compact.
-   - R-IDs in `## Acceptance` and `## Requirement coverage` must match (same IDs, same meanings).
+   - R-IDs in `## Acceptance Criteria` and `## Requirement coverage` must match (same IDs, same meanings).
    - R-IDs are plain markdown prose, not YAML — the reviewer matches them via LLM reasoning, not strict parsing.
 
 4. Set spec dependencies (from spec-scout findings):
@@ -430,7 +430,7 @@ Default to standard unless complexity demands more or less.
    - Targets come from repo-scout/context-scout findings in Step 1
 
    **`satisfies` frontmatter rules (optional, additive):**
-   - Populate `satisfies: [R1, R3]` only when the task obviously advances specific R-IDs from the spec's `## Acceptance` section.
+   - Populate `satisfies: [R1, R3]` only when the task obviously advances specific R-IDs from the spec's `## Acceptance Criteria` section.
    - Tasks that do infrastructure, refactoring, shared plumbing, or docs-only work may legitimately have **no** `satisfies` entry — omit the frontmatter entirely.
    - Use bare R-ID tokens (`[R1, R3]`), not quoted strings.
    - Frontmatter is additive — tasks created without it parse unchanged.

--- a/plugins/flow-next/tests/test_acceptance_criteria_parser.py
+++ b/plugins/flow-next/tests/test_acceptance_criteria_parser.py
@@ -1,0 +1,74 @@
+"""Tests for `_export_parse_acceptance_criteria` heading tolerance.
+
+Canonical heading since 1.1.4 is `## Acceptance Criteria` (matches the
+canonical template at `plugins/flow-next/templates/spec.md`). The parser
+also tolerates two legacy forms for back-compat:
+
+- `## Acceptance` — plan-skill template pre-1.1.4 (and `flowctl spec
+  skeleton` output, locked by the R22 invariant).
+- `## Acceptance criteria` — older lowercase-criteria form.
+"""
+
+import unittest
+from pathlib import Path
+import sys
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPTS_DIR = REPO_ROOT / "plugins" / "flow-next" / "scripts"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+import flowctl  # noqa: E402  (path-injected import)
+
+
+_BODY_TEMPLATE = """# Spec Title
+
+## Goal & Context
+
+Some goal.
+
+{heading}
+
+- **R1:** First criterion. [user]
+- **R2:** Second criterion. [paraphrase]
+
+## Boundaries
+
+Some boundaries.
+"""
+
+
+class TestAcceptanceCriteriaHeadingTolerance(unittest.TestCase):
+    def _parse(self, heading: str) -> list[dict]:
+        return flowctl._export_parse_acceptance_criteria(
+            _BODY_TEMPLATE.format(heading=heading)
+        )
+
+    def test_canonical_heading_parses(self) -> None:
+        crits = self._parse("## Acceptance Criteria")
+        self.assertEqual([c["id"] for c in crits], ["R1", "R2"])
+
+    def test_legacy_acceptance_heading_parses(self) -> None:
+        """Plan template pre-1.1.4 / `flowctl spec skeleton` use `## Acceptance`."""
+        crits = self._parse("## Acceptance")
+        self.assertEqual([c["id"] for c in crits], ["R1", "R2"])
+
+    def test_legacy_lowercase_criteria_heading_parses(self) -> None:
+        """Older specs may use `## Acceptance criteria` (lowercase)."""
+        crits = self._parse("## Acceptance criteria")
+        self.assertEqual([c["id"] for c in crits], ["R1", "R2"])
+
+    def test_no_acceptance_section_returns_empty(self) -> None:
+        body = "# Spec\n\n## Goal\n\nText.\n\n## Boundaries\n\nText.\n"
+        self.assertEqual(flowctl._export_parse_acceptance_criteria(body), [])
+
+    def test_unrelated_section_with_acceptance_prefix_does_not_match(self) -> None:
+        """`## Acceptance Tests` (not Criteria) should NOT match — distinct concept."""
+        body = _BODY_TEMPLATE.format(heading="## Acceptance Tests")
+        # The R-IDs under "Acceptance Tests" must not leak through as accepted criteria.
+        self.assertEqual(flowctl._export_parse_acceptance_criteria(body), [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**Spec:** none (chore / patch bump) · **Branch:** `chore-acceptance-heading-1.1.4` → `main`

The follow-up flagged in #135 — the canonical scaffold at `plugins/flow-next/templates/spec.md` (fn-44 / 1.1.0+) uses `## Acceptance Criteria`, but `/flow-next:plan`'s heredoc template wrote `## Acceptance`. Plan-generated specs (e.g. fn-46 itself) shipped with a heading that `flowctl spec export-cognitive-aid` didn't recognize, returning empty `acceptance_criteria` for those specs.

## What changed

- **Plan template aligned to canonical.** `flow-next-plan/steps.md` heredoc + 4 prose references now write `## Acceptance Criteria`. `agents/plan-sync.md` inline reference updated.
- **Parser tolerates 3 heading forms.** `_export_parse_acceptance_criteria` regex relaxed: canonical `## Acceptance Criteria` (preferred), legacy `## Acceptance criteria` (older lowercase), legacy `## Acceptance` (plan template pre-1.1.4 + `flowctl spec skeleton` output). Rejects `## Acceptance Tests` (distinct concept).
- **R22 invariant honored.** `flowctl spec skeleton` and `prospect promote` CLI heredocs intentionally keep `## Acceptance` — R22 locks the spec-skeleton output byte-for-byte to the 1.0.2 baseline. Parser tolerance covers this transparently.
- **Reviewer prompt block updated.** Declares `## Acceptance Criteria` canonical; lists both legacy variants for back-compat.
- **No migration commit for existing specs.** 26 specs currently use `## Acceptance` — the parser tolerance covers them. Touching merged spec files purely for cosmetic heading alignment isn't worth the history churn.

## Tests

- 5 new tests in `plugins/flow-next/tests/test_acceptance_criteria_parser.py` lock all 3 heading forms; reject `## Acceptance Tests`.
- 612/612 unit tests + 130/130 smoke green.
- Sync clean + idempotent.
- R22 `TestR22E_SpecSkeletonByteForByte` still passes (skeleton untouched).

## Version bump

`./scripts/bump.sh patch flow-next` aligned 5 manifest surfaces 1.1.3 → 1.1.4.

---

*Patch bump; no spec / no R-IDs (small mechanical chore). Smoke + sync handle correctness.*