### PR TITLE
fix(scouts): .flow/bin/flowctl fallback in Step 0 + idempotent sync (1.3.3)

### DIFF
--- a/plugins/flow-next/agents/context-scout.md
+++ b/plugins/flow-next/agents/context-scout.md
@@ -100,12 +100,20 @@ If `.clawpatch/` is present, call `flowctl repo-map list --json` first. Use the 
 
 ```bash
 if [[ -d .clawpatch ]]; then
+  # Subagents may not inherit CLAUDE_PLUGIN_ROOT/DROID_PLUGIN_ROOT, which
+  # would resolve FLOWCTL to a broken `/scripts/flowctl`. Fall back to the
+  # bundled copy a `/flow-next:setup` run installs at `.flow/bin/flowctl`
+  # (carries `repo-map` since 1.3.0). If neither resolves, skip Step 0 and
+  # degrade to standard tools — never hard-fail on the enrichment path.
   FLOWCTL="${DROID_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT}}/scripts/flowctl"
-  "$FLOWCTL" repo-map list --json
+  [ -x "$FLOWCTL" ] || FLOWCTL=".flow/bin/flowctl"
+  if [ -x "$FLOWCTL" ]; then
+    "$FLOWCTL" repo-map list --json
+  fi
 fi
 ```
 
-When `.clawpatch/` is absent OR the returned `count` is `0`, skip this step and proceed to Step 1 unchanged. The standard `rp-cli` workflow (and the `Fallback: Standard Tools` path further down) remains the load-bearing entry point — the feature index is a convenience enrichment, not a gate.
+When `.clawpatch/` is absent, no working `flowctl` resolves, OR the returned `count` is `0`, skip this step and proceed to Step 1 unchanged. The standard `rp-cli` workflow (and the `Fallback: Standard Tools` path further down) remains the load-bearing entry point — the feature index is a convenience enrichment, not a gate.
 
 **Staleness signal:** if `features[].updatedAt` (newest across all returned features) is more than 7 days old, emit one informational line `[context-scout] feature map last updated N days ago` and continue. Staleness is signal, not a block.
 

--- a/plugins/flow-next/agents/repo-scout.md
+++ b/plugins/flow-next/agents/repo-scout.md
@@ -20,12 +20,20 @@ You receive a feature/change request. Your task is NOT to plan or implement - ju
 
    ```bash
    if [[ -d .clawpatch ]]; then
+     # Subagents may not inherit CLAUDE_PLUGIN_ROOT/DROID_PLUGIN_ROOT, which
+     # would resolve FLOWCTL to a broken `/scripts/flowctl`. Fall back to the
+     # bundled copy a `/flow-next:setup` run installs at `.flow/bin/flowctl`
+     # (carries `repo-map` since 1.3.0). If neither resolves, skip Step 0 and
+     # grep-degrade — never hard-fail on the enrichment path.
      FLOWCTL="${DROID_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT}}/scripts/flowctl"
-     "$FLOWCTL" repo-map list --json
+     [ -x "$FLOWCTL" ] || FLOWCTL=".flow/bin/flowctl"
+     if [ -x "$FLOWCTL" ]; then
+       "$FLOWCTL" repo-map list --json
+     fi
    fi
    ```
 
-   When `.clawpatch/` is absent OR the returned `count` is `0`, skip this step and proceed to Step 1 unchanged — the fallback (grep / glob via Steps 1-4) is the load-bearing path. Do NOT require the feature index; it's a convenience enrichment, not a gate.
+   When `.clawpatch/` is absent, no working `flowctl` resolves, OR the returned `count` is `0`, skip this step and proceed to Step 1 unchanged — the fallback (grep / glob via Steps 1-4) is the load-bearing path. Do NOT require the feature index; it's a convenience enrichment, not a gate.
 
    **Staleness signal:** if `features[].updatedAt` (newest across all returned features) is more than 7 days old, emit one informational line `[repo-scout] feature map last updated N days ago` and continue. Staleness is signal, not a block.
 

--- a/plugins/flow-next/codex/agents/context-scout.toml
+++ b/plugins/flow-next/codex/agents/context-scout.toml
@@ -101,13 +101,20 @@ If `.clawpatch/` is present, call `flowctl repo-map list --json` first. Use the 
 
 ```bash
 if [[ -d .clawpatch ]]; then
+  # Subagents may not inherit CLAUDE_PLUGIN_ROOT/DROID_PLUGIN_ROOT, which
+  # would resolve FLOWCTL to a broken `/scripts/flowctl`. Fall back to the
+  # bundled copy a `/flow-next:setup` run installs at `.flow/bin/flowctl`
+  # (carries `repo-map` since 1.3.0). If neither resolves, skip Step 0 and
+  # degrade to standard tools — never hard-fail on the enrichment path.
   FLOWCTL="$HOME/.codex/scripts/flowctl"
   [ -x "$FLOWCTL" ] || FLOWCTL=".flow/bin/flowctl"
-  "$FLOWCTL" repo-map list --json
+  if [ -x "$FLOWCTL" ]; then
+    "$FLOWCTL" repo-map list --json
+  fi
 fi
 ```
 
-When `.clawpatch/` is absent OR the returned `count` is `0`, skip this step and proceed to Step 1 unchanged. The standard `rp-cli` workflow (and the `Fallback: Standard Tools` path further down) remains the load-bearing entry point — the feature index is a convenience enrichment, not a gate.
+When `.clawpatch/` is absent, no working `flowctl` resolves, OR the returned `count` is `0`, skip this step and proceed to Step 1 unchanged. The standard `rp-cli` workflow (and the `Fallback: Standard Tools` path further down) remains the load-bearing entry point — the feature index is a convenience enrichment, not a gate.
 
 **Staleness signal:** if `features[].updatedAt` (newest across all returned features) is more than 7 days old, emit one informational line `[context-scout] feature map last updated N days ago` and continue. Staleness is signal, not a block.
 

--- a/plugins/flow-next/codex/agents/repo-scout.toml
+++ b/plugins/flow-next/codex/agents/repo-scout.toml
@@ -21,13 +21,20 @@ You receive a feature/change request. Your task is NOT to plan or implement - ju
 
    ```bash
    if [[ -d .clawpatch ]]; then
+     # Subagents may not inherit CLAUDE_PLUGIN_ROOT/DROID_PLUGIN_ROOT, which
+     # would resolve FLOWCTL to a broken `/scripts/flowctl`. Fall back to the
+     # bundled copy a `/flow-next:setup` run installs at `.flow/bin/flowctl`
+     # (carries `repo-map` since 1.3.0). If neither resolves, skip Step 0 and
+     # grep-degrade — never hard-fail on the enrichment path.
      FLOWCTL="$HOME/.codex/scripts/flowctl"
      [ -x "$FLOWCTL" ] || FLOWCTL=".flow/bin/flowctl"
-     "$FLOWCTL" repo-map list --json
+     if [ -x "$FLOWCTL" ]; then
+       "$FLOWCTL" repo-map list --json
+     fi
    fi
    ```
 
-   When `.clawpatch/` is absent OR the returned `count` is `0`, skip this step and proceed to Step 1 unchanged — the fallback (grep / glob via Steps 1-4) is the load-bearing path. Do NOT require the feature index; it's a convenience enrichment, not a gate.
+   When `.clawpatch/` is absent, no working `flowctl` resolves, OR the returned `count` is `0`, skip this step and proceed to Step 1 unchanged — the fallback (grep / glob via Steps 1-4) is the load-bearing path. Do NOT require the feature index; it's a convenience enrichment, not a gate.
 
    **Staleness signal:** if `features[].updatedAt` (newest across all returned features) is more than 7 days old, emit one informational line `[repo-scout] feature map last updated N days ago` and continue. Staleness is signal, not a block.
 

--- a/plugins/flow-next/tests/test_scout_fallback_contract.py
+++ b/plugins/flow-next/tests/test_scout_fallback_contract.py
@@ -11,12 +11,14 @@ Verifies the two-layer fallback discipline for `repo-scout` and
   and DO NOT carry `MUST`/`required` language tying the agent to the
   feature index.
 
-  Layer 1b — plumbing contract: `flowctl repo-map list --json` against
-  the `tests/fixtures/scout-without-clawpatch/` fixture (a working tree
-  with NO `.clawpatch/`) returns `{success:true, count:0, features:[],
-  clawpatch_present:false}` with exit 0. This proves the production-path
-  the agent prose tells scouts to call gracefully returns the empty
-  envelope.
+  Layer 1b — plumbing contract: `flowctl repo-map list --json` in a
+  throwaway git repo with NO `.clawpatch/` returns `{success:true,
+  count:0, features:[], clawpatch_present:false}` with exit 0. This proves
+  the production-path the agent prose tells scouts to call gracefully
+  returns the empty envelope. (Runs in a temp git repo, not the in-repo
+  `tests/fixtures/scout-without-clawpatch/` fixture — `repo-map` resolves
+  `.clawpatch/` from git toplevel, so a fixture subdir can't isolate from a
+  real `.clawpatch/` that local dogfooding may have created at repo root.)
 
 Layer 2 (manual smoke — run `/flow-next:plan "test scope"` against this
 repo with no `.clawpatch/`, confirm scout output produced cleanly with no
@@ -39,6 +41,7 @@ import os
 import re
 import subprocess
 import sys
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -313,12 +316,21 @@ class PlumbingContract(unittest.TestCase):
                 "contain a .clawpatch/ directory"
             ),
         )
-        res = _run(
-            "repo-map",
-            "list",
-            "--json",
-            cwd=str(FIXTURE_NO_CLAWPATCH),
-        )
+        # HERMETIC plumbing check: `repo-map` resolves `.clawpatch/` via
+        # get_repo_root() (git toplevel), so running with cwd inside the
+        # flow-next repo's own tree would pick up a REAL `.clawpatch/` when a
+        # developer has run `/flow-next:map` locally (it's gitignored — absent
+        # in CI, but present after dogfooding). The in-repo fixture dir cannot
+        # isolate from the repo's git root. Run in a throwaway git repo so the
+        # `.clawpatch/` absence is genuine regardless of the host repo's state.
+        with tempfile.TemporaryDirectory() as td:
+            subprocess.run(
+                ["git", "init", td],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            res = _run("repo-map", "list", "--json", cwd=td)
         self.assertEqual(res.returncode, 0, msg=res.stderr)
         payload = json.loads(res.stdout)
         self.assertTrue(payload["success"])

--- a/scripts/sync-codex.sh
+++ b/scripts/sync-codex.sh
@@ -1281,20 +1281,41 @@ for md_file in "$SRC_AGENTS"/*.md; do
   # any leading whitespace; the inserted fallback line preserves that
   # indentation so embedded bash blocks stay aligned. Uses POSIX awk
   # (no gawk-only 3-arg match) so macOS / Linux behave identically.
+  #
+  # IDEMPOTENT: canonical agent bodies may ALREADY carry the
+  # `[ -x "$FLOWCTL" ] || FLOWCTL=".flow/bin/flowctl"` fallback on the line
+  # directly after the FLOWCTL= assignment (fn-50.3 hardening added it to
+  # repo-scout / context-scout for the Claude/Droid path). Only inject when
+  # the next line is NOT already that fallback — otherwise we emit a duplicate.
   body="$(echo "$body" | awk '
+    function flush_pending(   stripped) {
+      if (pending) {
+        stripped = nextline
+        sub(/^[[:space:]]+/, "", stripped)
+        if (stripped != "[ -x \"$FLOWCTL\" ] || FLOWCTL=\".flow/bin/flowctl\"") {
+          print fallback
+        }
+        pending = 0
+      }
+    }
     /^[[:space:]]*FLOWCTL="\$HOME\/\.codex\/scripts\/flowctl"[[:space:]]*$/ {
       print
-      # Capture leading whitespace by finding where FLOWCTL starts.
       indent = ""
       i = 1
       while (i <= length($0) && substr($0, i, 1) ~ /[[:space:]]/) {
         indent = indent substr($0, i, 1)
         i++
       }
-      printf "%s[ -x \"$FLOWCTL\" ] || FLOWCTL=\".flow/bin/flowctl\"\n", indent
+      fallback = indent "[ -x \"$FLOWCTL\" ] || FLOWCTL=\".flow/bin/flowctl\""
+      pending = 1
       next
     }
-    { print }
+    {
+      nextline = $0
+      flush_pending()
+      print
+    }
+    END { if (pending) print fallback }
   ')"
 
   # Escape backslashes for TOML triple-quoted strings


### PR DESCRIPTION
## TL;DR

Live-testing fn-50.3's scout enrichment (dispatching `repo-scout` against a real 9-feature `.clawpatch/`) surfaced a robustness gap + a Codex-mirror regression. Both fixed; the Droid/Claude/Codex env-var conditional now has a `.flow/bin/flowctl` safety net on all three.

## The gap

When `repo-scout`/`context-scout` run as **dispatched subagents**, they may not inherit `CLAUDE_PLUGIN_ROOT`/`DROID_PLUGIN_ROOT` → the Step 0 `FLOWCTL=…/scripts/flowctl` resolved to a broken `/scripts/flowctl` → `flowctl repo-map list --json` failed → scout silently grep-degraded → `features_anchored` **never fired** even with a populated `.clawpatch/`. Verified live: cleared the env vars, watched it break to `/scripts/flowctl`, fall back, and return `count: 9`.

## Changes

1. **Both scouts' Step 0** gain `[ -x "$FLOWCTL" ] || FLOWCTL=".flow/bin/flowctl"` — a `/flow-next:setup`-installed repo resolves the bundled copy (carries `repo-map` since 1.3.0) regardless of subprocess env. Neither resolves → skip Step 0 + grep-degrade (graceful).
2. **`sync-codex.sh` idempotent** — the fn-50.6 agent-body rewrite injected the fallback unconditionally after the Codex `FLOWCTL=` line, but the canonical now carries that line too → **duplicate** in the mirror. awk now skips injection when the next line is already the fallback (+ END-inject when `FLOWCTL=` is last). repo-scout / context-scout / worker tomls: exactly 1 fallback each; sync byte-idempotent.
3. **`test_scout_fallback_contract.py` hermetic** — plumbing check runs `repo-map list` in a throwaway git repo, not the in-repo `scout-without-clawpatch/` fixture. `repo-map` resolves `.clawpatch/` from git toplevel, so the fixture couldn't isolate from a real `.clawpatch/` that local dogfooding creates at repo root (failed locally, passed in CI where `.clawpatch/` is gitignored/absent). Temp-repo isolation fixes it regardless of host state.

## Env-var conditional — all 3 platforms

| Platform | Resolves | Fallback |
|---|---|---|
| Claude Code | `${CLAUDE_PLUGIN_ROOT}/scripts/flowctl` | `.flow/bin/flowctl` |
| Factory Droid | `${DROID_PLUGIN_ROOT}/scripts/flowctl` | `.flow/bin/flowctl` |
| Codex | `$HOME/.codex/scripts/flowctl` (sync-rewritten) | `.flow/bin/flowctl` |

## Verification

Python 687 pass / 2 win-skip · scout-contract 14/14 · repo-map 22/22 · map-smoke 75/75 · resolve-pr 58/0 · core smoke 127/2 (documented baseline — copilot-session-resume env failures, unrelated to this change) · sync-codex 9 guards green + byte-idempotent. Found via the full live test that mapped flow-next's own repo (`--source=agent` via codex → 9 features) and exercised the scout enrichment end-to-end.

## Version note

Touches `agents/**/*.md` → patch bump 1.3.2 → 1.3.3 after merge.