### PR TITLE
feat(map): heuristic-0-features hint + conventional-repo guidance (1.3.2)

### DIFF
--- a/.flow/meta.json
+++ b/.flow/meta.json
@@ -1,6 +1,6 @@
 {
   "next_spec": 1,
   "schema_version": 3,
-  "setup_date": "2026-05-27T08:57:43.373540Z",
-  "setup_version": "1.3.0"
+  "setup_date": "2026-05-27T09:22:07.180974Z",
+  "setup_version": "1.3.1"
 }

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,11 @@ scripts/ralph/
 .flow/.banner-acknowledged
 .flow/.migrating
 .flow/.migration-manifest
+
+# clawpatch feature-map state (fn-50). The /flow-next:map skill writes a
+# self-contained .clawpatch/.gitignore (`*` + `!.gitignore`) for user repos,
+# but its `!.gitignore` negation leaves that one file trackable — and our
+# `work` skill stages with `git add -A`. Ignore the whole dir at repo root so
+# our own dogfood map (local-only, regenerable via /flow-next:map --source
+# agent) never gets staged into the plugin repo.
+.clawpatch/

--- a/plugins/flow-next/codex/skills/flow-next-map/SKILL.md
+++ b/plugins/flow-next/codex/skills/flow-next-map/SKILL.md
@@ -30,7 +30,7 @@ Arguments: `$ARGUMENTS`
 
 Format: `[--source <heuristic|auto|agent>] [-- <extra clawpatch args>]`
 
-- **Default** (no args) → `clawpatch map --source heuristic` (provider-free, deterministic).
+- **Default** (no args) → `clawpatch map --source heuristic` (provider-free, deterministic). Heuristic targets conventional app/framework layouts; unconventional repos (CLI tools, plugins, markdown/docs-heavy, non-standard monorepos) may map to 0 features — Phase 5 surfaces a `--source=auto|agent` suggestion when that happens.
 - `--source auto|agent` → passthrough to clawpatch; user must have `CLAWPATCH_PROVIDER` configured for these paths (clawpatch's own concern, not ours).
 - `--` → terminator; tokens after flow to `clawpatch map` (e.g. `--since-ref origin/main`, `--paths src/`).
 

--- a/plugins/flow-next/codex/skills/flow-next-map/workflow.md
+++ b/plugins/flow-next/codex/skills/flow-next-map/workflow.md
@@ -327,11 +327,38 @@ if [[ -d "$FEATURES_DIR" ]]; then
 
 Mapped: $COUNT feature(s) at $FEATURES_DIR
 Last-mapped: $LAST
+EOF
+
+ # Zero-features-on-heuristic hint. clawpatch's heuristic mapper targets
+ # conventional app/framework layouts (npm bins, Next.js routes, Python
+ # packages, Rails/Laravel/Django, Go/Rust services, JVM, .NET, SwiftPM,
+ # Phoenix). Repos that don't match — CLI tools, plugins, markdown/docs-heavy,
+ # non-standard monorepos — get 0 features and clawpatch flags coverage as
+ # weak (`weak=true`, `agent-skip reason=heuristic` in the map output above).
+ # Surface the next step rather than leaving the user with a silent empty map.
+ if [[ "$COUNT" -eq 0 && "$SOURCE" == "heuristic" ]]; then
+ cat >&2 <<'EOF'
+
+Note: heuristic mapping found 0 features. clawpatch's deterministic mapper
+targets conventional app/framework layouts; if this repo is a CLI tool,
+plugin, or has a non-standard structure, the heuristic detectors may not
+match it (clawpatch flags this as "weak" coverage above). For richer,
+LLM-backed mapping:
+
+ /flow-next:map --source=auto # heuristic first, provider only if weak
+ /flow-next:map --source=agent # always provider-backed
+
+Both require a clawpatch provider configured (CLAWPATCH_PROVIDER, e.g. codex)
+and spend provider tokens — orthogonal to flow-next's review backend.
+EOF
+ fi
+
+ cat <<EOF
 
 Next steps:
- - flowctl repo-map list (lands in fn-50.2)
- - /flow-next:plan <spec-id> (scout consumption lands in fn-50.3)
- - /flow-next:capture (scout consumption lands in fn-50.3)
+ - flowctl repo-map list
+ - /flow-next:plan <spec-id> (scouts read the index when present)
+ - /flow-next:capture (scouts read the index when present)
 EOF
 else
  echo "Warning: clawpatch map exited 0 but .clawpatch/features/ is missing. Inspect $CLAWPATCH_DIR directly." >&2

--- a/plugins/flow-next/skills/flow-next-map/SKILL.md
+++ b/plugins/flow-next/skills/flow-next-map/SKILL.md
@@ -29,7 +29,7 @@ Arguments: `$ARGUMENTS`
 
 Format: `[--source <heuristic|auto|agent>] [-- <extra clawpatch args>]`
 
-- **Default** (no args) → `clawpatch map --source heuristic` (provider-free, deterministic).
+- **Default** (no args) → `clawpatch map --source heuristic` (provider-free, deterministic). Heuristic targets conventional app/framework layouts; unconventional repos (CLI tools, plugins, markdown/docs-heavy, non-standard monorepos) may map to 0 features — Phase 5 surfaces a `--source=auto|agent` suggestion when that happens.
 - `--source auto|agent` → passthrough to clawpatch; user must have `CLAWPATCH_PROVIDER` configured for these paths (clawpatch's own concern, not ours).
 - `--` → terminator; tokens after flow to `clawpatch map` (e.g. `--since-ref origin/main`, `--paths src/`).
 

--- a/plugins/flow-next/skills/flow-next-map/workflow.md
+++ b/plugins/flow-next/skills/flow-next-map/workflow.md
@@ -326,11 +326,38 @@ if [[ -d "$FEATURES_DIR" ]]; then
 
 Mapped: $COUNT feature(s) at $FEATURES_DIR
 Last-mapped: $LAST
+EOF
+
+  # Zero-features-on-heuristic hint. clawpatch's heuristic mapper targets
+  # conventional app/framework layouts (npm bins, Next.js routes, Python
+  # packages, Rails/Laravel/Django, Go/Rust services, JVM, .NET, SwiftPM,
+  # Phoenix). Repos that don't match — CLI tools, plugins, markdown/docs-heavy,
+  # non-standard monorepos — get 0 features and clawpatch flags coverage as
+  # weak (`weak=true`, `agent-skip reason=heuristic` in the map output above).
+  # Surface the next step rather than leaving the user with a silent empty map.
+  if [[ "$COUNT" -eq 0 && "$SOURCE" == "heuristic" ]]; then
+    cat >&2 <<'EOF'
+
+Note: heuristic mapping found 0 features. clawpatch's deterministic mapper
+targets conventional app/framework layouts; if this repo is a CLI tool,
+plugin, or has a non-standard structure, the heuristic detectors may not
+match it (clawpatch flags this as "weak" coverage above). For richer,
+LLM-backed mapping:
+
+    /flow-next:map --source=auto    # heuristic first, provider only if weak
+    /flow-next:map --source=agent   # always provider-backed
+
+Both require a clawpatch provider configured (CLAWPATCH_PROVIDER, e.g. codex)
+and spend provider tokens — orthogonal to flow-next's review backend.
+EOF
+  fi
+
+  cat <<EOF
 
 Next steps:
-  - flowctl repo-map list           (lands in fn-50.2)
-  - /flow-next:plan <spec-id>       (scout consumption lands in fn-50.3)
-  - /flow-next:capture              (scout consumption lands in fn-50.3)
+  - flowctl repo-map list
+  - /flow-next:plan <spec-id>       (scouts read the index when present)
+  - /flow-next:capture              (scouts read the index when present)
 EOF
 else
   echo "Warning: clawpatch map exited 0 but .clawpatch/features/ is missing. Inspect $CLAWPATCH_DIR directly." >&2


### PR DESCRIPTION
## TL;DR

Live-testing fn-50's `/flow-next:map` on flow-next's own repo (clawpatch 0.4.0, codex provider) surfaced a real UX gap: the heuristic mapper returns **0 features** for repos that don't match its conventional app/framework detectors — and the Phase 5 summary printed a silent "Mapped: 0 feature(s)" with no explanation. This surfaces clawpatch's own `weak=true` signal and points the user at `--source=auto|agent`.

## The finding

flow-next's repo is a Claude-Code-plugin + markdown-skill + `flowctl.py`-CLI + bun TUI. clawpatch's heuristic detectors target npm bins, Next.js routes, Python *packages*, Rails/Laravel/Django, Go/Rust services, JVM, .NET, SwiftPM, Phoenix — **none match**. Result: `map --source heuristic` → 0 features, `weak=true`, `agent-skip reason=heuristic`. `map --source agent` (codex) → **9 well-scoped features** in ~5.5 min (Flowctl CLI Core, Ralph Guardrails, Flow Memory System, TUI Shell/Theme/Integration, Plugin Packaging, Strategy/Docs).

So the provider-free default is the happy path *for conventional app repos*; unconventional repos (CLI tools, plugins, docs-heavy, non-standard monorepos) need `--source auto|agent`.

## Changes

- **`workflow.md` Phase 5** — when heuristic yields 0 features, print a note: explains the conventional-layout targeting, suggests `--source=auto` (heuristic-first, provider only if weak) / `--source=agent` (always provider-backed), notes both need `CLAWPATCH_PROVIDER` + tokens. Happy path (features > 0) unchanged.
- **`SKILL.md`** — one-line note on the Input section.
- **Codex mirror** regenerated.
- **`.gitignore`** — root-ignore `.clawpatch/`. The skill's self-contained `.clawpatch/.gitignore` (`*` + `!.gitignore`) leaves that one file trackable, and our `work` skill stages via `git add -A`; root-ignoring keeps our dogfood map out of the plugin repo.
- **`chore(.flow)`** (commit `1991da1`) — `setup_version` 1.3.0 → 1.3.1 from this session's setup re-run.

## Verification

This was found *by* a full live test (install clawpatch → init → map heuristic → map agent → repo-map list/show/since-ref → DE7 flip). All flow-next plumbing verified end-to-end against real 9-feature data. `map_smoke_test.sh` 75/75, `test_pnpm_home_hint_prose.py` 5/5, full suite green.

## Version note

Touches skill files → patch bump 1.3.1 → 1.3.2 after merge.