### PR TITLE
fix(flowctl): review-output R-ID parser preserves R4a/R4b suffixes (1.3.4)

### DIFF
--- a/.github/workflows/test-flow-next.yml
+++ b/.github/workflows/test-flow-next.yml
@@ -101,6 +101,13 @@ jobs:
             -p "test_scout_fallback_contract.py" \
             -v
 
+      - name: Python unit tests — review-output R-ID parser suffix (1.3.4)
+        run: |
+          python -m unittest discover \
+            -s plugins/flow-next/tests \
+            -p "test_unaddressed_rids_parser.py" \
+            -v
+
       - name: Python unit tests — PNPM_HOME hint prose contract (fn-50.1, Windows-coverage)
         run: |
           python -m unittest discover \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the flow-next.
 
+## [flow-next 1.3.4] - 2026-05-27
+
+### Fixed
+- **Review-output R-ID parser dropped single-letter suffixes (`R4a` / `R4b`)** — `parse_unaddressed_rids` extracted R-IDs from a reviewer's `Unaddressed R-IDs:` summary line (`_extract_rids`) and from the `## Requirements coverage` table fallback with bare `\bR(\d+)\b`. fn-49.1 (1.2.1) taught the *spec* acceptance-criteria parser the `R\d+[a-z]?` suffix form but left this *review-output* path behind, so a reviewer reporting `Unaddressed R-IDs: [R4a, R4b]` parsed to drop the suffixed IDs (`[R4a, R4b, R5]` → `['R5']`) — the R-ID coverage gate and fix-loop targeting silently lost exactly the new form. Both review-output regexes are now `\bR(\d+[a-z]?)\b`, in lockstep with the spec parser; multi-letter suffixes (`R4ab`) and separators (`R-4`) stay rejected. New `test_unaddressed_rids_parser.py` (10 cases: summary-line + coverage-table suffix survival, plain-R-ID back-compat, dedup order, malformed rejection) wired into the ubuntu/macos/windows CI matrix. Surfaced by a live impl-review A/B run in 1.3.x — the current review prompt (no experimental slop rubric) caught it.
+
 ## [flow-next 1.3.3] - 2026-05-27
 
 ### Fixed

--- a/plugins/flow-next/scripts/flowctl.py
+++ b/plugins/flow-next/scripts/flowctl.py
@@ -2671,7 +2671,12 @@ def parse_unaddressed_rids(output: str) -> Optional[list[str]]:
         """Return R-ID tokens found in ``text`` (de-duped, order-preserving)."""
         seen: set[str] = set()
         ordered: list[str] = []
-        for match in re.finditer(r"\bR(\d+)\b", text):
+        # Match `R<digits>` with an optional single-letter suffix (R4a / R4b).
+        # Keep in lockstep with the spec parser (`_export_parse_acceptance_criteria`,
+        # `R\d+[a-z]?` since fn-49.1) so suffixed R-IDs survive the review-output
+        # path (coverage gate + fix-loop targeting). Bare `R\d+` here silently
+        # dropped `R4a` / `R4b` — fn-49 fixed the spec parser but not this one.
+        for match in re.finditer(r"\bR(\d+[a-z]?)\b", text):
             rid = f"R{match.group(1)}"
             if rid not in seen:
                 seen.add(rid)
@@ -2718,7 +2723,7 @@ def parse_unaddressed_rids(output: str) -> Optional[list[str]]:
         # Header row detection
         if rid_token.lower() in {"r-id", "rid", "r id", "r"}:
             continue
-        rid_match = re.search(r"\bR(\d+)\b", rid_token)
+        rid_match = re.search(r"\bR(\d+[a-z]?)\b", rid_token)
         if not rid_match:
             continue
         rid = f"R{rid_match.group(1)}"

--- a/plugins/flow-next/tests/test_unaddressed_rids_parser.py
+++ b/plugins/flow-next/tests/test_unaddressed_rids_parser.py
@@ -1,0 +1,118 @@
+"""Tests for `parse_unaddressed_rids` — the review-output R-ID extractor.
+
+This is the *review-output* parser (reads a reviewer's `Unaddressed R-IDs:`
+summary line or a `## Requirements coverage` table), distinct from the *spec*
+acceptance-criteria parser (`_export_parse_acceptance_criteria`, covered by
+`test_acceptance_criteria_parser.py`).
+
+Regression context: fn-49.1 (1.2.1) taught the spec parser the `R\\d+[a-z]?`
+suffix form (R4a / R4b) but left this review-output path on bare `\\bR(\\d+)\\b`
+in BOTH the summary-line extractor (`_extract_rids`) and the coverage-table
+fallback. A reviewer reporting `Unaddressed R-IDs: [R4a, R4b]` therefore parsed
+to `[R5]`-style results with the suffixed R-IDs silently dropped — the R-ID
+coverage gate and fix-loop targeting lost exactly the new form. Surfaced by a
+live impl-review A/B in 1.3.x; fixed in 1.3.4 by extending both regexes to
+`\\bR(\\d+[a-z]?)\\b`, in lockstep with the spec parser.
+"""
+
+import unittest
+from pathlib import Path
+import sys
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPTS_DIR = REPO_ROOT / "plugins" / "flow-next" / "scripts"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+import flowctl  # noqa: E402  (path-injected import)
+
+
+class SummaryLineSuffix(unittest.TestCase):
+    """The `Unaddressed R-IDs:` summary line preserves single-letter suffixes."""
+
+    def test_suffixed_rids_survive(self) -> None:
+        # The regression: this used to drop R4a / R4b and return ['R5'].
+        self.assertEqual(
+            flowctl.parse_unaddressed_rids("Unaddressed R-IDs: [R4a, R4b, R5]"),
+            ["R4a", "R4b", "R5"],
+        )
+
+    def test_mixed_plain_and_suffixed(self) -> None:
+        self.assertEqual(
+            flowctl.parse_unaddressed_rids("Unaddressed R-IDs: [R3, R4a, R10]"),
+            ["R3", "R4a", "R10"],
+        )
+
+    def test_plain_rids_unchanged(self) -> None:
+        # Back-compat: bare R-IDs still parse exactly as before.
+        self.assertEqual(
+            flowctl.parse_unaddressed_rids("Unaddressed R-IDs: [R3, R5]"),
+            ["R3", "R5"],
+        )
+
+    def test_singular_heading_suffix(self) -> None:
+        self.assertEqual(
+            flowctl.parse_unaddressed_rids("Unaddressed R-ID: R4b"),
+            ["R4b"],
+        )
+
+    def test_empty_marker_returns_empty(self) -> None:
+        self.assertEqual(
+            flowctl.parse_unaddressed_rids("Unaddressed R-IDs: []"),
+            [],
+        )
+
+    def test_dedup_preserves_first_seen_order(self) -> None:
+        self.assertEqual(
+            flowctl.parse_unaddressed_rids("Unaddressed R-IDs: [R4a, R4a, R2]"),
+            ["R4a", "R2"],
+        )
+
+
+class CoverageTableFallbackSuffix(unittest.TestCase):
+    """The `## Requirements coverage` table fallback preserves suffixes."""
+
+    def _table(self, *rows: str) -> str:
+        head = (
+            "## Requirements coverage\n\n"
+            "| R-ID | Status | Evidence |\n"
+            "|------|--------|----------|\n"
+        )
+        return head + "\n".join(rows) + "\n"
+
+    def test_suffixed_not_addressed_row_surfaces(self) -> None:
+        out = self._table(
+            "| R4a | not-addressed | — |",
+            "| R4b | met | src/x.ts:10 |",
+            "| R5 | not-addressed | — |",
+        )
+        # No summary line → falls through to the table parser.
+        self.assertEqual(flowctl.parse_unaddressed_rids(out), ["R4a", "R5"])
+
+    def test_suffixed_met_rows_yield_empty(self) -> None:
+        out = self._table(
+            "| R4a | met | a |",
+            "| R4b | deferred | later |",
+        )
+        self.assertEqual(flowctl.parse_unaddressed_rids(out), [])
+
+
+class RejectsMalformed(unittest.TestCase):
+    """Multi-letter suffixes and separators stay rejected (parity with spec parser)."""
+
+    def test_multiletter_suffix_not_treated_as_rid(self) -> None:
+        # `R4ab` must not parse as `R4a` or `R4`.
+        self.assertNotIn(
+            "R4a",
+            flowctl.parse_unaddressed_rids("Unaddressed R-IDs: [R4ab]") or [],
+        )
+
+    def test_separator_form_rejected(self) -> None:
+        # `R-4` is not a canonical R-ID token.
+        result = flowctl.parse_unaddressed_rids("Unaddressed R-IDs: [R-4]") or []
+        self.assertNotIn("R4", result)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## TL;DR

`parse_unaddressed_rids` — the review-output R-ID extractor — dropped single-letter R-ID suffixes (`R4a` / `R4b`). fn-49.1 (1.2.1) fixed the *spec* parser but left this *review-output* path on bare `\bR(\d+)\b`. Found by a live impl-review A/B; confirmed real via functional test.

## The bug

```python
parse_unaddressed_rids("Unaddressed R-IDs: [R4a, R4b, R5]")  # → ['R5']  ❌
```

Two bare-`\bR(\d+)\b` regexes in the review-output path:
- `_extract_rids` (flowctl.py, summary-line `Unaddressed R-IDs:` extractor)
- the `## Requirements coverage` table fallback

A reviewer reporting `R4a` / `R4b` as unaddressed had them silently dropped → the **R-ID coverage gate** and **fix-loop targeting** lost exactly the suffixed form that fn-49 made canonical. The spec parser (`_export_parse_acceptance_criteria`) already used `R\d+[a-z]?` since fn-49.1; this path was the straggler.

## Fix

Both regexes → `\bR(\d+[a-z]?)\b`, in lockstep with the spec parser. Multi-letter suffixes (`R4ab`) and separators (`R-4`) stay rejected by design. ~2-line change + a dedicated regression test.

## Tests

New `test_unaddressed_rids_parser.py` (10 cases) wired into the ubuntu/macos/windows CI matrix:
- summary-line suffix survival (`[R4a, R4b, R5]` → all three)
- coverage-table fallback suffix survival
- plain-R-ID back-compat (unchanged)
- dedup / first-seen order
- malformed rejection (`R4ab`, `R-4`)

Full suite: **697 pass / 2 Windows-only skip.**

## Provenance

Surfaced during a live impl-review A/B (testing an experimental slop rubric, now shelved): the baseline review — **current prompt, no slop block** — caught this on the fn-49 diff. Nice meta-confirmation that the review system works; the experimental block would've hidden it. Verified the bug independently before fixing.

## Version note

flowctl behavior change → patch bump 1.3.3 → 1.3.4 after merge.