### PR TITLE
fix(flow-next): SE1 detects ruleset-based branch protection — 1.1.6

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,13 +6,13 @@
   },
   "metadata": {
     "description": "Plan-first workflows for Claude Code and Factory Droid. Ships flow-next: zero-dep, spec-driven, Ralph autonomous mode.",
-    "version": "1.1.5"
+    "version": "1.1.6"
   },
   "plugins": [
     {
       "name": "flow-next",
       "description": "Zero-dependency planning + execution with .flow/ task tracking and Ralph autonomous mode (multi-model review gates). Worker subagent per task for context isolation. Includes 21 subagents, 19 commands, 23 skills.",
-      "version": "1.1.5",
+      "version": "1.1.6",
       "author": {
         "name": "Gordon Mickel",
         "email": "gordon@mickel.tech",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the flow-next.
 
+## [flow-next 1.1.6] - 2026-05-21
+
+### Fixed
+- **`/flow-next:prime` SE1 (branch protection) now detects ruleset-based enforcement, not just classic branch protection.** Reported by Georg Keller (SEMA-CAD) — on GHE Enterprise, repo `main` was correctly protected via Enterprise-level rulesets (2 required reviews, Copilot review required, force-push / deletion blocked, GitFlow naming, file-path restrictions) but `agents/security-scout.md` only probed `GET /repos/{owner}/{repo}/branches/{branch}/protection` (legacy classic-protection endpoint) and treated the 404 as "not protected" — a false negative that surfaced as `SE1 ❌` in the Pillar 7 report and incorrectly recommended adding CODEOWNERS to enforce "Senior Developer" review. Scout now also probes `GET /repos/{owner}/{repo}/rules/branches/{branch}` (rulesets endpoint, covering repo / org / enterprise layers) and marks SE1 ✅ if EITHER endpoint returns enforcement (`pull_request`, `non_fast_forward`, `deletion`, `required_status_checks`, `required_linear_history`, `required_signatures`, `required_deployments`, or `code_scanning` rule types). Output template gains a `Mechanism: classic / rulesets / both` line + ruleset IDs when applicable. Pillar 7 (`pillars.md:151`) SE1 criterion updated to reflect both mechanisms. Classic branch protection is on GitHub's long-term deprecation path; rulesets are the canonical mechanism going forward.
+
 ## [flow-next 1.1.5] - 2026-05-21
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Flow-Next
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Flow-next](https://img.shields.io/badge/Flow--next-v1.1.5-green)](CHANGELOG.md)
+[![Flow-next](https://img.shields.io/badge/Flow--next-v1.1.6-green)](CHANGELOG.md)
 [![Docs](https://img.shields.io/badge/Docs-📖-informational)](plugins/flow-next/docs/README.md)
 
 [![Author](https://img.shields.io/badge/Author-Gordon_Mickel-orange)](https://mickel.tech)

--- a/plugins/flow-next/.claude-plugin/plugin.json
+++ b/plugins/flow-next/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "flow-next",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "description": "Zero-dependency planning + execution with .flow/ task tracking and Ralph autonomous mode (multi-model review gates). Worker subagent per task for context isolation. Prime assesses 8 pillars (48 criteria) with GitHub API integration. Includes 21 subagents, 19 commands, 23 skills.",
   "author": {
     "name": "Gordon Mickel",

--- a/plugins/flow-next/.codex-plugin/plugin.json
+++ b/plugins/flow-next/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "flow-next",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "description": "Zero-dependency planning + execution with .flow/ task tracking and Ralph autonomous mode. Worker subagent per task for context isolation. Compatible with Codex, Claude Code, and Factory Droid.",
   "author": {
     "name": "Gordon Mickel",

--- a/plugins/flow-next/agents/security-scout.md
+++ b/plugins/flow-next/agents/security-scout.md
@@ -16,14 +16,34 @@ Security configuration protects the codebase from accidental exposure and unauth
 
 ### Branch Protection (via GitHub API)
 
+GitHub protects branches via two independent mechanisms — **classic branch protection** and **rulesets** (introduced 2023; recommended by GitHub; classic on long-term deprecation path). Either path satisfies SE1; check BOTH before declaring "not protected".
+
 ```bash
 # Check if gh CLI is authenticated
 gh auth status 2>&1 | head -5
 
-# Check branch protection on main/master
+# 1. Classic branch protection (legacy endpoint)
 gh api /repos/{owner}/{repo}/branches/main/protection 2>&1 || \
 gh api /repos/{owner}/{repo}/branches/master/protection 2>&1
+
+# 2. Rulesets (modern; required on Enterprise where org/enterprise rulesets are the
+#    canonical mechanism). Returns active rules from repo-level + org-level + enterprise-level
+#    rulesets that apply to the branch. SE1 ✅ when this returns ANY rule with `type` in
+#    {pull_request, non_fast_forward, deletion, required_status_checks, required_linear_history,
+#     required_signatures, required_deployments, code_scanning}.
+gh api /repos/{owner}/{repo}/rules/branches/main 2>&1 || \
+gh api /repos/{owner}/{repo}/rules/branches/master 2>&1
 ```
+
+**SE1 verdict:**
+- ✅ if EITHER endpoint returns enforcement (classic protection JSON OR a non-empty ruleset rules array containing one of the enforcement types above).
+- ❌ only when BOTH endpoints return 404 / empty.
+- ⚠️ when `gh` is unauthenticated or the repo isn't on GitHub.
+
+**Report which mechanism is in effect** in the SE1 details line:
+- `classic` — legacy `branches/{branch}/protection`
+- `rulesets` — modern; cite ruleset IDs if available from the response (`ruleset_id` per rule)
+- `both` — rare but valid (classic + rulesets stacked)
 
 Note: Parse the repo owner/name from `git remote get-url origin` first.
 
@@ -85,7 +105,8 @@ grep -l "trivy\|grype\|anchore" .github/workflows/*.yml 2>/dev/null
 
 #### Branch Protection (SE1)
 - Status: ✅ Protected / ❌ Not protected / ⚠️ Unable to check
-- Details: [protection rules if available]
+- Mechanism: classic / rulesets / both — name which one(s) returned enforcement
+- Details: protection rules summary (PR reviews required, force-push blocked, deletion blocked, status checks required, etc.); cite ruleset IDs when applicable
 
 #### Secret Scanning (SE2)
 - Status: ✅ Enabled / ❌ Disabled

--- a/plugins/flow-next/codex/agents/security-scout.toml
+++ b/plugins/flow-next/codex/agents/security-scout.toml
@@ -16,14 +16,34 @@ Security configuration protects the codebase from accidental exposure and unauth
 
 ### Branch Protection (via GitHub API)
 
+GitHub protects branches via two independent mechanisms — **classic branch protection** and **rulesets** (introduced 2023; recommended by GitHub; classic on long-term deprecation path). Either path satisfies SE1; check BOTH before declaring "not protected".
+
 ```bash
 # Check if gh CLI is authenticated
 gh auth status 2>&1 | head -5
 
-# Check branch protection on main/master
+# 1. Classic branch protection (legacy endpoint)
 gh api /repos/{owner}/{repo}/branches/main/protection 2>&1 || \\
 gh api /repos/{owner}/{repo}/branches/master/protection 2>&1
+
+# 2. Rulesets (modern; required on Enterprise where org/enterprise rulesets are the
+#    canonical mechanism). Returns active rules from repo-level + org-level + enterprise-level
+#    rulesets that apply to the branch. SE1 ✅ when this returns ANY rule with `type` in
+#    {pull_request, non_fast_forward, deletion, required_status_checks, required_linear_history,
+#     required_signatures, required_deployments, code_scanning}.
+gh api /repos/{owner}/{repo}/rules/branches/main 2>&1 || \\
+gh api /repos/{owner}/{repo}/rules/branches/master 2>&1
 ```
+
+**SE1 verdict:**
+- ✅ if EITHER endpoint returns enforcement (classic protection JSON OR a non-empty ruleset rules array containing one of the enforcement types above).
+- ❌ only when BOTH endpoints return 404 / empty.
+- ⚠️ when `gh` is unauthenticated or the repo isn't on GitHub.
+
+**Report which mechanism is in effect** in the SE1 details line:
+- `classic` — legacy `branches/{branch}/protection`
+- `rulesets` — modern; cite ruleset IDs if available from the response (`ruleset_id` per rule)
+- `both` — rare but valid (classic + rulesets stacked)
 
 Note: Parse the repo owner/name from `git remote get-url origin` first.
 
@@ -85,7 +105,8 @@ grep -l "trivy\\|grype\\|anchore" .github/workflows/*.yml 2>/dev/null
 
 #### Branch Protection (SE1)
 - Status: ✅ Protected / ❌ Not protected / ⚠️ Unable to check
-- Details: [protection rules if available]
+- Mechanism: classic / rulesets / both — name which one(s) returned enforcement
+- Details: protection rules summary (PR reviews required, force-push blocked, deletion blocked, status checks required, etc.); cite ruleset IDs when applicable
 
 #### Secret Scanning (SE2)
 - Status: ✅ Enabled / ❌ Disabled

--- a/plugins/flow-next/codex/skills/flow-next-prime/pillars.md
+++ b/plugins/flow-next/codex/skills/flow-next-prime/pillars.md
@@ -148,7 +148,7 @@ Security posture and access controls.
 
 | ID | Criterion | Pass Condition |
 |----|-----------|----------------|
-| SE1 | Branch protection | Main/master branch protected (via `gh api`) |
+| SE1 | Branch protection | Main/master branch protected via classic branch protection OR rulesets (repo / org / enterprise level — any layer counts) |
 | SE2 | Secret scanning | GitHub secret scanning enabled |
 | SE3 | CODEOWNERS | .github/CODEOWNERS file exists |
 | SE4 | Dependency updates | Dependabot or Renovate configured |

--- a/plugins/flow-next/skills/flow-next-prime/pillars.md
+++ b/plugins/flow-next/skills/flow-next-prime/pillars.md
@@ -148,7 +148,7 @@ Security posture and access controls.
 
 | ID | Criterion | Pass Condition |
 |----|-----------|----------------|
-| SE1 | Branch protection | Main/master branch protected (via `gh api`) |
+| SE1 | Branch protection | Main/master branch protected via classic branch protection OR rulesets (repo / org / enterprise level — any layer counts) |
 | SE2 | Secret scanning | GitHub secret scanning enabled |
 | SE3 | CODEOWNERS | .github/CODEOWNERS file exists |
 | SE4 | Dependency updates | Dependabot or Renovate configured |


### PR DESCRIPTION
**Branch:** `chore-security-scout-rulesets-1.1.6` → `main` · **Spec:** none (direct fix; small chore + version bump)

## Reported

Georg Keller (SEMA-CAD) ran `/flow-next:prime` on an Enterprise GHE repo and got:

> `SE1 Branch protection ❌ — GET .../branches/main/protection → 404. CLAUDE.md policy forbids direct commits but there is no technical enforcement on GHE.`

…but `main` was correctly protected via Enterprise-level rulesets (2 required approving reviews, Copilot review required, force-push / deletion blocked, GitFlow naming, file-path restrictions). Classic protection was 404; rulesets enforcement was real but invisible to the scout.

## Root cause

`agents/security-scout.md` only probed `GET /repos/{owner}/{repo}/branches/{branch}/protection` (legacy classic-protection endpoint). Treated 404 as "not protected" → false-negative `SE1 ❌` → incorrect Pillar 7 finding + spurious CODEOWNERS recommendation.

Classic branch protection is on GitHub's long-term deprecation path. Rulesets (introduced 2023) are the canonical mechanism, especially on Enterprise where org / enterprise rulesets are typical.

## Fix

- Scout probes **both** endpoints: classic (`/branches/{branch}/protection`) AND rulesets (`/rules/branches/{branch}` — covers repo + org + enterprise layers).
- SE1 ✅ when **either** endpoint returns enforcement with rule types in `{pull_request, non_fast_forward, deletion, required_status_checks, required_linear_history, required_signatures, required_deployments, code_scanning}`.
- Output template gains `Mechanism: classic / rulesets / both` line + ruleset IDs when available from the response.
- `pillars.md:151` SE1 criterion updated: "Main/master branch protected via classic branch protection OR rulesets (repo / org / enterprise level — any layer counts)".

Codex mirror regenerated; SE1 ✅ now visible to both Claude and Codex `/flow-next:prime` runs.

## Verification

- 612/612 unit + 130/130 smoke green.
- Sync clean + idempotent.
- 5 manifest surfaces aligned at 1.1.6 via `scripts/bump.sh patch flow-next`.

## Credits

Reported and diagnosed by **Georg Keller** (System Architect, SEMA-CAD). His diagnosis cited the exact API endpoints + rule types + Enterprise ruleset IDs (98397, 98407, 98417, 406032) — the fix is a direct application.