### PR TITLE
fix(flow-next): Windows+Copilot argv-cap guard — 1.1.8

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,13 +6,13 @@
   },
   "metadata": {
     "description": "Plan-first workflows for Claude Code and Factory Droid. Ships flow-next: zero-dep, spec-driven, Ralph autonomous mode.",
-    "version": "1.1.7"
+    "version": "1.1.8"
   },
   "plugins": [
     {
       "name": "flow-next",
       "description": "Zero-dependency planning + execution with .flow/ task tracking and Ralph autonomous mode (multi-model review gates). Worker subagent per task for context isolation. Includes 21 subagents, 19 commands, 23 skills.",
-      "version": "1.1.7",
+      "version": "1.1.8",
       "author": {
         "name": "Gordon Mickel",
         "email": "gordon@mickel.tech",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to the flow-next.
 
+## [flow-next 1.1.8] - 2026-05-22
+
+### Fixed
+- **`flowctl copilot {impl,plan,completion}-review` now fails fast on Windows with an actionable error instead of an opaque `OSError winerror 206`.** Reported by Simon Flauger (SEMA-CAD) — spec-sized review prompts on native Windows + Copilot review backend deterministically blow the Windows `CreateProcessW` 32,767-char command-line cap. Copilot CLI (1.0.51 as of today) offers no `--prompt-file` / `@file` / stdin prompt delivery path, so flow-next has no way to stage the prompt off argv on Windows. The temp-file staging in `run_copilot_exec` is a hygiene scratch buffer, not an alternate delivery — it still reads the file back into argv. New `_copilot_windows_argv_too_long` guard (pure helper) projects the command-line length before `subprocess.run`, and on overflow returns the same `("", session_id, 2, msg)` tuple as the timeout path so callers surface a clean `copilot -p failed: ...` with the actual sizes, the Copilot-CLI cause, and the WSL workaround pointer. macOS / Linux / WSL hosts are unaffected. Tests in `tests/test_copilot_windows_argv_guard.py`.
+
+### Documentation
+- New `docs/troubleshooting.md` section "Copilot review backend fails on Windows" + `docs/platforms.md` section "Windows + Copilot review backend (limitation)" — both explain the cap, the Copilot-CLI cause, and point at WSL as the workaround.
+
+### Upstream
+- Filed a Windows-specific data point on [github/copilot-cli#3398](https://github.com/github/copilot-cli/issues/3398) ("Add a `--prompt-file <path>` flag") requesting first-class off-argv prompt delivery so this stops being a workaround. The real fix lives upstream.
+
 ## [flow-next 1.1.7] - 2026-05-22
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Flow-Next
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Flow-next](https://img.shields.io/badge/Flow--next-v1.1.7-green)](CHANGELOG.md)
+[![Flow-next](https://img.shields.io/badge/Flow--next-v1.1.8-green)](CHANGELOG.md)
 [![Docs](https://img.shields.io/badge/Docs-📖-informational)](plugins/flow-next/docs/README.md)
 
 [![Author](https://img.shields.io/badge/Author-Gordon_Mickel-orange)](https://mickel.tech)

--- a/plugins/flow-next/.claude-plugin/plugin.json
+++ b/plugins/flow-next/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "flow-next",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "description": "Zero-dependency planning + execution with .flow/ task tracking and Ralph autonomous mode (multi-model review gates). Worker subagent per task for context isolation. Prime assesses 8 pillars (48 criteria) with GitHub API integration. Includes 21 subagents, 19 commands, 23 skills.",
   "author": {
     "name": "Gordon Mickel",

--- a/plugins/flow-next/.codex-plugin/plugin.json
+++ b/plugins/flow-next/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "flow-next",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "description": "Zero-dependency planning + execution with .flow/ task tracking and Ralph autonomous mode. Worker subagent per task for context isolation. Compatible with Codex, Claude Code, and Factory Droid.",
   "author": {
     "name": "Gordon Mickel",

--- a/plugins/flow-next/docs/platforms.md
+++ b/plugins/flow-next/docs/platforms.md
@@ -141,6 +141,18 @@ chmod +x .flow/bin/flowctl
 - `claude-md-scout` is auto-renamed to `agents-md-scout` (CLAUDE.md → AGENTS.md patching).
 - Global install prompts (`/prompts:*`) are global-only (`~/.codex/prompts/`); native plugin avoids this limitation.
 
+## Windows + Copilot review backend (limitation)
+
+When you configure `review.backend = copilot` and run flowctl from native Windows (PowerShell / cmd.exe / Git Bash), spec-sized reviews fail with a "command line too long" error from flowctl 1.1.8+. This is a Windows + Copilot CLI interaction, not a flow-next bug:
+
+- Windows `CreateProcessW` caps `lpCommandLine` at 32,767 chars.
+- Copilot CLI's prompt delivery is argv-only — no `--prompt-file`, no `@file`, no stdin (verified through Copilot CLI 1.0.51).
+- Spec-driven review prompts routinely exceed the cap; flow-next has no off-argv path to give Copilot.
+
+**Workaround:** run flowctl from WSL. The Linux argv limit (~2 MB) absorbs spec-sized prompts. Copilot CLI runs unmodified inside WSL.
+
+All other platforms (macOS, Linux, WSL on Windows) are unaffected. Codex and Claude review backends use different delivery paths and are unaffected on every host. See [`troubleshooting.md`](troubleshooting.md#copilot-review-backend-fails-on-windows-with-command-line-too-long) for the full error message + diagnostic.
+
 ## Community ports and inspired projects
 
 | Project | Platform | Notes |

--- a/plugins/flow-next/docs/troubleshooting.md
+++ b/plugins/flow-next/docs/troubleshooting.md
@@ -72,6 +72,26 @@ Flow-Next's plan-review and impl-review skills include specific instructions for
 
 **Fix:** Remove or comment out custom rp-cli instructions from your `CLAUDE.md`/`AGENTS.md` when using Flow-Next reviews. The plugin provides complete rp-cli guidance.
 
+## Copilot review backend fails on Windows with "command line too long"
+
+> **Caution**: Copilot CLI on Windows cannot accept spec-sized review prompts. WSL is the only known workaround.
+
+Spec-driven `flowctl copilot impl-review` / `plan-review` / `completion-review` calls on native Windows fail with a clean error from flow-next 1.1.8+:
+
+```
+copilot -p failed: Copilot review cannot run on Windows: projected command
+line is 53,210 chars (prompt alone is 51,847 chars), exceeding the Windows
+CreateProcessW cap of 32,767 chars. ...
+```
+
+**Root cause:** Windows `CreateProcessW` caps the full command line at 32,767 chars. Copilot CLI (1.0.51 as of 2026-05) offers no off-argv prompt delivery — no `--prompt-file`, no `@file`, no stdin — so flow-next must pass the full review prompt through `-p "<text>"`. Spec-sized prompts blow the cap. The temp-file staging in `run_copilot_exec` is a hygiene scratch buffer, not an alternate delivery path.
+
+**Pre-1.1.8 symptom:** the same condition surfaced as an opaque `OSError winerror 206` or `[WinError 206] The filename or extension is too long`.
+
+**Workaround:** Run flowctl from WSL. The Linux argv limit (~2 MB) absorbs spec-sized prompts comfortably. Copilot CLI runs unmodified inside WSL.
+
+**Permanent fix:** lives in Copilot CLI upstream — tracking [github/copilot-cli#3398](https://github.com/github/copilot-cli/issues/3398) (request for first-class `--prompt-file` support).
+
 ## Uninstall
 
 Run manually in terminal (DCG blocks these from AI agents):

--- a/plugins/flow-next/scripts/flowctl.py
+++ b/plugins/flow-next/scripts/flowctl.py
@@ -3180,6 +3180,56 @@ def get_copilot_version() -> Optional[str]:
 # uniformly so behaviour is deterministic across platforms.
 COPILOT_ARGV_PROMPT_MAX = 30000
 
+# Windows CreateProcessW lpCommandLine hard cap (UTF-16 code units). Hitting
+# this surfaces as OSError winerror 206 ("the filename or extension is too
+# long"). Copilot CLI offers no off-argv prompt delivery
+# (no --prompt-file, no @file, no stdin — verified through 1.0.51), so
+# spec-sized review prompts on Windows deterministically blow this cap.
+WINDOWS_CMDLINE_CAP_CHARS = 32767
+# Reserve room for subprocess argv quoting / separators and future non-prompt
+# arg growth. Subprocess on Windows escapes each arg via list2cmdline; the
+# overhead is small but non-zero. 512 chars is more than the current
+# non-prompt argv contributes (≈ 200 chars at typical paths) with comfortable
+# headroom.
+WINDOWS_CMDLINE_SAFETY_MARGIN = 512
+
+
+def _copilot_windows_argv_too_long(cmd: list) -> Optional[str]:
+    """Detect when a Copilot invocation would exceed the Windows argv cap.
+
+    Returns ``None`` on non-Windows hosts or when the projected command line
+    fits within ``WINDOWS_CMDLINE_CAP_CHARS - WINDOWS_CMDLINE_SAFETY_MARGIN``.
+    Otherwise returns an actionable error message naming the cap, the
+    Copilot CLI limitation that forces argv delivery, and the WSL
+    workaround.
+
+    Pure / side-effect-free so it can be unit-tested without spawning copilot
+    or touching the filesystem. Caller is responsible for cleaning up any
+    temp prompt file before returning the error.
+    """
+    if sys.platform != "win32":
+        return None
+    # Subprocess on Windows joins argv via list2cmdline (quotes each arg,
+    # space-separates). A tight upper bound that doesn't depend on
+    # subprocess internals: per-arg = len(arg) + 2 quotes + 1 separator.
+    projected = sum(len(arg) + 3 for arg in cmd)
+    budget = WINDOWS_CMDLINE_CAP_CHARS - WINDOWS_CMDLINE_SAFETY_MARGIN
+    if projected < budget:
+        return None
+    # Identify the prompt-sized arg for the user-facing message.
+    prompt_len = max((len(arg) for arg in cmd), default=0)
+    return (
+        f"Copilot review cannot run on Windows: projected command line is "
+        f"{projected:,} chars (prompt alone is {prompt_len:,} chars), "
+        f"exceeding the Windows CreateProcessW cap of "
+        f"{WINDOWS_CMDLINE_CAP_CHARS:,} chars. Copilot CLI offers no "
+        f"--prompt-file / @file / stdin delivery path, so flow-next cannot "
+        f"stage spec-sized review prompts off the command line on Windows.\n"
+        f"\n"
+        f"Workaround: run flowctl from WSL (Linux argv cap ~2 MB). The "
+        f"upstream fix needs --prompt-file or stdin support in Copilot CLI."
+    )
+
 
 def run_copilot_exec(
     prompt: str,
@@ -3265,6 +3315,19 @@ def run_copilot_exec(
     # is the hot path. GPT-5.x models accept --effort.
     if not effective_model.startswith("claude-"):
         cmd += ["--effort", effective_effort]
+
+    # Windows argv-cap guard (1.1.8). Failing here returns the same
+    # ("", session_id, 2, msg) shape as the timeout branch, so callers
+    # surface a clean "copilot -p failed: <message>" instead of an opaque
+    # OSError winerror 206. No-op on macOS / Linux / WSL.
+    cmdline_error = _copilot_windows_argv_too_long(cmd)
+    if cmdline_error is not None:
+        if tmp_prompt_path is not None:
+            try:
+                tmp_prompt_path.unlink(missing_ok=True)
+            except OSError:
+                pass
+        return "", session_id, 2, cmdline_error
 
     try:
         try:

--- a/plugins/flow-next/tests/test_copilot_windows_argv_guard.py
+++ b/plugins/flow-next/tests/test_copilot_windows_argv_guard.py
@@ -1,0 +1,121 @@
+"""Tests for `_copilot_windows_argv_too_long` (1.1.8).
+
+Windows CreateProcessW caps lpCommandLine at 32767 chars. Copilot CLI
+delivers the prompt only via argv (no --prompt-file / @file / stdin),
+so spec-sized review prompts on Windows hit the cap. The guard returns
+an actionable error message; callers handle it like any other Copilot
+failure (exit_code 2 + clean error_exit).
+
+Pure helper — these tests don't spawn copilot or touch the filesystem.
+"""
+
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPTS_DIR = REPO_ROOT / "plugins" / "flow-next" / "scripts"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+import flowctl  # noqa: E402
+
+
+# A minimal-but-realistic argv shape. The non-prompt args contribute
+# ~150 chars at typical paths; the prompt arg dominates.
+_FIXED_ARGS = [
+    "/opt/homebrew/bin/copilot",
+    "-p",
+    # prompt placeholder — tests rewrite this
+    "",
+    "--resume=00000000-0000-0000-0000-000000000000",
+    "--output-format",
+    "text",
+    "-s",
+    "--no-ask-user",
+    "--allow-all-tools",
+    "--add-dir",
+    "/Users/gordon/repo",
+    "--disable-builtin-mcps",
+    "--no-custom-instructions",
+    "--log-level",
+    "error",
+    "--no-auto-update",
+    "--model",
+    "claude-opus-4.5",
+]
+
+
+def _cmd_with_prompt(n: int) -> list:
+    cmd = list(_FIXED_ARGS)
+    cmd[2] = "x" * n
+    return cmd
+
+
+class CopilotWindowsArgvGuard(unittest.TestCase):
+
+    def test_non_windows_returns_none_even_when_huge(self):
+        # On macOS / Linux the guard is a no-op even for absurd prompts.
+        for platform in ("darwin", "linux", "linux2"):
+            with self.subTest(platform=platform), \
+                    mock.patch.object(sys, "platform", platform):
+                # 200 KB prompt — would crash Windows, fine elsewhere.
+                self.assertIsNone(
+                    flowctl._copilot_windows_argv_too_long(
+                        _cmd_with_prompt(200_000)
+                    )
+                )
+
+    def test_windows_under_cap_returns_none(self):
+        # Small prompt — well under the 32767 cap.
+        with mock.patch.object(sys, "platform", "win32"):
+            self.assertIsNone(
+                flowctl._copilot_windows_argv_too_long(
+                    _cmd_with_prompt(1_000)
+                )
+            )
+
+    def test_windows_over_cap_returns_actionable_message(self):
+        # 40 KB prompt — comfortably over the 32767 cap.
+        with mock.patch.object(sys, "platform", "win32"):
+            msg = flowctl._copilot_windows_argv_too_long(
+                _cmd_with_prompt(40_000)
+            )
+        self.assertIsNotNone(msg)
+        # Message must surface: the actual cap, the Copilot-CLI cause,
+        # the WSL workaround. These are the three things the operator
+        # needs to know to recover or escalate.
+        self.assertIn("32,767", msg)
+        self.assertIn("Copilot CLI offers no", msg)
+        self.assertIn("WSL", msg)
+        # Sanity: actual lengths surface for diagnosability.
+        self.assertIn("40,000", msg)
+
+    def test_windows_just_at_boundary(self):
+        # Prompt sized so projected ≈ cap - margin should trip; margin - 1
+        # below should be clean. Use a synthetic cmd with only the prompt
+        # arg to make the math obvious.
+        with mock.patch.object(sys, "platform", "win32"):
+            budget = (
+                flowctl.WINDOWS_CMDLINE_CAP_CHARS
+                - flowctl.WINDOWS_CMDLINE_SAFETY_MARGIN
+            )
+            # Per-arg overhead is 3 chars (2 quotes + 1 separator). With a
+            # single arg, projected = len + 3.
+            self.assertIsNone(
+                flowctl._copilot_windows_argv_too_long(["x" * (budget - 10)])
+            )
+            self.assertIsNotNone(
+                flowctl._copilot_windows_argv_too_long(["x" * (budget + 10)])
+            )
+
+    def test_empty_cmd_returns_none(self):
+        # Defensive: an empty cmd list shouldn't raise even on Windows.
+        with mock.patch.object(sys, "platform", "win32"):
+            self.assertIsNone(flowctl._copilot_windows_argv_too_long([]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Reported by Simon Flauger (SEMA-CAD): `flowctl copilot {impl,plan,completion}-review` fails on native Windows for spec-sized prompts with an opaque `OSError winerror 206`. Windows `CreateProcessW` caps `lpCommandLine` at 32,767 chars; Copilot CLI (1.0.51) offers no `--prompt-file` / `@file` / stdin delivery path, so flow-next has no way to stage the prompt off argv on Windows.

The real fix lives upstream — commented on [github/copilot-cli#3398](https://github.com/github/copilot-cli/issues/3398) with the Windows data point. On our side, narrow-scope guard so users get a clean WSL-pointer error instead of a cryptic OSError.

## What changed

- **`scripts/flowctl.py`** — new `_copilot_windows_argv_too_long` pure helper. `sys.platform == "win32"` AND projected cmdline ≥ 32767-512 chars → returns actionable error string (cap, cause, WSL workaround). Wired into `run_copilot_exec` after the `cmd` is built; on hit, cleans up the temp prompt file and returns `("", session_id, 2, msg)` — same shape as the timeout branch, so existing callers' `error_exit(...)` path surfaces a clean `copilot -p failed: <msg>`.
- **`tests/test_copilot_windows_argv_guard.py`** — 5 tests covering: non-Windows always None, Windows under-cap None, Windows over-cap actionable message, boundary, empty cmd.
- **`docs/troubleshooting.md`** — new section "Copilot review backend fails on Windows" with the full error + WSL workaround + upstream issue link.
- **`docs/platforms.md`** — new section "Windows + Copilot review backend (limitation)" in the platforms matrix narrative.
- **Bump 1.1.7 → 1.1.8** via `scripts/bump.sh`. CHANGELOG entry with Simon's report attribution.

## Verification

- `python3 -m unittest discover plugins/flow-next/tests -q` → 617 tests pass.
- New 5 tests for the guard pass cleanly.
- `bash scripts/sync-codex.sh` → all 17 validation checks pass.
- macOS / Linux / WSL hosts unaffected (the helper short-circuits on `sys.platform != "win32"`).

## Where to look

- `plugins/flow-next/scripts/flowctl.py:3181-3236` — constants + helper.
- `plugins/flow-next/scripts/flowctl.py:3322-3334` — wire-in site in `run_copilot_exec`.
- `plugins/flow-next/tests/test_copilot_windows_argv_guard.py` — coverage.
- `CHANGELOG.md` — rationale + upstream tracking link.

## Test plan

- [x] 617 tests pass (5 new)
- [x] Codex mirror sync clean
- [x] Upstream issue commented
- [x] docs + platforms updated