### PR TITLE
fix(flow-next): promote .flow/usage.md to canonical template — 1.1.10

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,13 +6,13 @@
   },
   "metadata": {
     "description": "Plan-first workflows for Claude Code and Factory Droid. Ships flow-next: zero-dep, spec-driven, Ralph autonomous mode.",
-    "version": "1.1.9"
+    "version": "1.1.10"
   },
   "plugins": [
     {
       "name": "flow-next",
       "description": "Zero-dependency planning + execution with .flow/ task tracking and Ralph autonomous mode (multi-model review gates). Worker subagent per task for context isolation. Includes 21 subagents, 19 commands, 23 skills.",
-      "version": "1.1.9",
+      "version": "1.1.10",
       "author": {
         "name": "Gordon Mickel",
         "email": "gordon@mickel.tech",

--- a/.flow/bin/flowctl.py
+++ b/.flow/bin/flowctl.py
@@ -1019,10 +1019,18 @@ def get_default_config() -> dict:
     """Return default config structure."""
     return {
         "memory": {"enabled": True},
-        "planSync": {"enabled": True, "crossEpic": False},
+        "planSync": {"enabled": True, "crossSpec": False},
         "review": {"backend": None},
         "scouts": {"github": False},
     }
+
+
+# Canonical mapping for legacy config keys. Reads of a legacy key resolve to the
+# canonical key when present in the raw file; writes always target the canonical.
+# Mirrors the fn-43 epic→spec rename cadence.
+_CONFIG_KEY_ALIASES: dict[str, str] = {
+    "planSync.crossEpic": "planSync.crossSpec",
+}
 
 
 def deep_merge(base: dict, override: dict) -> dict:
@@ -1061,6 +1069,110 @@ def get_config(key: str, default=None):
         if config == {}:
             return default
     return config if config != {} else default
+
+
+_CONFIG_RAW_SENTINEL = object()
+
+
+def _get_config_from_file(key: str):
+    """Probe the raw .flow/config.json for `key` without applying defaults.
+
+    Returns the value if `key` exists in the persisted file, or
+    `_CONFIG_RAW_SENTINEL` when the key is absent (or the file itself
+    is absent / unreadable). The sentinel distinguishes "user explicitly
+    set the key to None / false" from "key never written" — load-bearing
+    for the legacy-alias fallback semantic (see `_CONFIG_KEY_ALIASES`).
+    """
+    config_path = get_flow_dir() / CONFIG_FILE
+    if not config_path.exists():
+        return _CONFIG_RAW_SENTINEL
+    try:
+        data = json.loads(config_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, Exception):
+        return _CONFIG_RAW_SENTINEL
+    if not isinstance(data, dict):
+        return _CONFIG_RAW_SENTINEL
+    current = data
+    for part in key.split("."):
+        if not isinstance(current, dict) or part not in current:
+            return _CONFIG_RAW_SENTINEL
+        current = current[part]
+    return current
+
+
+def resolve_config_key_for_read(key: str):
+    """Resolve a config-key read, honoring legacy aliases.
+
+    Returns a 3-tuple ``(effective_key, value, deprecation_legacy_form)``:
+
+    - ``effective_key`` — the key actually used to obtain the value.
+    - ``value`` — the resolved value, honoring "canonical wins over legacy"
+      and "legacy falls back when canonical absent from the raw file."
+    - ``deprecation_legacy_form`` — when non-empty, the caller should emit
+      `_emit_rename_deprecation(deprecation_legacy_form, canonical)`.
+      Populated whenever the user typed the legacy alias by name, even if
+      canonical is also present in the raw file. Canonical value precedence
+      is unchanged — the deprecation fires on the legacy *input form*, not on
+      where the value came from, so scripts still asking for the legacy key
+      after `set planSync.crossSpec` keep getting the migration signal
+      before 2.0 removes the alias. When the user reads the canonical key,
+      no warning fires even if the legacy key supplied the value via
+      fallback — they're already on the new name.
+
+    Canonical-vs-legacy precedence is identical in both directions:
+    canonical wins when present in the raw file; legacy fills in when
+    canonical is absent. The only thing the input key changes is which
+    label is returned and whether a deprecation fires.
+    """
+    # Identify the canonical/legacy pair regardless of which side the caller
+    # supplied. `key` may be legacy (looked up via `_CONFIG_KEY_ALIASES`) or
+    # canonical (reverse-lookup against alias targets).
+    canonical_from_alias = _CONFIG_KEY_ALIASES.get(key)
+    if canonical_from_alias is not None:
+        # User typed the legacy name.
+        canonical = canonical_from_alias
+        legacy = key
+        user_typed_legacy = True
+    else:
+        # User typed something else; may be canonical for a known alias, or
+        # an unrelated key entirely.
+        legacy_match = next(
+            (lg for lg, cn in _CONFIG_KEY_ALIASES.items() if cn == key), None
+        )
+        if legacy_match is None:
+            # Not part of any alias pair — standard lookup.
+            return key, get_config(key), ""
+        canonical = key
+        legacy = legacy_match
+        user_typed_legacy = False
+
+    canonical_raw = _get_config_from_file(canonical)
+    if canonical_raw is not _CONFIG_RAW_SENTINEL:
+        # Canonical wins value precedence; warn only when the user typed the
+        # legacy form (canonical reads remain the migration path).
+        return canonical, canonical_raw, legacy if user_typed_legacy else ""
+    legacy_raw = _get_config_from_file(legacy)
+    if legacy_raw is not _CONFIG_RAW_SENTINEL:
+        # Legacy supplies the value via fallback. Warn only when the user
+        # typed the legacy form (reading canonical is the migration path).
+        return legacy, legacy_raw, legacy if user_typed_legacy else ""
+    # Neither key set; fall back to merged defaults via the canonical key.
+    return canonical, get_config(canonical), ""
+
+
+def resolve_config_key_for_write(key: str) -> tuple[str, str]:
+    """Resolve a config-key write, redirecting legacy aliases to canonical.
+
+    Returns ``(canonical_key, deprecation_legacy_form)``. When the user wrote
+    a known legacy key, ``deprecation_legacy_form`` is non-empty and the
+    caller should emit a deprecation warning. The actual write must target
+    the canonical key; the legacy entry (if present in the file) is left
+    untouched — it becomes "wins-on-fallback-only" until 2.0.
+    """
+    canonical = _CONFIG_KEY_ALIASES.get(key)
+    if canonical is None:
+        return key, ""
+    return canonical, key
 
 
 def set_config(key: str, value) -> dict:
@@ -3068,6 +3180,16 @@ def get_copilot_version() -> Optional[str]:
 # uniformly so behaviour is deterministic across platforms.
 COPILOT_ARGV_PROMPT_MAX = 30000
 
+def _copilot_session_marker(repo_root: Path, session_id: str) -> Path:
+    """Path to the touch-file that records whether a Copilot session has been
+    created on this host.
+
+    Used only on the Windows stdin path, where ``--resume=<uuid>`` is
+    resume-only (errors on first call). Caller writes the marker after a
+    successful first invocation so subsequent calls switch to ``--resume``.
+    """
+    return repo_root / ".flow" / "tmp" / "copilot-sessions" / session_id
+
 
 def run_copilot_exec(
     prompt: str,
@@ -3075,28 +3197,36 @@ def run_copilot_exec(
     repo_root: Path,
     spec: Optional["BackendSpec"] = None,
 ) -> tuple[str, str, int, str]:
-    """Run copilot -p and return (stdout, session_id, exit_code, stderr).
+    """Run copilot and return (stdout, session_id, exit_code, stderr).
 
-    Copilot's ``--resume=<uuid>`` is create-or-resume: the caller always supplies
-    a UUID. First call creates a session with that exact ID; subsequent calls
-    with the same ID resume. We therefore don't need stdout parsing to recover
-    the session ID (unlike Codex).
+    Prompt-delivery path depends on host platform:
 
-    Prompt delivery:
-    - Short prompts (< COPILOT_ARGV_PROMPT_MAX chars): passed directly as argv.
-    - Large prompts: staged via ``.flow/tmp/copilot-prompt-<uuid>.txt`` then
-      read back into a Python string for argv (copilot's ``-p`` has no @file
-      syntax). The temp file is removed in ``finally`` so KeyboardInterrupt,
-      TimeoutExpired, and non-zero exits all clean up.
+    - **POSIX (macOS / Linux / WSL)** — argv path: ``copilot -p <prompt>
+      --resume=<uuid> ...``. ``--resume`` is create-or-resume in this mode,
+      so caller doesn't need to track session existence.
 
-    ``spec``: a resolved ``BackendSpec`` (backend=copilot) whose ``model`` and
-    ``effort`` are used verbatim. Env-var fills happen upstream in
-    ``resolve_review_spec()`` / ``BackendSpec.resolve()``; this function
-    reads ``spec.model`` / ``spec.effort`` directly. When ``spec`` is
-    ``None`` (defensive / non-review callers), fall back to bare-copilot
-    resolution (env + registry defaults).
+    - **Windows** — stdin path: ``copilot --session-id=<uuid> ...`` (or
+      ``--resume=<uuid>`` on continuation) with the prompt piped via
+      ``subprocess.run(input=prompt, ...)``. The argv path would blow the
+      ``CreateProcessW`` 32,767-char cap for spec-sized prompts; Copilot
+      CLI (≥1.0.51) has no ``--prompt-file`` / ``@file`` (tracking
+      github/copilot-cli#3398), but stdin works and bypasses the cap
+      entirely. Stdin mode's ``--resume`` is resume-only (errors with
+      "No session matched" on first call), so we use ``--session-id`` for
+      the first call and ``--resume`` afterwards — tracked via a touch
+      marker under ``.flow/tmp/copilot-sessions/<uuid>``.
 
-    Claude-model effort skip: the ``--effort`` flag is passed unless
+    On POSIX, ``COPILOT_ARGV_PROMPT_MAX`` triggers a temp-file scratch
+    buffer (hygiene only — the temp file is read back into argv). The
+    file is cleaned in ``finally`` so KeyboardInterrupt / TimeoutExpired /
+    non-zero exits all unlink.
+
+    ``spec``: a resolved ``BackendSpec`` (backend=copilot). Env-var fills
+    happen upstream; ``spec.model`` / ``spec.effort`` are read directly.
+    When ``spec`` is ``None`` (defensive / non-review callers), fall back
+    to bare-copilot resolution (env + registry defaults).
+
+    Claude-model effort skip: ``--effort`` is dropped when
     ``effective_model`` starts with ``claude-`` (Copilot rejects
     reasoning-effort on Claude-family models).
 
@@ -3114,25 +3244,10 @@ def run_copilot_exec(
     effective_model = spec.model or "gpt-5.2"
     effective_effort = spec.effort or "high"
 
-    # For large prompts, stage to disk then read back. Copilot has no @file
-    # syntax for -p, so we always end up with the prompt in argv — but the
-    # temp file acts as a scratch buffer that avoids exposing huge strings
-    # in any command-line reconstruction path.
-    tmp_prompt_path: Optional[Path] = None
-    prompt_for_argv = prompt
-    if len(prompt) >= COPILOT_ARGV_PROMPT_MAX:
-        tmp_dir = repo_root / ".flow" / "tmp"
-        tmp_dir.mkdir(parents=True, exist_ok=True)
-        tmp_prompt_path = tmp_dir / f"copilot-prompt-{uuid.uuid4()}.txt"
-        tmp_prompt_path.write_text(prompt, encoding="utf-8")
-        # Read back (copilot has no --prompt-file; argv is the only delivery path)
-        prompt_for_argv = tmp_prompt_path.read_text(encoding="utf-8")
+    use_stdin = sys.platform == "win32"
 
-    cmd = [
-        copilot,
-        "-p",
-        prompt_for_argv,
-        f"--resume={session_id}",
+    # Common args for both delivery paths (everything except prompt + session flag).
+    common_args = [
         "--output-format",
         "text",
         "-s",
@@ -3152,7 +3267,39 @@ def run_copilot_exec(
     # effort configuration"). Default model is claude-opus-4.5, so this branch
     # is the hot path. GPT-5.x models accept --effort.
     if not effective_model.startswith("claude-"):
-        cmd += ["--effort", effective_effort]
+        common_args += ["--effort", effective_effort]
+
+    tmp_prompt_path: Optional[Path] = None
+    marker: Optional[Path] = None
+    subprocess_kwargs: dict = {}
+
+    if use_stdin:
+        # Windows stdin path: prompt via subprocess input, session flag picks
+        # create-or-resume based on a touch marker. No -p, no temp scratch.
+        marker = _copilot_session_marker(repo_root, session_id)
+        marker.parent.mkdir(parents=True, exist_ok=True)
+        session_arg = (
+            f"--resume={session_id}" if marker.exists()
+            else f"--session-id={session_id}"
+        )
+        cmd = [copilot, session_arg, *common_args]
+        subprocess_kwargs["input"] = prompt
+    else:
+        # POSIX argv path (unchanged): -p + create-or-resume --resume.
+        prompt_for_argv = prompt
+        if len(prompt) >= COPILOT_ARGV_PROMPT_MAX:
+            tmp_dir = repo_root / ".flow" / "tmp"
+            tmp_dir.mkdir(parents=True, exist_ok=True)
+            tmp_prompt_path = tmp_dir / f"copilot-prompt-{uuid.uuid4()}.txt"
+            tmp_prompt_path.write_text(prompt, encoding="utf-8")
+            prompt_for_argv = tmp_prompt_path.read_text(encoding="utf-8")
+        cmd = [
+            copilot,
+            "-p",
+            prompt_for_argv,
+            f"--resume={session_id}",
+            *common_args,
+        ]
 
     try:
         try:
@@ -3162,10 +3309,16 @@ def run_copilot_exec(
                 text=True, encoding="utf-8",
                 check=False,  # Don't raise on non-zero exit; caller inspects
                 timeout=600,
+                **subprocess_kwargs,
             )
+            # Windows stdin path: record first-call success so subsequent
+            # invocations switch from --session-id to --resume. Touch is
+            # idempotent so repeat calls are safe.
+            if use_stdin and marker is not None and result.returncode == 0:
+                marker.touch(exist_ok=True)
             return result.stdout, session_id, result.returncode, result.stderr
         except subprocess.TimeoutExpired:
-            return "", session_id, 2, "copilot -p timed out (600s)"
+            return "", session_id, 2, "copilot timed out (600s)"
     finally:
         # Clean up temp file on every exit path (success, failure, timeout,
         # KeyboardInterrupt). unlink(missing_ok=True) avoids TOCTOU races.
@@ -3281,21 +3434,22 @@ If you notice genuine issues with content INSIDE these files (e.g., a spec that 
 #
 # Shared prompt block that instructs reviewers to emit a per-R-ID coverage table
 # whenever the epic spec numbers its acceptance criteria (`- **R1:** ...`). The
-# reviewer parses the heading in either `## Acceptance` or the legacy
-# `## Acceptance criteria` form (plan skill writes the former; older epic specs
-# may use the latter). Missing R-IDs flip the verdict to NEEDS_WORK unless the
-# spec marks the requirement deferred. The block is injected into impl-review
-# and epic-review (completion-review) prompts. Keep synchronized with the RP
-# workflow.md files.
+# reviewer parses the heading as `## Acceptance Criteria` (canonical since
+# 1.1.4 / fn-46-follow-up) and tolerates the legacy `## Acceptance` (plan
+# template pre-1.1.4) and `## Acceptance criteria` (older lowercase form)
+# variants for back-compat. Missing R-IDs flip the verdict to NEEDS_WORK
+# unless the spec marks the requirement deferred. The block is injected into
+# impl-review and epic-review (completion-review) prompts. Keep synchronized
+# with the RP workflow.md files.
 
 R_ID_COVERAGE_BLOCK = """## Requirements coverage (if spec has R-IDs)
 
 If the task or epic spec references an epic spec with numbered acceptance
 criteria like `- **R1:** ...`, `- **R2:** ...`, produce a per-R-ID coverage
-table. Read the epic spec's `## Acceptance` section (or the legacy
-`## Acceptance criteria` heading — reviewer MUST tolerate both). If no R-IDs
-are present anywhere, skip this block entirely — the rest of the review is
-unchanged.
+table. Read the epic spec's `## Acceptance Criteria` section (canonical;
+reviewer MUST also tolerate the legacy `## Acceptance` and `## Acceptance
+criteria` heading variants for back-compat). If no R-IDs are present
+anywhere, skip this block entirely — the rest of the review is unchanged.
 
 For each R-ID, classify status:
 
@@ -3868,22 +4022,30 @@ def resolve_spec_arg(
 _RENAME_DEPRECATION_EMITTED: set[str] = set()
 
 
-def _emit_rename_deprecation(legacy_form: str, canonical_form: str) -> None:
+def _emit_rename_deprecation(
+    legacy_form: str, canonical_form: str, extra: str = ""
+) -> None:
     """Print a one-shot stderr deprecation for a legacy `epic`-named surface.
 
     Suppress with `FLOW_NO_DEPRECATION=1`. Mirrors the `_memory_emit_deprecation`
     pattern but is keyed on a `legacy_form` string so a single process emits
     each warning at most once (the rename touches enough call-sites that
     per-call emission would spam Ralph logs).
+
+    `extra` is an optional trailing fragment appended after the standard
+    deprecation prose (e.g. ``"Removed in 2.0."``). Kept as a parameter so
+    future deprecations can opt into the same suffix without diverging
+    wording across call-sites.
     """
     if legacy_form in _RENAME_DEPRECATION_EMITTED:
         return
     _RENAME_DEPRECATION_EMITTED.add(legacy_form)
     if os.environ.get("FLOW_NO_DEPRECATION") == "1":
         return
+    suffix = f" {extra}" if extra else ""
     print(
         f"Warning: {legacy_form} is deprecated; use {canonical_form}. "
-        f"(Suppress with FLOW_NO_DEPRECATION=1.)",
+        f"(Suppress with FLOW_NO_DEPRECATION=1.){suffix}",
         file=sys.stderr,
     )
 
@@ -4572,13 +4734,71 @@ def cmd_ralph_status(args: argparse.Namespace) -> None:
 
 
 def cmd_config_get(args: argparse.Namespace) -> None:
-    """Get a config value."""
+    """Get a config value.
+
+    By default, merges built-in defaults (via `load_flow_config()`) so an
+    unset key like `planSync.crossSpec` returns its default `False`. Setup
+    skills (and any caller that needs to know whether a key is set in the
+    on-disk file) pass `--raw` to bypass the merge and get `null` for
+    truly-absent keys. See fn-46.1: the merge-defaults path was the source
+    of the cycle-1 setup-prompt regression on PR #135.
+    """
     if not ensure_flow_exists():
         error_exit(
             ".flow/ does not exist. Run 'flowctl init' first.", use_json=args.json
         )
 
-    value = get_config(args.key)
+    raw = getattr(args, "raw", False)
+
+    if raw:
+        # Bypass merge; resolve via the canonical/legacy raw-file probe so
+        # callers see `null` exactly when neither the canonical nor the
+        # legacy key is persisted to .flow/config.json. Deprecation still
+        # fires when the user typed the legacy alias and only legacy is set.
+        canonical_from_alias = _CONFIG_KEY_ALIASES.get(args.key)
+        if canonical_from_alias is not None:
+            canonical = canonical_from_alias
+            legacy = args.key
+            user_typed_legacy = True
+        else:
+            legacy_match = next(
+                (lg for lg, cn in _CONFIG_KEY_ALIASES.items() if cn == args.key),
+                None,
+            )
+            canonical = args.key
+            legacy = legacy_match
+            user_typed_legacy = False
+
+        canonical_raw = _get_config_from_file(canonical)
+        if canonical_raw is not _CONFIG_RAW_SENTINEL:
+            value = canonical_raw
+        elif legacy is not None:
+            legacy_raw = _get_config_from_file(legacy)
+            if legacy_raw is not _CONFIG_RAW_SENTINEL:
+                value = legacy_raw
+                if user_typed_legacy:
+                    _emit_rename_deprecation(legacy, canonical, extra="Removed in 2.0.")
+            else:
+                value = None
+        else:
+            value = None
+
+        if args.json:
+            json_output({"key": args.key, "value": value, "raw": True})
+        else:
+            if value is None:
+                print(f"{args.key}: (not set)")
+            elif isinstance(value, bool):
+                print(f"{args.key}: {'true' if value else 'false'}")
+            else:
+                print(f"{args.key}: {value}")
+        return
+
+    _, value, deprecation_legacy = resolve_config_key_for_read(args.key)
+    if deprecation_legacy:
+        canonical = _CONFIG_KEY_ALIASES[deprecation_legacy]
+        _emit_rename_deprecation(deprecation_legacy, canonical, extra="Removed in 2.0.")
+
     if args.json:
         json_output({"key": args.key, "value": value})
     else:
@@ -4597,13 +4817,21 @@ def cmd_config_set(args: argparse.Namespace) -> None:
             ".flow/ does not exist. Run 'flowctl init' first.", use_json=args.json
         )
 
-    set_config(args.key, args.value)
-    new_value = get_config(args.key)
+    canonical_key, deprecation_legacy = resolve_config_key_for_write(args.key)
+    if deprecation_legacy:
+        _emit_rename_deprecation(
+            deprecation_legacy, canonical_key, extra="Removed in 2.0."
+        )
+
+    set_config(canonical_key, args.value)
+    new_value = get_config(canonical_key)
 
     if args.json:
-        json_output({"key": args.key, "value": new_value, "message": f"{args.key} set"})
+        json_output(
+            {"key": canonical_key, "value": new_value, "message": f"{canonical_key} set"}
+        )
     else:
-        print(f"{args.key} set to {new_value}")
+        print(f"{canonical_key} set to {new_value}")
 
 
 def cmd_review_backend(args: argparse.Namespace) -> None:
@@ -11717,10 +11945,12 @@ def _export_resolve_merge_base(base_ref: str) -> Optional[str]:
 def _export_parse_acceptance_criteria(spec_text: str) -> list[dict[str, Any]]:
     """Extract R-ID acceptance criteria from an epic spec.
 
-    Looks for the `## Acceptance Criteria` (or `## Acceptance criteria`)
-    section and parses bullets matching `- **R<N>:** <text>`. Source-tag
-    suffixes like `[user]` / `[paraphrase]` / `[inferred]` / `[strategy:track]`
-    are extracted into the `tag` field (last `[...]` token in the bullet).
+    Canonical heading is `## Acceptance Criteria` (since 1.1.4). For
+    back-compat, also tolerates `## Acceptance criteria` (older lowercase
+    form) and bare `## Acceptance` (plan template pre-1.1.4). Parses bullets
+    matching `- **R<N>:** <text>`. Source-tag suffixes like `[user]` /
+    `[paraphrase]` / `[inferred]` / `[strategy:track]` are extracted into
+    the `tag` field (last `[...]` token in the bullet).
 
     Returns list of `{"id": "R1", "text": "...", "tag": "..."}`. Empty list
     if no acceptance section or no R-IDs.
@@ -11728,9 +11958,9 @@ def _export_parse_acceptance_criteria(spec_text: str) -> list[dict[str, Any]]:
     if not spec_text:
         return []
 
-    # Find the section heading. Tolerate both casings.
+    # Find the section heading. Tolerate canonical + 2 legacy forms.
     heading_re = re.compile(
-        r"^##\s+Acceptance\s+[Cc]riteria\s*$",
+        r"^##\s+Acceptance(?:\s+[Cc]riteria)?\s*$",
         re.MULTILINE,
     )
     m = heading_re.search(spec_text)
@@ -19068,8 +19298,8 @@ def cmd_copilot_impl_review(args: argparse.Namespace) -> None:
                 Path(receipt_path).unlink(missing_ok=True)
             except OSError:
                 pass
-        msg = (stderr or output or "copilot -p failed").strip()
-        error_exit(f"copilot -p failed: {msg}", use_json=args.json, code=2)
+        msg = (stderr or output or "copilot failed").strip()
+        error_exit(f"copilot failed: {msg}", use_json=args.json, code=2)
 
     # Parse verdict
     verdict = parse_codex_verdict(output)
@@ -19270,8 +19500,8 @@ def cmd_copilot_plan_review(args: argparse.Namespace) -> None:
                 Path(receipt_path).unlink(missing_ok=True)
             except OSError:
                 pass
-        msg = (stderr or output or "copilot -p failed").strip()
-        error_exit(f"copilot -p failed: {msg}", use_json=args.json, code=2)
+        msg = (stderr or output or "copilot failed").strip()
+        error_exit(f"copilot failed: {msg}", use_json=args.json, code=2)
 
     verdict = parse_codex_verdict(output)
 
@@ -19457,8 +19687,8 @@ def cmd_copilot_completion_review(args: argparse.Namespace) -> None:
                 Path(receipt_path).unlink(missing_ok=True)
             except OSError:
                 pass
-        msg = (stderr or output or "copilot -p failed").strip()
-        error_exit(f"copilot -p failed: {msg}", use_json=args.json, code=2)
+        msg = (stderr or output or "copilot failed").strip()
+        error_exit(f"copilot failed: {msg}", use_json=args.json, code=2)
 
     verdict = parse_codex_verdict(output)
 
@@ -20650,6 +20880,16 @@ def main() -> None:
     p_config_get = config_sub.add_parser("get", help="Get config value")
     p_config_get.add_argument("key", help="Config key (e.g., memory.enabled)")
     p_config_get.add_argument("--json", action="store_true", help="JSON output")
+    p_config_get.add_argument(
+        "--raw",
+        action="store_true",
+        help=(
+            "Bypass merged defaults. Returns null for keys absent from the "
+            "on-disk .flow/config.json (distinguishes unset from "
+            "explicitly-false). Used by /flow-next:setup to detect "
+            "first-run state."
+        ),
+    )
     p_config_get.set_defaults(func=cmd_config_get)
 
     p_config_set = config_sub.add_parser("set", help="Set config value")

--- a/.flow/meta.json
+++ b/.flow/meta.json
@@ -1,6 +1,6 @@
 {
   "next_spec": 1,
   "schema_version": 3,
-  "setup_date": "2026-02-21T00:00:00Z",
-  "setup_version": "0.24.0"
+  "setup_date": "2026-05-22T11:35:53Z",
+  "setup_version": "1.1.9"
 }

--- a/.flow/templates/spec.md
+++ b/.flow/templates/spec.md
@@ -4,7 +4,6 @@ consumers:
   - flow-next-capture        # synthesizes a spec from conversation context
   - flow-next-interview      # refines a spec via Q&A (--scope=business|technical|both)
   - flow-next-plan           # breaks a spec into tasks
-  - flow-next-work           # implements tasks against the spec
   - CLAUDE.md                # "Creating a spec" guide cross-links here rather than embedding
 canonical_sections:
   - Goal & Context           # scope: business
@@ -40,6 +39,16 @@ nest — see https://html.spec.whatwg.org/multipage/syntax.html#comments.)
 R-IDs in `## Acceptance Criteria` are append-only across passes. Never renumber.
 Never replace existing entries. A later pass appends new criteria with the next
 unused number.
+-->
+
+<!--
+To customize for your project, copy this file to `<repo-root>/SPEC.md` and edit there.
+
+Discovery cascade (first match wins):
+  1. <repo_root>/SPEC.md           (your customized scaffold — uppercase preferred)
+  2. <repo_root>/spec.md           (lowercase honored when uppercase absent)
+  3. .flow/templates/spec.md       (project-local copy from /flow-next:setup)
+  4. bundled ${PLUGIN_ROOT}/templates/spec.md  (this file — canonical source of truth)
 -->
 
 # <spec-id> <Title>

--- a/.flow/usage.md
+++ b/.flow/usage.md
@@ -14,20 +14,28 @@ Task tracking for AI agents. All state lives in `.flow/`.
 ```
 .flow/
 ├── bin/flowctl                  # CLI (this install)
+├── templates/spec.md            # Canonical 7-section spec scaffold (copied by /flow-next:setup)
 ├── specs/fn-N-slug.md           # Spec content (canonical)
 ├── specs/fn-N-slug.json         # Spec metadata (1.0+ — colocated with the markdown)
-├── tasks/fn-N-slug.M.json       # Task metadata (e.g., fn-1-add-oauth.1.json)
 ├── tasks/fn-N-slug.M.md         # Task specifications
-├── memory/                      # Context memory (categorized bug/ + knowledge/)
+├── tasks/fn-N-slug.M.json       # Task metadata
+├── memory/{bug,knowledge}/<category>/  # Context memory (categorized; bug: build-errors, runtime-errors, test-failures, …; knowledge: architecture-patterns, conventions, …)
 ├── prospects/<slug>-<date>.md   # Ideation artifacts (v0.36.0+)
+├── review-receipts/<branch>.json  # Review verdicts + findings (per branch)
+├── review-deferred/<branch>.md  # Walkthrough deferrals (fn-32.3)
 ├── .flow_version                # 1.0.0 sentinel — written after layout migration
-├── .gitignore                   # Auto-managed by flowctl (1.0+) — excludes migration transients
-└── meta.json                    # Project metadata
+├── .gitignore                   # Auto-managed by flowctl (1.0+) — excludes per-developer state + migration transients
+└── meta.json                    # Project metadata (schema_version, setup_version, setup_date)
 ```
 
 `.flow/epics/` is the pre-1.0 sidecar location. Repos created on 1.0+ never have it; pre-1.0 repos keep working via the alias layer until you run `flowctl migrate-rename --yes` (or `/flow-next:setup`'s upgrade branch).
 
 `.flow/.gitignore` is auto-written by `flowctl init` and `flowctl migrate-rename` so `git add -A` doesn't accidentally commit per-developer state (`.checkpoint-*.json`, `receipts/`, `tmp/`) or migration transients (`.backup-pre-1.0/`, `.banner-acknowledged`, `.migrating`, `.migration-manifest`). Idempotent; user patterns added below the auto-managed footer are preserved on update.
+
+The project's strategic intent and canonical vocabulary live **outside** `.flow/` so they survive `rm -rf .flow/`:
+
+- `STRATEGY.md` (repo root) — target problem, approach, personas, metrics, active tracks (v0.40.0+).
+- `GLOSSARY.md` (repo root or any ancestor) — canonical terms with `_Avoid_` aliases (v0.39.0+).
 
 ## IDs
 
@@ -52,23 +60,38 @@ Task tracking for AI agents. All state lives in `.flow/`.
 .flow/bin/flowctl cat fn-1-add-oauth            # Spec markdown
 .flow/bin/flowctl cat fn-1-add-oauth.2          # Task spec (markdown)
 
-# Status
-.flow/bin/flowctl ready --spec fn-1-add-oauth   # What's ready to work on
+# State
+.flow/bin/flowctl status                        # .flow state + active Ralph runs
+.flow/bin/flowctl ready --spec fn-1-add-oauth   # Tasks ready to work on
 .flow/bin/flowctl validate --all                # Check structure
 .flow/bin/flowctl state-path                    # Show state directory (for worktrees)
 
-# Create
-.flow/bin/flowctl spec create --title "..."
+# Spec lifecycle
+.flow/bin/flowctl spec create --title "..."                    # Create new spec
+.flow/bin/flowctl spec set-plan fn-1-add-oauth --file plan.md  # Replace spec markdown
+.flow/bin/flowctl spec set-title fn-1-add-oauth --title "..."  # Rename (updates slug)
+.flow/bin/flowctl spec set-branch fn-1-add-oauth --branch ...  # Set branch name
+.flow/bin/flowctl spec close fn-1-add-oauth                    # Close spec
+.flow/bin/flowctl spec skeleton                                # Print fresh-spec scaffold
+
+# Task lifecycle
 .flow/bin/flowctl task create --spec fn-1-add-oauth --title "..."
 .flow/bin/flowctl task create --spec fn-1-add-oauth --title "..." --deps fn-1-add-oauth.1,fn-1-add-oauth.2
+.flow/bin/flowctl task set-description <id> --description-file desc.md
+.flow/bin/flowctl task set-acceptance <id> --acceptance-file accept.md
+.flow/bin/flowctl task set-spec <id> --file spec.md            # Full task spec from file
+.flow/bin/flowctl task reset <id>                              # Reset to todo (cascading: --cascade)
 
 # Dependencies
 .flow/bin/flowctl task set-deps fn-1-add-oauth.3 --deps fn-1-add-oauth.1,fn-1-add-oauth.2
 .flow/bin/flowctl dep add fn-1-add-oauth.3 fn-1-add-oauth.1
+.flow/bin/flowctl spec add-dep fn-1-add-oauth --dep fn-2
+.flow/bin/flowctl spec rm-dep fn-1-add-oauth --dep fn-2
 
 # Work
 .flow/bin/flowctl start fn-1-add-oauth.2        # Claim task
 .flow/bin/flowctl done fn-1-add-oauth.2 --summary-file s.md --evidence-json e.json
+.flow/bin/flowctl block fn-1-add-oauth.2 --reason-file reason.md   # Block task with reason
 
 # Spec cognitive-aid export (used by /flow-next:make-pr, v0.42.0+)
 .flow/bin/flowctl spec export-cognitive-aid fn-1-add-oauth                  # text mode summary
@@ -117,6 +140,33 @@ Task tracking for AI agents. All state lives in `.flow/`.
 .flow/bin/flowctl strategy list --json                             # {groups, file_count, total_sections} — parallel to glossary list
 
 # /flow-next:strategy skill writes STRATEGY.md directly (no flowctl strategy add — too prose-heavy for atomic CLI).
+
+# Config (per-project knobs in .flow/config.json — see /flow-next:setup for guided setup)
+.flow/bin/flowctl config get review.backend                        # rp|codex|copilot|none, or spec form like codex:gpt-5.4:high
+.flow/bin/flowctl config get review.backend --raw --json           # bypass merged defaults (null = absent from file)
+.flow/bin/flowctl config set review.backend codex                  # bare backend
+.flow/bin/flowctl config set review.backend codex:gpt-5.4:high     # full spec (backend:model:effort)
+.flow/bin/flowctl config set memory.enabled true                   # auto-capture from NEEDS_WORK reviews
+.flow/bin/flowctl config set planSync.enabled true                 # sync downstream task specs after impl drift
+.flow/bin/flowctl config set planSync.crossSpec false              # also check other open specs (canonical key; legacy alias planSync.crossEpic removed in 2.0)
+.flow/bin/flowctl config set scouts.github false                   # GitHub scout (requires gh CLI)
+
+# Per-spec / per-task backend overrides (override the global review.backend per workstream)
+.flow/bin/flowctl spec set-backend fn-1-add-oauth --review codex:gpt-5.4:high
+.flow/bin/flowctl task set-backend fn-1-add-oauth.3 --impl copilot:claude-opus-4.5
+.flow/bin/flowctl task show-backend fn-1-add-oauth.3                # effective specs (task + spec levels merged)
+.flow/bin/flowctl review-backend                                    # show backend that would run now (ASK if unset)
+
+# Checkpoint (save/restore spec state — useful before destructive edits)
+.flow/bin/flowctl checkpoint save fn-1-add-oauth                    # snapshot spec + tasks
+.flow/bin/flowctl checkpoint restore fn-1-add-oauth                 # restore from snapshot
+.flow/bin/flowctl checkpoint delete fn-1-add-oauth                  # delete snapshot
+
+# Ralph (autonomous mode run control — for /flow-next:ralph-init users)
+.flow/bin/flowctl ralph status                                      # current run state
+.flow/bin/flowctl ralph pause                                       # pause running loop
+.flow/bin/flowctl ralph resume                                      # resume paused loop
+.flow/bin/flowctl ralph stop                                        # request stop after current iteration
 ```
 
 ## Workflow

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the flow-next.
 
+## [flow-next 1.1.10] - 2026-05-22
+
+### Fixed
+- **`/flow-next:setup` template `usage.md` was stale and missing 3 documented CLI surfaces + most of the per-project knobs.** Caught when re-running `/flow-next:setup` on the dev repo bumped its `setup_version` from 0.24.0 to 1.1.9 and the byte-compare gate flagged `.flow/usage.md` as customized. Root cause: the `fn-43.12 user-facing docs sweep` (commit `445a4ef`) updated only the dev repo's `.flow/usage.md` with new prospect / spec export-cognitive-aid / `.flow_version` sentinel content; the canonical template at `plugins/flow-next/skills/flow-next-setup/templates/usage.md` was never backported, so every fresh `/flow-next:setup` from 0.42.0 onward shipped a `.flow/usage.md` missing those sections. Promoted the richer dev-repo version to the canonical template AND extended it with the surfaces neither version covered: `flowctl status`, `config get/set` (all five knobs: review.backend, memory.enabled, planSync.enabled, planSync.crossSpec, scouts.github), per-spec / per-task `set-backend` + `show-backend` + `review-backend`, `checkpoint save/restore/delete`, `ralph pause/resume/stop/status`, `spec set-plan/set-title/set-branch/close/skeleton/add-dep/rm-dep`, `task set-description/set-acceptance/set-spec/reset`, `block --reason-file`. Also corrected the `specs/*.md` vs `specs/*.json` framing (.md is canonical content; .json is metadata — template had them reversed) and expanded the file-structure diagram to mention `templates/spec.md`, `review-receipts/`, `review-deferred/`, the `memory/{bug,knowledge}/<category>/` shape, and `STRATEGY.md` / `GLOSSARY.md` as out-of-`.flow/` canonical files. Template grew 100 → 212 lines.
+
+### Documentation
+- Same canonical content also written to this repo's `.flow/usage.md` so the dev install stays byte-identical to what the setup template ships.
+
 ## [flow-next 1.1.9] - 2026-05-22
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Flow-Next
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Flow-next](https://img.shields.io/badge/Flow--next-v1.1.9-green)](CHANGELOG.md)
+[![Flow-next](https://img.shields.io/badge/Flow--next-v1.1.10-green)](CHANGELOG.md)
 [![Docs](https://img.shields.io/badge/Docs-📖-informational)](plugins/flow-next/docs/README.md)
 
 [![Author](https://img.shields.io/badge/Author-Gordon_Mickel-orange)](https://mickel.tech)

--- a/plugins/flow-next/.claude-plugin/plugin.json
+++ b/plugins/flow-next/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "flow-next",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "description": "Zero-dependency planning + execution with .flow/ task tracking and Ralph autonomous mode (multi-model review gates). Worker subagent per task for context isolation. Prime assesses 8 pillars (48 criteria) with GitHub API integration. Includes 21 subagents, 19 commands, 23 skills.",
   "author": {
     "name": "Gordon Mickel",

--- a/plugins/flow-next/.codex-plugin/plugin.json
+++ b/plugins/flow-next/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "flow-next",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "description": "Zero-dependency planning + execution with .flow/ task tracking and Ralph autonomous mode. Worker subagent per task for context isolation. Compatible with Codex, Claude Code, and Factory Droid.",
   "author": {
     "name": "Gordon Mickel",

--- a/plugins/flow-next/codex/skills/flow-next-setup/templates/usage.md
+++ b/plugins/flow-next/codex/skills/flow-next-setup/templates/usage.md
@@ -14,17 +14,28 @@ Task tracking for AI agents. All state lives in `.flow/`.
 ```
 .flow/
 ├── bin/flowctl # CLI (this install)
-├── specs/fn-N-slug.json # Spec metadata (e.g., fn-1-add-oauth.json)
-├── specs/fn-N-slug.md # Spec markdown
-├── tasks/fn-N-slug.M.json # Task metadata (e.g., fn-1-add-oauth.1.json)
+├── templates/spec.md # Canonical 7-section spec scaffold (copied by /flow-next:setup)
+├── specs/fn-N-slug.md # Spec content (canonical)
+├── specs/fn-N-slug.json # Spec metadata (1.0+ — colocated with the markdown)
 ├── tasks/fn-N-slug.M.md # Task specifications
-├── memory/ # Context memory
-├── .flow_version # 1.0.0 sentinel — written after migration; tracked
-├── .gitignore # Auto-managed by flowctl (1.0+) — excludes transients
-└── meta.json # Project metadata
+├── tasks/fn-N-slug.M.json # Task metadata
+├── memory/{bug,knowledge}/<category>/ # Context memory (categorized; bug: build-errors, runtime-errors, test-failures, …; knowledge: architecture-patterns, conventions, …)
+├── prospects/<slug>-<date>.md # Ideation artifacts (v0.36.0+)
+├── review-receipts/<branch>.json # Review verdicts + findings (per branch)
+├── review-deferred/<branch>.md # Walkthrough deferrals (fn-32.3)
+├── .flow_version # 1.0.0 sentinel — written after layout migration
+├── .gitignore # Auto-managed by flowctl (1.0+) — excludes per-developer state + migration transients
+└── meta.json # Project metadata (schema_version, setup_version, setup_date)
 ```
 
-`.flow/.gitignore` is auto-written so `git add -A` doesn't accidentally commit per-developer state (`.checkpoint-*.json`, `receipts/`, `tmp/`) or migration transients (`.backup-pre-1.0/`, `.banner-acknowledged`, `.migrating`, `.migration-manifest`). Idempotent on re-init / re-migrate; user patterns added below the auto-managed footer are preserved.
+`.flow/epics/` is the pre-1.0 sidecar location. Repos created on 1.0+ never have it; pre-1.0 repos keep working via the alias layer until you run `flowctl migrate-rename --yes` (or `/flow-next:setup`'s upgrade branch).
+
+`.flow/.gitignore` is auto-written by `flowctl init` and `flowctl migrate-rename` so `git add -A` doesn't accidentally commit per-developer state (`.checkpoint-*.json`, `receipts/`, `tmp/`) or migration transients (`.backup-pre-1.0/`, `.banner-acknowledged`, `.migrating`, `.migration-manifest`). Idempotent; user patterns added below the auto-managed footer are preserved on update.
+
+The project's strategic intent and canonical vocabulary live **outside** `.flow/` so they survive `rm -rf .flow/`:
+
+- `STRATEGY.md` (repo root) — target problem, approach, personas, metrics, active tracks (v0.40.0+).
+- `GLOSSARY.md` (repo root or any ancestor) — canonical terms with `_Avoid_` aliases (v0.39.0+).
 
 ## IDs
 
@@ -49,23 +60,113 @@ Task tracking for AI agents. All state lives in `.flow/`.
 .flow/bin/flowctl cat fn-1-add-oauth # Spec markdown
 .flow/bin/flowctl cat fn-1-add-oauth.2 # Task spec (markdown)
 
-# Status
-.flow/bin/flowctl ready --spec fn-1-add-oauth # What's ready to work on
+# State
+.flow/bin/flowctl status # .flow state + active Ralph runs
+.flow/bin/flowctl ready --spec fn-1-add-oauth # Tasks ready to work on
 .flow/bin/flowctl validate --all # Check structure
 .flow/bin/flowctl state-path # Show state directory (for worktrees)
 
-# Create
-.flow/bin/flowctl spec create --title "..."
+# Spec lifecycle
+.flow/bin/flowctl spec create --title "..." # Create new spec
+.flow/bin/flowctl spec set-plan fn-1-add-oauth --file plan.md # Replace spec markdown
+.flow/bin/flowctl spec set-title fn-1-add-oauth --title "..." # Rename (updates slug)
+.flow/bin/flowctl spec set-branch fn-1-add-oauth --branch ... # Set branch name
+.flow/bin/flowctl spec close fn-1-add-oauth # Close spec
+.flow/bin/flowctl spec skeleton # Print fresh-spec scaffold
+
+# Task lifecycle
 .flow/bin/flowctl task create --spec fn-1-add-oauth --title "..."
 .flow/bin/flowctl task create --spec fn-1-add-oauth --title "..." --deps fn-1-add-oauth.1,fn-1-add-oauth.2
+.flow/bin/flowctl task set-description <id> --description-file desc.md
+.flow/bin/flowctl task set-acceptance <id> --acceptance-file accept.md
+.flow/bin/flowctl task set-spec <id> --file spec.md # Full task spec from file
+.flow/bin/flowctl task reset <id> # Reset to todo (cascading: --cascade)
 
 # Dependencies
 .flow/bin/flowctl task set-deps fn-1-add-oauth.3 --deps fn-1-add-oauth.1,fn-1-add-oauth.2
 .flow/bin/flowctl dep add fn-1-add-oauth.3 fn-1-add-oauth.1
+.flow/bin/flowctl spec add-dep fn-1-add-oauth --dep fn-2
+.flow/bin/flowctl spec rm-dep fn-1-add-oauth --dep fn-2
 
 # Work
 .flow/bin/flowctl start fn-1-add-oauth.2 # Claim task
 .flow/bin/flowctl done fn-1-add-oauth.2 --summary-file s.md --evidence-json e.json
+.flow/bin/flowctl block fn-1-add-oauth.2 --reason-file reason.md # Block task with reason
+
+# Spec cognitive-aid export (used by /flow-next:make-pr, v0.42.0+)
+.flow/bin/flowctl spec export-cognitive-aid fn-1-add-oauth # text mode summary
+.flow/bin/flowctl spec export-cognitive-aid fn-1-add-oauth --json # full structured payload
+.flow/bin/flowctl spec export-cognitive-aid fn-1-add-oauth --base main # diff against base ref
+.flow/bin/flowctl spec export-cognitive-aid fn-1-add-oauth --section coverage --json # one section only
+
+# Prospect (ideation artifacts under .flow/prospects/, v0.36.0+)
+.flow/bin/flowctl prospect list # active artifacts (<30d)
+.flow/bin/flowctl prospect list --all --json # everything
+.flow/bin/flowctl prospect read <id> # full body
+.flow/bin/flowctl prospect read <id> --section survivors # focus|grounding|survivors|rejected
+.flow/bin/flowctl prospect promote <id> --idea N # idea N → new spec
+.flow/bin/flowctl prospect promote <id> --idea N --force # override idempotency guard
+.flow/bin/flowctl prospect archive <id> # → .flow/prospects/_archive/
+
+# Memory (categorized learnings under .flow/memory/, v0.33.0+)
+.flow/bin/flowctl memory list # default: --status active
+.flow/bin/flowctl memory list --status stale # stale entries only
+.flow/bin/flowctl memory search <query> # default: --status active
+.flow/bin/flowctl memory search <query> --status all # active + stale
+.flow/bin/flowctl memory read <id> # full entry
+.flow/bin/flowctl memory mark-stale <id> --reason "..." # flag stale (v0.37.0+)
+.flow/bin/flowctl memory mark-fresh <id> # clear stale flag (v0.37.0+)
+.flow/bin/flowctl memory list-legacy # list legacy entries with mechanical defaults (v0.37.0+)
+.flow/bin/flowctl memory list-legacy --json # used by /flow-next:memory-migrate skill
+.flow/bin/flowctl memory migrate [--yes] [--json] # deterministic-only legacy migration (use /flow-next:memory-migrate for agent-native classification)
+
+# Glossary (project-canonical terms at repo root, v0.39.0+ — survives `rm -rf .flow/`)
+.flow/bin/flowctl glossary add <term> --definition "..." # upsert single-line term
+.flow/bin/flowctl glossary add <term> --definition-file body.md # multi-line definition from file
+.flow/bin/flowctl glossary add <term> --definition-file - # multi-line from stdin
+.flow/bin/flowctl glossary add <term> --avoid "alt1,alt2" --relates-to "x,y"
+.flow/bin/flowctl glossary list # text mode: grouped by file (nearest first)
+.flow/bin/flowctl glossary list --json # {groups, file_count, total_terms}
+.flow/bin/flowctl glossary read <term> # nearest-ancestor walk; first match wins
+.flow/bin/flowctl glossary read <term> --json # {path, term, definition, avoid, relates_to}
+.flow/bin/flowctl glossary remove <term> # last-term remove leaves `# Glossary` husk (R18)
+
+# Strategy (project-canonical strategic intent at repo root, v0.40.0+ — survives `rm -rf .flow/`)
+.flow/bin/flowctl strategy status # text mode: husk / sections_filled / total_sections / last_updated
+.flow/bin/flowctl strategy status --json # {exists, husk, sections_filled, total_sections, last_updated, file_path}
+.flow/bin/flowctl strategy read # full STRATEGY.md (single-root walk from cwd up to repo root)
+.flow/bin/flowctl strategy read --section approach # one section only (target_problem / approach / personas / metrics / tracks / milestones / not_working_on)
+.flow/bin/flowctl strategy read --json # {path, name, last_updated, target_problem, approach, personas, metrics, tracks, milestones, not_working_on}
+.flow/bin/flowctl strategy list --json # {groups, file_count, total_sections} — parallel to glossary list
+
+# /flow-next:strategy skill writes STRATEGY.md directly (no flowctl strategy add — too prose-heavy for atomic CLI).
+
+# Config (per-project knobs in .flow/config.json — see /flow-next:setup for guided setup)
+.flow/bin/flowctl config get review.backend # rp|codex|copilot|none, or spec form like codex:gpt-5.4:high
+.flow/bin/flowctl config get review.backend --raw --json # bypass merged defaults (null = absent from file)
+.flow/bin/flowctl config set review.backend codex # bare backend
+.flow/bin/flowctl config set review.backend codex:gpt-5.4:high # full spec (backend:model:effort)
+.flow/bin/flowctl config set memory.enabled true # auto-capture from NEEDS_WORK reviews
+.flow/bin/flowctl config set planSync.enabled true # sync downstream task specs after impl drift
+.flow/bin/flowctl config set planSync.crossSpec false # also check other open specs (canonical key; legacy alias planSync.crossEpic removed in 2.0)
+.flow/bin/flowctl config set scouts.github false # GitHub scout (requires gh CLI)
+
+# Per-spec / per-task backend overrides (override the global review.backend per workstream)
+.flow/bin/flowctl spec set-backend fn-1-add-oauth --review codex:gpt-5.4:high
+.flow/bin/flowctl task set-backend fn-1-add-oauth.3 --impl copilot:claude-opus-4.5
+.flow/bin/flowctl task show-backend fn-1-add-oauth.3 # effective specs (task + spec levels merged)
+.flow/bin/flowctl review-backend # show backend that would run now (ASK if unset)
+
+# Checkpoint (save/restore spec state — useful before destructive edits)
+.flow/bin/flowctl checkpoint save fn-1-add-oauth # snapshot spec + tasks
+.flow/bin/flowctl checkpoint restore fn-1-add-oauth # restore from snapshot
+.flow/bin/flowctl checkpoint delete fn-1-add-oauth # delete snapshot
+
+# Ralph (autonomous mode run control — for /flow-next:ralph-init users)
+.flow/bin/flowctl ralph status # current run state
+.flow/bin/flowctl ralph pause # pause running loop
+.flow/bin/flowctl ralph resume # resume paused loop
+.flow/bin/flowctl ralph stop # request stop after current iteration
 ```
 
 ## Workflow
@@ -93,6 +194,17 @@ Runtime state (status, assignee, etc.) is stored in `.git/flow-state/`, shared a
 ```
 
 Migration is optional — existing repos work without changes.
+
+## Deprecation: legacy `flowctl epic *` aliases
+
+flow-next 1.0.0 renamed the spec surface from `epic` to `spec`. The legacy `flowctl epic *` subcommands continue to work in 1.x as thin aliases that dispatch to the new `flowctl spec *` handlers; each invocation emits a one-line stderr deprecation warning. Suppress via `FLOW_NO_DEPRECATION=1`. Aliases are removed in 2.0.
+
+A pre-1.0 `.flow/` directory keeps working via the alias layer (no auto-migration). To migrate to the canonical 1.0+ layout, run either:
+
+- `/flow-next:setup` (interactive, prompts before writing) — recommended in human-driven sessions.
+- `flowctl migrate-rename --yes` (deterministic) — recommended for scripts and CI.
+
+`FLOW_NO_AUTO_MIGRATE=1` suppresses the migration banner entirely; alias mode keeps working.
 
 ## More Info
 

--- a/plugins/flow-next/skills/flow-next-setup/templates/usage.md
+++ b/plugins/flow-next/skills/flow-next-setup/templates/usage.md
@@ -13,18 +13,29 @@ Task tracking for AI agents. All state lives in `.flow/`.
 
 ```
 .flow/
-├── bin/flowctl             # CLI (this install)
-├── specs/fn-N-slug.json    # Spec metadata (e.g., fn-1-add-oauth.json)
-├── specs/fn-N-slug.md      # Spec markdown
-├── tasks/fn-N-slug.M.json  # Task metadata (e.g., fn-1-add-oauth.1.json)
-├── tasks/fn-N-slug.M.md    # Task specifications
-├── memory/                 # Context memory
-├── .flow_version           # 1.0.0 sentinel — written after migration; tracked
-├── .gitignore              # Auto-managed by flowctl (1.0+) — excludes transients
-└── meta.json               # Project metadata
+├── bin/flowctl                  # CLI (this install)
+├── templates/spec.md            # Canonical 7-section spec scaffold (copied by /flow-next:setup)
+├── specs/fn-N-slug.md           # Spec content (canonical)
+├── specs/fn-N-slug.json         # Spec metadata (1.0+ — colocated with the markdown)
+├── tasks/fn-N-slug.M.md         # Task specifications
+├── tasks/fn-N-slug.M.json       # Task metadata
+├── memory/{bug,knowledge}/<category>/  # Context memory (categorized; bug: build-errors, runtime-errors, test-failures, …; knowledge: architecture-patterns, conventions, …)
+├── prospects/<slug>-<date>.md   # Ideation artifacts (v0.36.0+)
+├── review-receipts/<branch>.json  # Review verdicts + findings (per branch)
+├── review-deferred/<branch>.md  # Walkthrough deferrals (fn-32.3)
+├── .flow_version                # 1.0.0 sentinel — written after layout migration
+├── .gitignore                   # Auto-managed by flowctl (1.0+) — excludes per-developer state + migration transients
+└── meta.json                    # Project metadata (schema_version, setup_version, setup_date)
 ```
 
-`.flow/.gitignore` is auto-written so `git add -A` doesn't accidentally commit per-developer state (`.checkpoint-*.json`, `receipts/`, `tmp/`) or migration transients (`.backup-pre-1.0/`, `.banner-acknowledged`, `.migrating`, `.migration-manifest`). Idempotent on re-init / re-migrate; user patterns added below the auto-managed footer are preserved.
+`.flow/epics/` is the pre-1.0 sidecar location. Repos created on 1.0+ never have it; pre-1.0 repos keep working via the alias layer until you run `flowctl migrate-rename --yes` (or `/flow-next:setup`'s upgrade branch).
+
+`.flow/.gitignore` is auto-written by `flowctl init` and `flowctl migrate-rename` so `git add -A` doesn't accidentally commit per-developer state (`.checkpoint-*.json`, `receipts/`, `tmp/`) or migration transients (`.backup-pre-1.0/`, `.banner-acknowledged`, `.migrating`, `.migration-manifest`). Idempotent; user patterns added below the auto-managed footer are preserved on update.
+
+The project's strategic intent and canonical vocabulary live **outside** `.flow/` so they survive `rm -rf .flow/`:
+
+- `STRATEGY.md` (repo root) — target problem, approach, personas, metrics, active tracks (v0.40.0+).
+- `GLOSSARY.md` (repo root or any ancestor) — canonical terms with `_Avoid_` aliases (v0.39.0+).
 
 ## IDs
 
@@ -49,23 +60,113 @@ Task tracking for AI agents. All state lives in `.flow/`.
 .flow/bin/flowctl cat fn-1-add-oauth            # Spec markdown
 .flow/bin/flowctl cat fn-1-add-oauth.2          # Task spec (markdown)
 
-# Status
-.flow/bin/flowctl ready --spec fn-1-add-oauth   # What's ready to work on
+# State
+.flow/bin/flowctl status                        # .flow state + active Ralph runs
+.flow/bin/flowctl ready --spec fn-1-add-oauth   # Tasks ready to work on
 .flow/bin/flowctl validate --all                # Check structure
 .flow/bin/flowctl state-path                    # Show state directory (for worktrees)
 
-# Create
-.flow/bin/flowctl spec create --title "..."
+# Spec lifecycle
+.flow/bin/flowctl spec create --title "..."                    # Create new spec
+.flow/bin/flowctl spec set-plan fn-1-add-oauth --file plan.md  # Replace spec markdown
+.flow/bin/flowctl spec set-title fn-1-add-oauth --title "..."  # Rename (updates slug)
+.flow/bin/flowctl spec set-branch fn-1-add-oauth --branch ...  # Set branch name
+.flow/bin/flowctl spec close fn-1-add-oauth                    # Close spec
+.flow/bin/flowctl spec skeleton                                # Print fresh-spec scaffold
+
+# Task lifecycle
 .flow/bin/flowctl task create --spec fn-1-add-oauth --title "..."
 .flow/bin/flowctl task create --spec fn-1-add-oauth --title "..." --deps fn-1-add-oauth.1,fn-1-add-oauth.2
+.flow/bin/flowctl task set-description <id> --description-file desc.md
+.flow/bin/flowctl task set-acceptance <id> --acceptance-file accept.md
+.flow/bin/flowctl task set-spec <id> --file spec.md            # Full task spec from file
+.flow/bin/flowctl task reset <id>                              # Reset to todo (cascading: --cascade)
 
 # Dependencies
 .flow/bin/flowctl task set-deps fn-1-add-oauth.3 --deps fn-1-add-oauth.1,fn-1-add-oauth.2
 .flow/bin/flowctl dep add fn-1-add-oauth.3 fn-1-add-oauth.1
+.flow/bin/flowctl spec add-dep fn-1-add-oauth --dep fn-2
+.flow/bin/flowctl spec rm-dep fn-1-add-oauth --dep fn-2
 
 # Work
 .flow/bin/flowctl start fn-1-add-oauth.2        # Claim task
 .flow/bin/flowctl done fn-1-add-oauth.2 --summary-file s.md --evidence-json e.json
+.flow/bin/flowctl block fn-1-add-oauth.2 --reason-file reason.md   # Block task with reason
+
+# Spec cognitive-aid export (used by /flow-next:make-pr, v0.42.0+)
+.flow/bin/flowctl spec export-cognitive-aid fn-1-add-oauth                  # text mode summary
+.flow/bin/flowctl spec export-cognitive-aid fn-1-add-oauth --json           # full structured payload
+.flow/bin/flowctl spec export-cognitive-aid fn-1-add-oauth --base main      # diff against base ref
+.flow/bin/flowctl spec export-cognitive-aid fn-1-add-oauth --section coverage --json  # one section only
+
+# Prospect (ideation artifacts under .flow/prospects/, v0.36.0+)
+.flow/bin/flowctl prospect list                          # active artifacts (<30d)
+.flow/bin/flowctl prospect list --all --json             # everything
+.flow/bin/flowctl prospect read <id>                     # full body
+.flow/bin/flowctl prospect read <id> --section survivors # focus|grounding|survivors|rejected
+.flow/bin/flowctl prospect promote <id> --idea N         # idea N → new spec
+.flow/bin/flowctl prospect promote <id> --idea N --force # override idempotency guard
+.flow/bin/flowctl prospect archive <id>                  # → .flow/prospects/_archive/
+
+# Memory (categorized learnings under .flow/memory/, v0.33.0+)
+.flow/bin/flowctl memory list                            # default: --status active
+.flow/bin/flowctl memory list --status stale             # stale entries only
+.flow/bin/flowctl memory search <query>                  # default: --status active
+.flow/bin/flowctl memory search <query> --status all     # active + stale
+.flow/bin/flowctl memory read <id>                       # full entry
+.flow/bin/flowctl memory mark-stale <id> --reason "..."  # flag stale (v0.37.0+)
+.flow/bin/flowctl memory mark-fresh <id>                 # clear stale flag (v0.37.0+)
+.flow/bin/flowctl memory list-legacy                     # list legacy entries with mechanical defaults (v0.37.0+)
+.flow/bin/flowctl memory list-legacy --json              # used by /flow-next:memory-migrate skill
+.flow/bin/flowctl memory migrate [--yes] [--json]        # deterministic-only legacy migration (use /flow-next:memory-migrate for agent-native classification)
+
+# Glossary (project-canonical terms at repo root, v0.39.0+ — survives `rm -rf .flow/`)
+.flow/bin/flowctl glossary add <term> --definition "..."           # upsert single-line term
+.flow/bin/flowctl glossary add <term> --definition-file body.md    # multi-line definition from file
+.flow/bin/flowctl glossary add <term> --definition-file -          # multi-line from stdin
+.flow/bin/flowctl glossary add <term> --avoid "alt1,alt2" --relates-to "x,y"
+.flow/bin/flowctl glossary list                                    # text mode: grouped by file (nearest first)
+.flow/bin/flowctl glossary list --json                             # {groups, file_count, total_terms}
+.flow/bin/flowctl glossary read <term>                             # nearest-ancestor walk; first match wins
+.flow/bin/flowctl glossary read <term> --json                      # {path, term, definition, avoid, relates_to}
+.flow/bin/flowctl glossary remove <term>                           # last-term remove leaves `# Glossary` husk (R18)
+
+# Strategy (project-canonical strategic intent at repo root, v0.40.0+ — survives `rm -rf .flow/`)
+.flow/bin/flowctl strategy status                                  # text mode: husk / sections_filled / total_sections / last_updated
+.flow/bin/flowctl strategy status --json                           # {exists, husk, sections_filled, total_sections, last_updated, file_path}
+.flow/bin/flowctl strategy read                                    # full STRATEGY.md (single-root walk from cwd up to repo root)
+.flow/bin/flowctl strategy read --section approach                 # one section only (target_problem / approach / personas / metrics / tracks / milestones / not_working_on)
+.flow/bin/flowctl strategy read --json                             # {path, name, last_updated, target_problem, approach, personas, metrics, tracks, milestones, not_working_on}
+.flow/bin/flowctl strategy list --json                             # {groups, file_count, total_sections} — parallel to glossary list
+
+# /flow-next:strategy skill writes STRATEGY.md directly (no flowctl strategy add — too prose-heavy for atomic CLI).
+
+# Config (per-project knobs in .flow/config.json — see /flow-next:setup for guided setup)
+.flow/bin/flowctl config get review.backend                        # rp|codex|copilot|none, or spec form like codex:gpt-5.4:high
+.flow/bin/flowctl config get review.backend --raw --json           # bypass merged defaults (null = absent from file)
+.flow/bin/flowctl config set review.backend codex                  # bare backend
+.flow/bin/flowctl config set review.backend codex:gpt-5.4:high     # full spec (backend:model:effort)
+.flow/bin/flowctl config set memory.enabled true                   # auto-capture from NEEDS_WORK reviews
+.flow/bin/flowctl config set planSync.enabled true                 # sync downstream task specs after impl drift
+.flow/bin/flowctl config set planSync.crossSpec false              # also check other open specs (canonical key; legacy alias planSync.crossEpic removed in 2.0)
+.flow/bin/flowctl config set scouts.github false                   # GitHub scout (requires gh CLI)
+
+# Per-spec / per-task backend overrides (override the global review.backend per workstream)
+.flow/bin/flowctl spec set-backend fn-1-add-oauth --review codex:gpt-5.4:high
+.flow/bin/flowctl task set-backend fn-1-add-oauth.3 --impl copilot:claude-opus-4.5
+.flow/bin/flowctl task show-backend fn-1-add-oauth.3                # effective specs (task + spec levels merged)
+.flow/bin/flowctl review-backend                                    # show backend that would run now (ASK if unset)
+
+# Checkpoint (save/restore spec state — useful before destructive edits)
+.flow/bin/flowctl checkpoint save fn-1-add-oauth                    # snapshot spec + tasks
+.flow/bin/flowctl checkpoint restore fn-1-add-oauth                 # restore from snapshot
+.flow/bin/flowctl checkpoint delete fn-1-add-oauth                  # delete snapshot
+
+# Ralph (autonomous mode run control — for /flow-next:ralph-init users)
+.flow/bin/flowctl ralph status                                      # current run state
+.flow/bin/flowctl ralph pause                                       # pause running loop
+.flow/bin/flowctl ralph resume                                      # resume paused loop
+.flow/bin/flowctl ralph stop                                        # request stop after current iteration
 ```
 
 ## Workflow
@@ -93,6 +194,17 @@ Runtime state (status, assignee, etc.) is stored in `.git/flow-state/`, shared a
 ```
 
 Migration is optional — existing repos work without changes.
+
+## Deprecation: legacy `flowctl epic *` aliases
+
+flow-next 1.0.0 renamed the spec surface from `epic` to `spec`. The legacy `flowctl epic *` subcommands continue to work in 1.x as thin aliases that dispatch to the new `flowctl spec *` handlers; each invocation emits a one-line stderr deprecation warning. Suppress via `FLOW_NO_DEPRECATION=1`. Aliases are removed in 2.0.
+
+A pre-1.0 `.flow/` directory keeps working via the alias layer (no auto-migration). To migrate to the canonical 1.0+ layout, run either:
+
+- `/flow-next:setup` (interactive, prompts before writing) — recommended in human-driven sessions.
+- `flowctl migrate-rename --yes` (deterministic) — recommended for scripts and CI.
+
+`FLOW_NO_AUTO_MIGRATE=1` suppresses the migration banner entirely; alias mode keeps working.
 
 ## More Info
 


### PR DESCRIPTION
## Summary

Caught when re-running `/flow-next:setup` on this repo bumped `setup_version` from 0.24.0 to 1.1.9 and the byte-compare gate flagged `.flow/usage.md` as customized. Investigation showed the dev repo had a richer `.flow/usage.md` than the canonical template that ships to fresh installs.

**Root cause:** `fn-43.12 user-facing docs sweep` (commit `445a4ef`, "fn-43.12 user-facing docs sweep — root README + plugin README + CLAUDE.md + .flow/usage.md") updated only the dev repo's `.flow/usage.md`. The canonical template at `plugins/flow-next/skills/flow-next-setup/templates/usage.md` was never backported, so every fresh `/flow-next:setup` from 0.42.0 onward shipped a `.flow/usage.md` missing 3 documented surfaces (prospect, spec export-cognitive-aid, `.flow_version` sentinel).

## What changed

- **Promoted the richer dev-repo usage.md to the canonical template** (and copied back to `.flow/usage.md` so the dev install stays byte-identical to what ships).
- **Extended with surfaces neither version covered:**
  - `flowctl status`
  - `flowctl config get/set` — all five knobs (review.backend, memory.enabled, planSync.enabled, planSync.crossSpec, scouts.github), bare + spec form, `--raw` flag
  - Per-spec / per-task `set-backend`, `task show-backend`, `review-backend`
  - `flowctl checkpoint save/restore/delete`
  - `flowctl ralph pause/resume/stop/status`
  - `flowctl spec set-plan / set-title / set-branch / close / skeleton / add-dep / rm-dep`
  - `flowctl task set-description / set-acceptance / set-spec / reset`
  - `flowctl block --reason-file`
- **Fixed reversed file-structure framing** (template had `specs/*.json` as canonical and `*.md` as metadata; reality is the opposite — `.md` is canonical content, `.json` is colocated metadata).
- **Expanded file-structure diagram** with `templates/spec.md`, `review-receipts/<branch>.json`, `review-deferred/<branch>.md`, `memory/{bug,knowledge}/<category>/` (with category enumeration), and a paragraph about `STRATEGY.md` / `GLOSSARY.md` living at repo root (outside `.flow/`).
- **Dev-repo `.flow/` install refreshed** by the setup re-run (bin/flowctl.py, templates/spec.md, usage.md, meta.json setup_version 0.24.0 → 1.1.10) so the dogfood install matches what the template ships.
- **Bump 1.1.9 → 1.1.10**.

## Verification

- 619 unit tests pass (2 skipped — Windows smoke on macOS).
- `bash scripts/sync-codex.sh` clean; Codex mirror template regenerated.
- `diff plugins/flow-next/skills/flow-next-setup/templates/usage.md .flow/usage.md` → identical.
- Manual cross-check: every command in the new usage.md exists in `.flow/bin/flowctl --help`; every subcommand mentioned has matching `--help`.

## Out of scope (separate follow-up)

While auditing, noticed `flowctl init` silently writes `crossSpec: false` to `.flow/config.json` even when `crossEpic: true` is already set. Per the 1.1.3 read-precedence logic the new canonical key wins, so this silently flips the user's setting from enabled to disabled. Reverted the `.flow/config.json` change in this branch; tracking as a separate concern.

## Test plan

- [x] 619 tests pass
- [x] Codex mirror sync clean
- [x] Template byte-identical to .flow/usage.md
- [x] Every command in usage.md verified against flowctl --help