### PR TITLE
docs(flow-next-drive): drop dangling 'see CHANGELOG' attribution pointer

### DIFF
--- a/plugins/flow-next/codex/skills/flow-next-drive/SKILL.md
+++ b/plugins/flow-next/codex/skills/flow-next-drive/SKILL.md
@@ -11,7 +11,7 @@ Drive any UI surface the way a real user would. Whatever driver the environment 
 
 It orchestrates drivers — it does not reimplement them. The default rung (Vercel's `agent-browser` CLI) is the only driver assumed present; every other rung is detected and optional. A pass must succeed with whatever the environment actually has — most cloud VMs, Linux, and CI have no Computer Use, so it is never a hard dependency and never on a headless/no-display path.
 
-> Driver ladder + universal-flow structure adapted from Ray Fernando's `running-bug-review-board` skill (Apache-2.0) — see CHANGELOG.
+> Driver ladder + universal-flow structure adapted from Ray Fernando's `running-bug-review-board` skill (Apache-2.0).
 
 ## Step 1 — Detect the surface, then branch
 

--- a/plugins/flow-next/codex/skills/flow-next-drive/references/computer-use.md
+++ b/plugins/flow-next/codex/skills/flow-next-drive/references/computer-use.md
@@ -14,7 +14,7 @@ Computer Use at all. agent-browser stays the only assumed-present driver; this
 rung is detected and optional, and a pass must still complete without it.
 
 > Driver ladder + graceful-degradation structure adapted from Ray Fernando's
-> `running-bug-review-board` skill (Apache-2.0) — see CHANGELOG. This reference
+> `running-bug-review-board` skill (Apache-2.0). This reference
 > extends Ray's single-provider (Codex CU) playbook to **both** Computer Use
 > providers and corrects the "Computer Use is the only way to reach Electron"
 > claim (Electron / WebView2 are Chromium → the web ladder, not this rung).

--- a/plugins/flow-next/skills/flow-next-drive/SKILL.md
+++ b/plugins/flow-next/skills/flow-next-drive/SKILL.md
@@ -9,7 +9,7 @@ Drive any UI surface the way a real user would. Whatever driver the environment 
 
 It orchestrates drivers — it does not reimplement them. The default rung (Vercel's `agent-browser` CLI) is the only driver assumed present; every other rung is detected and optional. A pass must succeed with whatever the environment actually has — most cloud VMs, Linux, and CI have no Computer Use, so it is never a hard dependency and never on a headless/no-display path.
 
-> Driver ladder + universal-flow structure adapted from Ray Fernando's `running-bug-review-board` skill (Apache-2.0) — see CHANGELOG.
+> Driver ladder + universal-flow structure adapted from Ray Fernando's `running-bug-review-board` skill (Apache-2.0).
 
 ## Step 1 — Detect the surface, then branch
 

--- a/plugins/flow-next/skills/flow-next-drive/references/computer-use.md
+++ b/plugins/flow-next/skills/flow-next-drive/references/computer-use.md
@@ -14,7 +14,7 @@ Computer Use at all. agent-browser stays the only assumed-present driver; this
 rung is detected and optional, and a pass must still complete without it.
 
 > Driver ladder + graceful-degradation structure adapted from Ray Fernando's
-> `running-bug-review-board` skill (Apache-2.0) — see CHANGELOG. This reference
+> `running-bug-review-board` skill (Apache-2.0). This reference
 > extends Ray's single-provider (Codex CU) playbook to **both** Computer Use
 > providers and corrects the "Computer Use is the only way to reach Electron"
 > claim (Electron / WebView2 are Chromium → the web ladder, not this rung).


### PR DESCRIPTION
## What

The flow-next-drive attribution lines pointed readers to `see CHANGELOG`, but the flow-next CHANGELOG has **no** Ray Fernando / Apache-2.0 entry — the pointer was dead.

Removes only the `— see CHANGELOG` tail; the in-place credit stays in all four spots (claude + codex `SKILL.md`, and both `references/computer-use.md`).

## Why

A broken "see CHANGELOG" is worse than no pointer. The Apache-2.0 borrowing here is conceptual (driver-ladder pattern + the universal-flow loop phrasing) — credited in place, which is sufficient (source has no NOTICE file).

## Not touched

The `flow-next-tracker-sync` skill has the same dangling `see CHANGELOG` pointer in 3 spots (a separate borrowed component). Left intact pending a decision on whether to strip those too.