### PR TITLE
fix(flow-next): business interview no longer asks about deadlines — 1.1.5

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,13 +6,13 @@
   },
   "metadata": {
     "description": "Plan-first workflows for Claude Code and Factory Droid. Ships flow-next: zero-dep, spec-driven, Ralph autonomous mode.",
-    "version": "1.1.4"
+    "version": "1.1.5"
   },
   "plugins": [
     {
       "name": "flow-next",
       "description": "Zero-dependency planning + execution with .flow/ task tracking and Ralph autonomous mode (multi-model review gates). Worker subagent per task for context isolation. Includes 21 subagents, 19 commands, 23 skills.",
-      "version": "1.1.4",
+      "version": "1.1.5",
       "author": {
         "name": "Gordon Mickel",
         "email": "gordon@mickel.tech",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the flow-next.
 
+## [flow-next 1.1.5] - 2026-05-21
+
+### Fixed
+- **`/flow-next:interview --scope=business` no longer asks about deadlines, time budgets, or duration-based prioritization.** Agents can't estimate their own work, so the previous "Deadlines and what drives them" / "Cuts we'd accept to ship two weeks faster" / "engineering time" framing collapsed the interview into a cascade of brutal-prioritization follow-ups whenever the user mentioned any time pressure (e.g. answering "in 2 hours" to a deadline question would re-trigger MVP-Scope and What-NOT-to-Build re-asks from a time-pressure angle). Removed the time-bearing bullets from `questions-business.md` MVP Scope and Business Constraints; replaced with feature-value framing (concrete cuts the PO would accept if scope must shrink, infra/vendor/licensing budget envelope, external dependencies that must be honored). Added explicit guardrail to `questions-business.md` Business Constraints and to `SKILL.md` "NOT in scope" section: do not ask about deadlines / sprint cadence / "ship before X"; if the user volunteers a deadline in answer to another question, acknowledge it without cascading into prioritization re-asks. 5 manifest surfaces aligned at 1.1.5 via `scripts/bump.sh patch flow-next`.
+
 ## [flow-next 1.1.4] - 2026-05-20
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Flow-Next
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Flow-next](https://img.shields.io/badge/Flow--next-v1.1.4-green)](CHANGELOG.md)
+[![Flow-next](https://img.shields.io/badge/Flow--next-v1.1.5-green)](CHANGELOG.md)
 [![Docs](https://img.shields.io/badge/Docs-📖-informational)](plugins/flow-next/docs/README.md)
 
 [![Author](https://img.shields.io/badge/Author-Gordon_Mickel-orange)](https://mickel.tech)

--- a/plugins/flow-next/.claude-plugin/plugin.json
+++ b/plugins/flow-next/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "flow-next",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "Zero-dependency planning + execution with .flow/ task tracking and Ralph autonomous mode (multi-model review gates). Worker subagent per task for context isolation. Prime assesses 8 pillars (48 criteria) with GitHub API integration. Includes 21 subagents, 19 commands, 23 skills.",
   "author": {
     "name": "Gordon Mickel",

--- a/plugins/flow-next/.codex-plugin/plugin.json
+++ b/plugins/flow-next/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "flow-next",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "Zero-dependency planning + execution with .flow/ task tracking and Ralph autonomous mode. Worker subagent per task for context isolation. Compatible with Codex, Claude Code, and Factory Droid.",
   "author": {
     "name": "Gordon Mickel",

--- a/plugins/flow-next/codex/skills/flow-next-interview/SKILL.md
+++ b/plugins/flow-next/codex/skills/flow-next-interview/SKILL.md
@@ -606,6 +606,7 @@ Both banks share the `Pre-Question Taxonomy` and `Interview Guidelines` blocks, 
 - Task sizing (S/M/L)
 - Dependency ordering
 - Phased implementation details
+- **Time estimates, deadlines, durations, sprint cadence, "ship before X" framing.** Agents can't estimate their own work and shouldn't push the user into time-based prioritization debates. If the user volunteers a deadline in answer to another question, acknowledge it without cascading into MVP-Scope or What-NOT-to-Build re-asks driven by the time pressure.
 
 ## Write Refined Spec
 

--- a/plugins/flow-next/codex/skills/flow-next-interview/questions-business.md
+++ b/plugins/flow-next/codex/skills/flow-next-interview/questions-business.md
@@ -30,16 +30,18 @@ Ask NON-OBVIOUS questions only. Expect 40+ questions for complex specs.
 ## MVP Scope
 
 - Smallest version that proves the bet
-- Cuts we'd accept to ship two weeks faster
 - Path-from-MVP for the features we cut
 - Definition of "shippable" for this pass
+- Concrete cuts the PO would accept if scope must shrink (framed by feature value, NOT by time pressure)
 
 ## Business Constraints
 
 - Regulatory / compliance obligations (data residency, retention, audit)
-- Deadlines and what drives them
-- Budget envelope (engineering time, infra cost, vendor spend)
+- Budget envelope (infra cost, vendor spend, licensing) — NOT engineering time / duration
 - Brand / partner / contractual commitments
+- External dependencies that must be honored (third-party APIs, partner releases, regulatory windows)
+
+**Do NOT ask about deadlines, sprint cadence, hours/days/weeks budgets, or "ship before X" timing.** Agents can't estimate their own work, and time-pressure framing collapses the interview into prioritization debates. If the user volunteers a deadline, acknowledge it without chasing it through MVP-Scope and What-NOT-to-Build re-asks.
 
 ## What NOT to Build
 

--- a/plugins/flow-next/skills/flow-next-interview/SKILL.md
+++ b/plugins/flow-next/skills/flow-next-interview/SKILL.md
@@ -613,6 +613,7 @@ Both banks share the `Pre-Question Taxonomy` and `Interview Guidelines` blocks, 
 - Task sizing (S/M/L)
 - Dependency ordering
 - Phased implementation details
+- **Time estimates, deadlines, durations, sprint cadence, "ship before X" framing.** Agents can't estimate their own work and shouldn't push the user into time-based prioritization debates. If the user volunteers a deadline in answer to another question, acknowledge it without cascading into MVP-Scope or What-NOT-to-Build re-asks driven by the time pressure.
 
 ## Write Refined Spec
 

--- a/plugins/flow-next/skills/flow-next-interview/questions-business.md
+++ b/plugins/flow-next/skills/flow-next-interview/questions-business.md
@@ -30,16 +30,18 @@ Ask NON-OBVIOUS questions only. Expect 40+ questions for complex specs.
 ## MVP Scope
 
 - Smallest version that proves the bet
-- Cuts we'd accept to ship two weeks faster
 - Path-from-MVP for the features we cut
 - Definition of "shippable" for this pass
+- Concrete cuts the PO would accept if scope must shrink (framed by feature value, NOT by time pressure)
 
 ## Business Constraints
 
 - Regulatory / compliance obligations (data residency, retention, audit)
-- Deadlines and what drives them
-- Budget envelope (engineering time, infra cost, vendor spend)
+- Budget envelope (infra cost, vendor spend, licensing) — NOT engineering time / duration
 - Brand / partner / contractual commitments
+- External dependencies that must be honored (third-party APIs, partner releases, regulatory windows)
+
+**Do NOT ask about deadlines, sprint cadence, hours/days/weeks budgets, or "ship before X" timing.** Agents can't estimate their own work, and time-pressure framing collapses the interview into prioritization debates. If the user volunteers a deadline, acknowledge it without chasing it through MVP-Scope and What-NOT-to-Build re-asks.
 
 ## What NOT to Build
 


### PR DESCRIPTION
**Branch:** `chore-business-interview-no-time-1.1.5` → `main` · **Spec:** none (direct fix; small chore + version bump)

## Reported behavior

`/flow-next:interview --scope=business` asks _"Is there a deadline or session date this needs to land before?"_ → user answers _"in 2 hours"_ → interview cascades into _"brutal prioritization"_ + _"must-haves vs killable items"_ re-asks of MVP Scope and What-NOT-to-Build, driven by time pressure that agents can't actually estimate against.

## Root cause

Three time-bearing bullets in `questions-business.md`:

- `MVP Scope` → "Cuts we'd accept to ship two weeks faster"
- `Business Constraints` → "Deadlines and what drives them"
- `Business Constraints` → "Budget envelope (engineering time, infra cost, vendor spend)"

Once any of those gets a time-pressure answer, the agent treats the remaining dimensions through that lens.

## Fix

- **Remove** the two deadline/duration bullets from `questions-business.md`.
- **Reframe** budget envelope: drop "engineering time"; keep "infra cost, vendor spend, licensing".
- **Reframe** MVP Scope's "what to cut" question by feature value, not time pressure: _"Concrete cuts the PO would accept if scope must shrink (framed by feature value, NOT by time pressure)."_
- **Add explicit guardrail** in `questions-business.md` Business Constraints _and_ in `SKILL.md` "NOT in scope": _"Do not ask about deadlines / sprint cadence / 'ship before X'. Agents can't estimate their own work. If the user volunteers a deadline in answer to another question, acknowledge it without cascading into MVP-Scope or What-NOT-to-Build re-asks driven by the time pressure."_

Codex mirror regenerated via `sync-codex.sh`.

## Verification

- 612/612 unit + 130/130 smoke green
- Sync clean + idempotent
- All 5 manifest surfaces aligned at 1.1.5 via `scripts/bump.sh patch flow-next`

## Why a patch bump (not docs-only)

Skill prose + a question bank change the interview's interactive surface. Per CLAUDE.md: _"Bump version when skill / phase / agent / command files change (affects plugin behavior)."_ Pure CHANGELOG / docs-only changes wouldn't bump; this one does.