### PR TITLE
docs(claude-md): add PR workflow rules — make-pr / resolve-pr discipline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,13 @@ flow-next is a first-class citizen on Claude Code, Codex, and Factory Droid. **A
 - Do not add extra commands / agents / skills unless explicitly requested.
 - For pure docs / agent_docs / README changes, do NOT bump the plugin version.
 
+## PR workflow
+
+- **PRs derived from a flow-next spec** → use `/flow-next:make-pr <spec-id>`. It generates a cognitive-aid PR body (R-ID coverage table, critical-changes summary, decision context, "where to look") from the spec export. Never hand-write a body when a spec exists — the skill carries discipline the manual version drifts away from.
+- **Chore PRs without a spec** (version bumps, small mechanical fixes, CHANGELOG-only changes, third-party-reported regressions) — write the body manually but match the make-pr structure: short summary + What changed + Verification + Version note (or "no version bump per CLAUDE.md docs-only rule" if applicable). Don't open bare-body PRs.
+- **Review feedback on any PR** → `/flow-next:resolve-pr` (auto-detects PR from current branch). Resolves threads via dispatched resolver agents, validates combined state, replies + resolves via GraphQL. Bounded at 2 fix-verify cycles before escalation.
+- **No direct `gh pr merge` from skills.** Merge is a human decision; do it explicitly when the PR is ready.
+
 ## flow-next.dev docs site
 
 - Marketing/docs site lives at `~/work/flow-next.dev` (`https://flow-next.dev`).


### PR DESCRIPTION
**Branch:** `chore-claude-md-pr-workflow` → `main` · **Spec:** none (CLAUDE.md-only docs edit; no plugin behavior change → no version bump per CLAUDE.md's own rule)

## What changed

New `## PR workflow` section in `CLAUDE.md` between Editing rules and flow-next.dev docs site. Codifies the discipline we've used through fn-45 / fn-46 / fn-47 / 1.1.4 / 1.1.5 / 1.1.6:

1. **PRs derived from a flow-next spec** → `/flow-next:make-pr <spec-id>`. Generates the cognitive-aid body (R-ID coverage, critical-changes, decision context, "where to look") from the spec export. The skill carries discipline manual bodies drift away from.
2. **Chore PRs without a spec** (version bumps, mechanical fixes, third-party regression reports like the SE1 ruleset fix in 1.1.6) → write the body manually but match the make-pr structure: TL;DR + What changed + Verification + Version note. No bare-body PRs.
3. **Review feedback on any PR** → `/flow-next:resolve-pr`. Bounded at 2 fix-verify cycles.
4. **No direct `gh pr merge` from skills.** Merge is a human decision.

## Why two-tier (recommended over "every PR has a spec")

Strict "every PR has a spec" would require `/flow-next:capture` for one-line chore fixes — ~5 min overhead per fix; cleaner R-ID history. The two-tier rule matches what we actually do without ceremony for trivial fixes.

## Verification

CLAUDE.md-only change. No tests, no sync, no manifest version bump. Just guidance for the next agent working in this repo.