### PR TITLE
fix(flow-next): init mirrors legacy crossEpic→crossSpec — 1.1.11

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,13 +6,13 @@
   },
   "metadata": {
     "description": "Plan-first workflows for Claude Code and Factory Droid. Ships flow-next: zero-dep, spec-driven, Ralph autonomous mode.",
-    "version": "1.1.10"
+    "version": "1.1.11"
   },
   "plugins": [
     {
       "name": "flow-next",
       "description": "Zero-dependency planning + execution with .flow/ task tracking and Ralph autonomous mode (multi-model review gates). Worker subagent per task for context isolation. Includes 21 subagents, 19 commands, 23 skills.",
-      "version": "1.1.10",
+      "version": "1.1.11",
       "author": {
         "name": "Gordon Mickel",
         "email": "gordon@mickel.tech",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the flow-next.
 
+## [flow-next 1.1.11] - 2026-05-22
+
+### Fixed
+- **`flowctl init` no longer silently flips pre-1.1.3 users' `planSync.crossEpic` from on to off.** Caught while auditing `/flow-next:setup` against the dev repo (this fix's sibling 1.1.10 PR surfaced the `.flow/config.json` diff). Pre-1.1.3 users have `planSync.crossEpic: true` (the only key) in their on-disk config. 1.1.3 introduced `planSync.crossSpec: false` as the new canonical default, and the 1.1.3 read precedence is "canonical wins on presence". Without a pre-merge mirror, every upgrading user who'd opted into cross-spec sync lost the setting on the next `flowctl init` (which `/flow-next:setup` runs unconditionally + bundled worker paths). `flowctl init` now detects the legacy-without-canonical state and mirrors `crossEpic` → `crossSpec` before the default-merge so the canonical key reflects the user's intended setting. Legacy key is preserved per the 1.1.3 deprecation cadence (removed in 2.0). Mirror is idempotent — only runs when legacy is set and canonical is absent.
+
+### Tests
+- `tests/test_init_crossspec_mirror.py` — 5 cases: mirrors `True` legacy, mirrors `False` legacy, canonical-present takes precedence (no mirror), neither-set fresh-install (no mirror), idempotent on re-run.
+
 ## [flow-next 1.1.10] - 2026-05-22
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Flow-Next
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Flow-next](https://img.shields.io/badge/Flow--next-v1.1.10-green)](CHANGELOG.md)
+[![Flow-next](https://img.shields.io/badge/Flow--next-v1.1.11-green)](CHANGELOG.md)
 [![Docs](https://img.shields.io/badge/Docs-📖-informational)](plugins/flow-next/docs/README.md)
 
 [![Author](https://img.shields.io/badge/Author-Gordon_Mickel-orange)](https://mickel.tech)

--- a/plugins/flow-next/.claude-plugin/plugin.json
+++ b/plugins/flow-next/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "flow-next",
-  "version": "1.1.10",
+  "version": "1.1.11",
   "description": "Zero-dependency planning + execution with .flow/ task tracking and Ralph autonomous mode (multi-model review gates). Worker subagent per task for context isolation. Prime assesses 8 pillars (48 criteria) with GitHub API integration. Includes 21 subagents, 19 commands, 23 skills.",
   "author": {
     "name": "Gordon Mickel",

--- a/plugins/flow-next/.codex-plugin/plugin.json
+++ b/plugins/flow-next/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "flow-next",
-  "version": "1.1.10",
+  "version": "1.1.11",
   "description": "Zero-dependency planning + execution with .flow/ task tracking and Ralph autonomous mode. Worker subagent per task for context isolation. Compatible with Codex, Claude Code, and Factory Droid.",
   "author": {
     "name": "Gordon Mickel",

--- a/plugins/flow-next/scripts/flowctl.py
+++ b/plugins/flow-next/scripts/flowctl.py
@@ -4478,6 +4478,23 @@ def cmd_init(args: argparse.Namespace) -> None:
                 raw = {}
         except (json.JSONDecodeError, Exception):
             raw = {}
+        # Pre-merge migration (1.1.11): if user has legacy planSync.crossEpic
+        # and no canonical planSync.crossSpec, mirror the legacy value to
+        # canonical so the new default (False) doesn't silently flip the
+        # user's effective setting. Read precedence (1.1.3+) is "canonical
+        # wins on presence", so without this mirror, every upgrading user
+        # who had crossEpic set lost their cross-spec sync silently. Legacy
+        # key is kept readable through 1.x per the deprecation cadence.
+        ps = raw.get("planSync")
+        if (
+            isinstance(ps, dict)
+            and "crossEpic" in ps
+            and "crossSpec" not in ps
+        ):
+            ps["crossSpec"] = ps["crossEpic"]
+            actions.append(
+                "mirrored legacy planSync.crossEpic → canonical planSync.crossSpec"
+            )
         merged = deep_merge(get_default_config(), raw)
         if merged != raw:
             atomic_write_json(config_path, merged)

--- a/plugins/flow-next/tests/test_init_crossspec_mirror.py
+++ b/plugins/flow-next/tests/test_init_crossspec_mirror.py
@@ -1,0 +1,196 @@
+"""Tests for `flowctl init`'s legacy `planSync.crossEpic` → canonical
+`planSync.crossSpec` mirror (1.1.11).
+
+Pre-1.1.3 users had `planSync.crossEpic: true` (the only key) in their
+on-disk config. The 1.1.3 default-merge introduced `planSync.crossSpec:
+false` as the new canonical default, and the 1.1.3 read precedence is
+"canonical wins on presence". Without a mirror, every upgrading user
+who'd opted into cross-spec sync lost the setting silently on the next
+`flowctl init` (called by `/flow-next:setup` and bundled worker paths).
+
+1.1.11 adds a pre-merge mirror: if `crossEpic` is in the file and
+`crossSpec` is absent, copy `crossEpic` → `crossSpec` so the canonical
+key reflects the user's intended setting. Legacy key is preserved per
+the 1.1.3 deprecation cadence (removed in 2.0).
+"""
+
+import json
+import sys
+import unittest
+from pathlib import Path
+import tempfile
+from unittest import mock
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPTS_DIR = REPO_ROOT / "plugins" / "flow-next" / "scripts"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+import flowctl  # noqa: E402
+
+
+def _run_init(repo_root: Path):
+    """Invoke `flowctl init --json` against ``repo_root``."""
+    args = mock.MagicMock()
+    args.json = True
+    args.path = str(repo_root)
+    # cmd_init reads global state; we need to ensure cwd-style resolution
+    # finds repo_root. The simplest path is to chdir during the call.
+    cwd = Path.cwd()
+    captured: dict = {}
+
+    def capture_output(payload):
+        captured.update(payload)
+
+    try:
+        import os
+        os.chdir(repo_root)
+        with mock.patch.object(flowctl, "json_output",
+                               side_effect=capture_output):
+            flowctl.cmd_init(args)
+    finally:
+        import os
+        os.chdir(cwd)
+    return captured
+
+
+def _read_config(repo_root: Path) -> dict:
+    return json.loads((repo_root / ".flow" / "config.json").read_text())
+
+
+class InitMirrorsLegacyCrossEpic(unittest.TestCase):
+    """legacy crossEpic + no crossSpec → mirror to canonical."""
+
+    def test_mirrors_true_legacy(self):
+        with tempfile.TemporaryDirectory() as td:
+            repo_root = Path(td)
+            flow_dir = repo_root / ".flow"
+            flow_dir.mkdir()
+            # Seed pre-1.1.3 layout: crossEpic explicitly true, no crossSpec.
+            (flow_dir / "config.json").write_text(json.dumps({
+                "planSync": {"enabled": True, "crossEpic": True},
+                "memory": {"enabled": True},
+                "review": {},
+            }))
+            result = _run_init(repo_root)
+
+            cfg = _read_config(repo_root)
+            # Mirror happened: crossSpec now reflects user's intended value.
+            self.assertEqual(cfg["planSync"]["crossSpec"], True)
+            # Legacy key preserved per 1.1.3 deprecation cadence.
+            self.assertEqual(cfg["planSync"]["crossEpic"], True)
+            # Action log mentions the mirror.
+            actions = result.get("actions", [])
+            mirror_msgs = [
+                a for a in actions
+                if "crossEpic" in a and "crossSpec" in a
+            ]
+            self.assertEqual(len(mirror_msgs), 1,
+                             f"expected mirror action; got actions={actions}")
+
+    def test_mirrors_false_legacy(self):
+        # If user explicitly turned crossEpic off (rare but valid),
+        # mirroring preserves that too.
+        with tempfile.TemporaryDirectory() as td:
+            repo_root = Path(td)
+            flow_dir = repo_root / ".flow"
+            flow_dir.mkdir()
+            (flow_dir / "config.json").write_text(json.dumps({
+                "planSync": {"crossEpic": False},
+            }))
+            _run_init(repo_root)
+            cfg = _read_config(repo_root)
+            self.assertEqual(cfg["planSync"]["crossSpec"], False)
+            self.assertEqual(cfg["planSync"]["crossEpic"], False)
+
+
+class InitDoesNotMirrorWhenCanonicalPresent(unittest.TestCase):
+    """If user already set canonical crossSpec, the legacy value is ignored
+    (canonical-wins-on-presence semantics)."""
+
+    def test_canonical_wins(self):
+        with tempfile.TemporaryDirectory() as td:
+            repo_root = Path(td)
+            flow_dir = repo_root / ".flow"
+            flow_dir.mkdir()
+            (flow_dir / "config.json").write_text(json.dumps({
+                "planSync": {
+                    "crossEpic": True,    # legacy says enable
+                    "crossSpec": False,   # canonical says disable
+                },
+            }))
+            result = _run_init(repo_root)
+            cfg = _read_config(repo_root)
+            # User's explicit canonical setting wins; no mirror runs.
+            self.assertEqual(cfg["planSync"]["crossSpec"], False)
+            self.assertEqual(cfg["planSync"]["crossEpic"], True)
+            actions = result.get("actions", [])
+            mirror_msgs = [
+                a for a in actions
+                if "crossEpic" in a and "crossSpec" in a
+            ]
+            self.assertEqual(mirror_msgs, [],
+                             "must not mirror when canonical is present")
+
+
+class InitDoesNotMirrorWhenNeitherSet(unittest.TestCase):
+    """Fresh-install style configs (neither key set) just get default-merge
+    behavior with crossSpec: false."""
+
+    def test_neither_set(self):
+        with tempfile.TemporaryDirectory() as td:
+            repo_root = Path(td)
+            flow_dir = repo_root / ".flow"
+            flow_dir.mkdir()
+            (flow_dir / "config.json").write_text(json.dumps({
+                "memory": {"enabled": True},
+            }))
+            result = _run_init(repo_root)
+            cfg = _read_config(repo_root)
+            # Default canonical (false) lands; no legacy key written.
+            self.assertEqual(cfg["planSync"]["crossSpec"], False)
+            self.assertNotIn("crossEpic", cfg["planSync"])
+            actions = result.get("actions", [])
+            mirror_msgs = [
+                a for a in actions
+                if "crossEpic" in a and "crossSpec" in a
+            ]
+            self.assertEqual(mirror_msgs, [],
+                             "must not mirror when legacy is absent")
+
+
+class InitIdempotent(unittest.TestCase):
+    """Re-running init on a config that already has both keys (post-mirror
+    state) must be a no-op for the planSync section."""
+
+    def test_idempotent_after_mirror(self):
+        with tempfile.TemporaryDirectory() as td:
+            repo_root = Path(td)
+            flow_dir = repo_root / ".flow"
+            flow_dir.mkdir()
+            # First run: legacy → mirror happens.
+            (flow_dir / "config.json").write_text(json.dumps({
+                "planSync": {"crossEpic": True},
+            }))
+            _run_init(repo_root)
+            cfg_after_first = _read_config(repo_root)
+            self.assertEqual(cfg_after_first["planSync"]["crossSpec"], True)
+            # Second run: no mirror action expected.
+            result = _run_init(repo_root)
+            actions = result.get("actions", [])
+            mirror_msgs = [
+                a for a in actions
+                if "crossEpic" in a and "crossSpec" in a
+            ]
+            self.assertEqual(mirror_msgs, [],
+                             "second run must not re-mirror")
+            cfg_after_second = _read_config(repo_root)
+            self.assertEqual(
+                cfg_after_second["planSync"], cfg_after_first["planSync"],
+                "planSync section must be byte-identical across reruns",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

`flowctl init` was silently flipping pre-1.1.3 users' `planSync.crossEpic` from on to off. Caught while auditing `/flow-next:setup` on the dev repo (sibling [#144](https://github.com/gmickel/flow-next/pull/144) for 1.1.10 surfaced the symptom).

**Pre-condition:** pre-1.1.3 users have `planSync.crossEpic: true` (only key) in `.flow/config.json`. 1.1.3 introduced `planSync.crossSpec: false` as the new canonical default with "canonical wins on presence" read precedence.

**Failure:** every `flowctl init` (called unconditionally by `/flow-next:setup`, plus bundled worker paths) ran `deep_merge(get_default_config(), raw)`. The merge produced `{crossEpic: true, crossSpec: false}`. Canonical wins on read → user's cross-spec sync silently became false.

## What changed

`plugins/flow-next/scripts/flowctl.py:4481` — added a pre-merge mirror step:

```python
ps = raw.get("planSync")
if isinstance(ps, dict) and "crossEpic" in ps and "crossSpec" not in ps:
    ps["crossSpec"] = ps["crossEpic"]
    actions.append("mirrored legacy planSync.crossEpic → canonical planSync.crossSpec")
merged = deep_merge(get_default_config(), raw)
```

Mirror runs only when legacy is set AND canonical is absent — so subsequent init runs are a no-op for the planSync section. Legacy key is preserved per 1.1.3's deprecation cadence (removed in 2.0).

## Tests

`tests/test_init_crossspec_mirror.py` — 5 cases:

| Scenario | Expected |
|---|---|
| legacy `crossEpic: true`, no canonical | mirror writes `crossSpec: true`; legacy kept |
| legacy `crossEpic: false`, no canonical | mirror writes `crossSpec: false`; legacy kept |
| both set (`crossEpic: true`, `crossSpec: false`) | no mirror; canonical wins as-is |
| neither set (fresh install) | no mirror; default `crossSpec: false` lands |
| re-run on already-mirrored config | no mirror action; planSync section byte-identical |

## Verification

- 624 unit tests pass (5 new).
- `bash scripts/sync-codex.sh` clean.

## Test plan

- [x] 624 tests pass
- [x] Codex mirror sync clean
- [x] Idempotency verified (re-run produces no actions)