### PR TITLE
fix(flow-next): strip request_user_input from codex mirror frontmatter — 1.1.7

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,13 +6,13 @@
   },
   "metadata": {
     "description": "Plan-first workflows for Claude Code and Factory Droid. Ships flow-next: zero-dep, spec-driven, Ralph autonomous mode.",
-    "version": "1.1.6"
+    "version": "1.1.7"
   },
   "plugins": [
     {
       "name": "flow-next",
       "description": "Zero-dependency planning + execution with .flow/ task tracking and Ralph autonomous mode (multi-model review gates). Worker subagent per task for context isolation. Includes 21 subagents, 19 commands, 23 skills.",
-      "version": "1.1.6",
+      "version": "1.1.7",
       "author": {
         "name": "Gordon Mickel",
         "email": "gordon@mickel.tech",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the flow-next.
 
+## [flow-next 1.1.7] - 2026-05-22
+
+### Fixed
+- **`request_user_input` no longer leaks into Codex mirror SKILL.md `allowed-tools:` frontmatter.** fn-45 (v1.1.2) rewrote canonical `AskUserQuestion` to plain-text numbered prompts in mirror prose, but the `allowed-tools:` frontmatter rewrite preserved the tool token on the assumption that Codex reads `agents/openai.yaml` for the contract and treats SKILL.md frontmatter as "harmless residue". In practice the agent reads the frontmatter, trusts the listed tools, and calls `request_user_input` — which errors in Default mode (openai/codex #10384, #11536, #12694), exactly the failure fn-45 was meant to eliminate. Symptom reproduced by a user running `/flow-next:make-pr` from a Codex Desktop Default-mode session: "Preview gate tool unavailable in Default mode". `sync-codex.sh` Stage 3 H now STRIPS `AskUserQuestion` from the mirror's `allowed-tools:` line (cleaning adjacent commas) instead of rewriting it; the R6 mirror-scan guard now also fails sync on any `^allowed-tools:.*\brequest_user_input\b` match so future regressions surface immediately. 6 affected mirror SKILL.md files cleaned: `flow-next-make-pr`, `flow-next-capture`, `flow-next-audit`, `flow-next-strategy`, `flow-next-memory-migrate`, `flow-next-prospect`.
+
 ## [flow-next 1.1.6] - 2026-05-21
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Flow-Next
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Flow-next](https://img.shields.io/badge/Flow--next-v1.1.6-green)](CHANGELOG.md)
+[![Flow-next](https://img.shields.io/badge/Flow--next-v1.1.7-green)](CHANGELOG.md)
 [![Docs](https://img.shields.io/badge/Docs-📖-informational)](plugins/flow-next/docs/README.md)
 
 [![Author](https://img.shields.io/badge/Author-Gordon_Mickel-orange)](https://mickel.tech)

--- a/plugins/flow-next/.claude-plugin/plugin.json
+++ b/plugins/flow-next/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "flow-next",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "description": "Zero-dependency planning + execution with .flow/ task tracking and Ralph autonomous mode (multi-model review gates). Worker subagent per task for context isolation. Prime assesses 8 pillars (48 criteria) with GitHub API integration. Includes 21 subagents, 19 commands, 23 skills.",
   "author": {
     "name": "Gordon Mickel",

--- a/plugins/flow-next/.codex-plugin/plugin.json
+++ b/plugins/flow-next/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "flow-next",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "description": "Zero-dependency planning + execution with .flow/ task tracking and Ralph autonomous mode. Worker subagent per task for context isolation. Compatible with Codex, Claude Code, and Factory Droid.",
   "author": {
     "name": "Gordon Mickel",

--- a/plugins/flow-next/codex/skills/flow-next-audit/SKILL.md
+++ b/plugins/flow-next/codex/skills/flow-next-audit/SKILL.md
@@ -2,7 +2,7 @@
 name: flow-next-audit
 description: Audit `.flow/memory/` entries against the current codebase and decide Keep / Update / Consolidate / Replace / Delete per entry. Triggers on /flow-next:audit, "audit memory", "review memory", "refresh learnings", "sweep stale memory", "consolidate overlapping memory entries". Optional `mode:autofix` token in arguments runs without questions and marks ambiguous as stale. Optional scope hint after the mode token (concept, category, module, or path) narrows what gets audited.
 user-invocable: false
-allowed-tools: request_user_input, Read, Bash, Grep, Glob, Write, Edit, Task
+allowed-tools: Read, Bash, Grep, Glob, Write, Edit, Task
 ---
 
 # /flow-next:audit — agent-native memory staleness review

--- a/plugins/flow-next/codex/skills/flow-next-capture/SKILL.md
+++ b/plugins/flow-next/codex/skills/flow-next-capture/SKILL.md
@@ -2,7 +2,7 @@
 name: flow-next-capture
 description: Synthesize the current conversation context into a flow-next spec at `.flow/specs/<spec-id>.md` via `flowctl spec create + spec set-plan` — agent-native, source-tagged, with mandatory read-back before write. Triggers on /flow-next:capture, "capture spec", "lock down what we discussed", "make a spec from this conversation", "convert conversation to spec". Optional `mode:autofix` token runs without questions and requires `--yes` to commit. Optional `--rewrite <spec-id>` overwrites an existing spec; `--from-compacted-ok` overrides the compaction-detection refusal; `--override-strategy` proceeds despite a contradiction with an active STRATEGY.md track (and prompts to record the override as a decision).
 user-invocable: false
-allowed-tools: request_user_input, Read, Bash, Grep, Glob, Write, Edit, Task
+allowed-tools: Read, Bash, Grep, Glob, Write, Edit, Task
 ---
 
 # /flow-next:capture — agent-native conversation → spec

--- a/plugins/flow-next/codex/skills/flow-next-make-pr/SKILL.md
+++ b/plugins/flow-next/codex/skills/flow-next-make-pr/SKILL.md
@@ -2,7 +2,7 @@
 name: flow-next-make-pr
 description: Render a cognitive-aid PR body from flow-next state and open via gh. Triggers on /flow-next:make-pr with optional spec id and flags (--draft, --ready, --no-mermaid, --base <ref>, --memory, --dry-run). Auto-detects spec from current branch when no id given. NOT Ralph-blocked — autonomous loops can surface a draft PR for human review.
 user-invocable: false
-allowed-tools: request_user_input, Read, Bash, Grep, Glob, Write, Edit, Task
+allowed-tools: Read, Bash, Grep, Glob, Write, Edit, Task
 ---
 
 # /flow-next:make-pr — PR-as-cognitive-aid

--- a/plugins/flow-next/codex/skills/flow-next-memory-migrate/SKILL.md
+++ b/plugins/flow-next/codex/skills/flow-next-memory-migrate/SKILL.md
@@ -2,7 +2,7 @@
 name: flow-next-memory-migrate
 description: Migrate pre-fn-30 legacy flat memory files (`.flow/memory/pitfalls.md`, `conventions.md`, `decisions.md`) into the categorized YAML schema. Triggers on /flow-next:memory-migrate, "migrate memory", "convert legacy memory", "lift pitfalls into categorized schema", "convert old memory format". Optional `mode:autofix` token in arguments runs without questions and accepts mechanical defaults for ambiguous classifications. Optional scope hint after the mode token narrows the migration to a specific legacy file (e.g. `pitfalls.md`).
 user-invocable: false
-allowed-tools: request_user_input, Read, Bash, Grep, Glob, Write, Edit, Task
+allowed-tools: Read, Bash, Grep, Glob, Write, Edit, Task
 ---
 
 # /flow-next:memory-migrate — agent-native legacy migration

--- a/plugins/flow-next/codex/skills/flow-next-prospect/SKILL.md
+++ b/plugins/flow-next/codex/skills/flow-next-prospect/SKILL.md
@@ -2,7 +2,7 @@
 name: flow-next-prospect
 description: Generate ranked candidate ideas grounded in the repo, upstream of /flow-next:plan. Triggers on /flow-next:prospect with an optional focus hint (concept, path, constraint, or volume).
 user-invocable: false
-allowed-tools: request_user_input, Read, Bash, Grep, Glob, Write, Edit, Task
+allowed-tools: Read, Bash, Grep, Glob, Write, Edit, Task
 ---
 
 # Prospect — upstream-of-plan idea generation

--- a/plugins/flow-next/codex/skills/flow-next-strategy/SKILL.md
+++ b/plugins/flow-next/codex/skills/flow-next-strategy/SKILL.md
@@ -2,7 +2,7 @@
 name: flow-next-strategy
 description: "Create or maintain `STRATEGY.md` — the product's target problem, our approach, who it's for, key metrics, and tracks of work. Use when starting a new product, updating direction, or when prompts like 'write our strategy', 'update the roadmap', 'what are we working on', or 'set up the strategy doc' come up. Also fires when `/flow-next:prospect`, `/flow-next:plan`, `/flow-next:interview`, or `/flow-next:capture` need upstream grounding and no strategy doc exists yet."
 user-invocable: false
-allowed-tools: request_user_input, Read, Write, Bash
+allowed-tools: Read, Write, Bash
 ---
 
 # /flow-next:strategy — repo-root STRATEGY.md anchor

--- a/scripts/sync-codex.sh
+++ b/scripts/sync-codex.sh
@@ -620,12 +620,29 @@ text = re.sub(
     text,
 )
 
-# H. Frontmatter `allowed-tools: AskUserQuestion, ...` — keep the legacy
-#    token name for the harmless residue line; Codex reads
-#    agents/openai.yaml for the actual contract.
+# H. Frontmatter `allowed-tools: AskUserQuestion, ...` — STRIP the token
+#    entirely from the mirror. fn-45 originally rewrote it to
+#    `request_user_input` on the assumption that Codex reads
+#    `agents/openai.yaml` for the tool contract and treats SKILL.md
+#    frontmatter as harmless residue. In practice the agent reads
+#    SKILL.md frontmatter, trusts the listed tools, and calls
+#    `request_user_input` — which errors out in Default mode
+#    (openai/codex #10384, #11536, #12694). Stripping the token leaves
+#    only tools the mirror actually uses. Clean up any leading comma or
+#    trailing comma left behind so the list stays well-formed.
+def _strip_aukq(match):
+    head = match.group(1)
+    rest = match.group(2)
+    # Drop the token AND a trailing ", " if present; else drop a leading
+    # ", " if it was the last item.
+    if rest.startswith(', '):
+        return head + rest[2:]
+    if head.endswith(', '):
+        return head[:-2] + rest
+    return head + rest
 text = re.sub(
-    r'^(allowed-tools:[^\n]*?)\bAskUserQuestion\b',
-    r'\1request_user_input',
+    r'^(allowed-tools:[^\n]*?)\bAskUserQuestion\b(.*)$',
+    _strip_aukq,
     text,
     flags=re.MULTILINE,
 )
@@ -1396,14 +1413,16 @@ fi
 # calls (openai/codex #10384, #11536, #12694). Stage 3 instructs the agent to
 # render a plain-text numbered prompt instead; any surviving reference is a
 # sync bug that would re-introduce the failure. Exclude /templates/ subdirs.
-# Patterns: backticked invocation, "tool" form, function-call form, and the
-# two hard-mandate phrasings that survived the old `request_user_input`
-# rewrite era. The frontmatter `allowed-tools: request_user_input` line is
-# harmless residue and does not match any of these patterns.
-rui_refs=$( { grep -rnE '`request_user_input`|request_user_input tool|request_user_input\(|MUST use `request_user_input`|ONLY ask via `request_user_input`' "$CODEX_DIR/skills/" 2>/dev/null || true; } | { grep -v '/templates/' || true; } | wc -l | tr -d ' ')
+# Patterns: backticked invocation, "tool" form, function-call form, the two
+# hard-mandate phrasings that survived the old `request_user_input` rewrite
+# era, AND `allowed-tools:` frontmatter listings (v1.1.7 — fn-45 originally
+# exempted these as "harmless residue", but agents trust the frontmatter
+# tool list and call the unavailable tool).
+RUI_PATTERN='`request_user_input`|request_user_input tool|request_user_input\(|MUST use `request_user_input`|ONLY ask via `request_user_input`|^allowed-tools:.*\brequest_user_input\b'
+rui_refs=$( { grep -rnE "$RUI_PATTERN" "$CODEX_DIR/skills/" 2>/dev/null || true; } | { grep -v '/templates/' || true; } | wc -l | tr -d ' ')
 if [ "$rui_refs" != "0" ]; then
   echo -e "  ${RED}✗${NC} $rui_refs request_user_input refs leaked into codex skill prose — Stage 3 (fn-45) should have rewritten these"
-  { grep -rnE '`request_user_input`|request_user_input tool|request_user_input\(|MUST use `request_user_input`|ONLY ask via `request_user_input`' "$CODEX_DIR/skills/" 2>/dev/null || true; } | { grep -v '/templates/' || true; } | head -10
+  { grep -rnE "$RUI_PATTERN" "$CODEX_DIR/skills/" 2>/dev/null || true; } | { grep -v '/templates/' || true; } | head -10
   errors=$((errors + 1))
 else
   echo -e "  ${GREEN}✓${NC} No request_user_input refs in Codex skill prose"


### PR DESCRIPTION
## Summary

fn-45 (v1.1.2) rewrote canonical `AskUserQuestion` to plain-text numbered prompts in mirror prose but left the token in 6 SKILL.md `allowed-tools:` frontmatter lines as "harmless residue". Codex agents read SKILL.md frontmatter, trust the listed tools, and call `request_user_input` — which errors in Default mode (openai/codex #10384, #11536, #12694), exactly the failure fn-45 was meant to eliminate.

Reproduced symptom (user-reported, Codex Desktop Default-mode `/flow-next:make-pr`): _"Preview gate tool unavailable in Default mode"_.

## What changed

- **`scripts/sync-codex.sh` Stage 3 H** — was `AskUserQuestion → request_user_input` on `allowed-tools:` lines. Now STRIPS the token entirely + cleans adjacent commas so the list stays well-formed.
- **R6 guard tightened** — `rui_refs` pattern now also matches `^allowed-tools:.*\brequest_user_input\b`, so any future regression fails sync immediately.
- **6 mirror SKILL.md files regenerated** — `flow-next-make-pr`, `flow-next-capture`, `flow-next-audit`, `flow-next-strategy`, `flow-next-memory-migrate`, `flow-next-prospect`. All `allowed-tools:` lines now list only tools the mirror actually uses (Read, Bash, Grep, Glob, Write, Edit, Task).
- **Bump 1.1.6 → 1.1.7** via `scripts/bump.sh patch flow-next`. CHANGELOG entry added.

## Verification

- `bash scripts/sync-codex.sh` → clean (all 17 validation checks pass, including the tightened R6 guard).
- `grep '^allowed-tools:' plugins/flow-next/codex/skills/*/SKILL.md` → zero `request_user_input` matches.
- Canonical SKILL.md files unchanged (still carry `AskUserQuestion` for Claude).

## Where to look

- `scripts/sync-codex.sh:623-642` — Stage 3 H strip-not-rewrite logic.
- `scripts/sync-codex.sh:1394-1413` — R6 guard pattern.
- `CHANGELOG.md` — full rationale + 6-file list.

## Test plan

- [x] sync regen produces zero `request_user_input` matches in mirror frontmatter
- [x] All 24 skills + 21 agents validate clean
- [x] CHANGELOG entry written