### PR TITLE
fix(flow-next): sync usage.md template + drift guard + migrate backup race — 1.5.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,13 +6,13 @@
   },
   "metadata": {
     "description": "Plan-first workflows for Claude Code and Factory Droid. Ships flow-next: zero-dep, spec-driven, Ralph autonomous mode.",
-    "version": "1.5.0"
+    "version": "1.5.1"
   },
   "plugins": [
     {
       "name": "flow-next",
       "description": "Zero-dependency planning + execution with .flow/ task tracking and Ralph autonomous mode (multi-model review gates). Worker subagent per task for context isolation. Includes 21 subagents, 21 commands, 25 skills.",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "author": {
         "name": "Gordon Mickel",
         "email": "gordon@mickel.tech",

--- a/.github/workflows/test-flow-next.yml
+++ b/.github/workflows/test-flow-next.yml
@@ -6,11 +6,16 @@ on:
     paths:
       - "plugins/flow-next/**"
       - ".github/workflows/test-flow-next.yml"
+      # Dogfood copies guarded against template drift (test_dogfood_template_parity).
+      - ".flow/usage.md"
+      - ".flow/templates/spec.md"
   pull_request:
     branches: [main]
     paths:
       - "plugins/flow-next/**"
       - ".github/workflows/test-flow-next.yml"
+      - ".flow/usage.md"
+      - ".flow/templates/spec.md"
   workflow_dispatch:
 
 jobs:
@@ -107,6 +112,16 @@ jobs:
             -s plugins/flow-next/tests \
             -p "test_unaddressed_rids_parser.py" \
             -v
+
+      - name: Python unit tests — dogfood template parity (1.5.1)
+        run: |
+          python -m unittest discover \
+            -s plugins/flow-next/tests \
+            -p "test_dogfood_template_parity.py" \
+            -v
+        # Guards .flow/usage.md ≡ canonical setup template (and spec.md) so the
+        # fn-52 desync — tracker-sync docs added to the dogfood copy but not the
+        # bundled template — hard-fails CI instead of shipping to consumers.
 
       - name: Python unit tests — PNPM_HOME hint prose contract (fn-50.1, Windows-coverage)
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the flow-next.
 
+## [flow-next 1.5.1] - 2026-06-03
+
+### Fixed
+- **`/flow-next:setup` shipped a `usage.md` with no tracker-sync docs.** fn-52 (1.5.0) added the `flowctl sync` / `--tracker-first` command block to the repo's dogfood `.flow/usage.md` but **not** to the bundled template `/flow-next:setup` actually copies (`plugins/flow-next/skills/flow-next-setup/templates/usage.md`), so every fresh setup on 1.5.0 produced a `usage.md` documenting the whole CLI **except** the tracker-sync bridge that shipped in the same release. The canonical template is now byte-synced to the dogfood copy (Codex mirror regenerated via `sync-codex.sh`).
+  - **Drift guard so it can't recur:** new `test_dogfood_template_parity.py` hard-asserts `.flow/usage.md` ≡ its canonical setup template (and `.flow/templates/spec.md` ≡ `templates/spec.md`), wired into the ubuntu/macos/windows CI matrix with `.flow/usage.md` / `.flow/templates/spec.md` added to the workflow `paths` triggers. Edit the lived-in dogfood copy and forget the template → CI fails instead of consumers getting stale docs.
+- **Flaky Windows CI: `migration_smoke.sh` Scenario 8b (parallel `migrate-rename`).** `_migrate_copy_tree_to_backup` listed `.flow/` via `iterdir()` then `shutil.copy2`'d each entry — but a **concurrent** migrate-rename's writability probe (`_migrate_writable`) drops a transient `.rw-probe-*.tmp` in `.flow/` that can appear in the listing then vanish before the copy opens it (`FileNotFoundError`). Classic TOCTOU; Windows widened the window (slower unlink + file locking) so it flaked there. The backup copy now skips `.rw-probe-*` by prefix and tolerates any entry that disappears mid-copy (the lock dir serialises real pre-1.0 state, so a vanishing file is always a transient).
+
 ## [flow-next 1.5.0] - 2026-06-03
 
 > Tracker-sync bridge (fn-52). Codex mirror + plugin version bump land in fn-52.9; the flow-next.dev docs pass lands in fn-52.11.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Flow-Next
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Flow-next](https://img.shields.io/badge/Flow--next-v1.5.0-green)](CHANGELOG.md)
+[![Flow-next](https://img.shields.io/badge/Flow--next-v1.5.1-green)](CHANGELOG.md)
 [![Docs](https://img.shields.io/badge/Docs-📖-informational)](plugins/flow-next/docs/README.md)
 
 [![Author](https://img.shields.io/badge/Author-Gordon_Mickel-orange)](https://mickel.tech)

--- a/plugins/flow-next/.claude-plugin/plugin.json
+++ b/plugins/flow-next/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "flow-next",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Zero-dependency planning + execution with .flow/ task tracking and Ralph autonomous mode (multi-model review gates). Worker subagent per task for context isolation. Prime assesses 8 pillars (48 criteria) with GitHub API integration. Includes 21 subagents, 21 commands, 25 skills.",
   "author": {
     "name": "Gordon Mickel",

--- a/plugins/flow-next/.codex-plugin/plugin.json
+++ b/plugins/flow-next/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "flow-next",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Zero-dependency planning + execution with .flow/ task tracking and Ralph autonomous mode. Worker subagent per task for context isolation. Compatible with Codex, Claude Code, and Factory Droid.",
   "author": {
     "name": "Gordon Mickel",

--- a/plugins/flow-next/codex/skills/flow-next-setup/templates/usage.md
+++ b/plugins/flow-next/codex/skills/flow-next-setup/templates/usage.md
@@ -108,6 +108,22 @@ The project's strategic intent and canonical vocabulary live **outside** `.flow/
 .flow/bin/flowctl prospect promote <id> --idea N --force # override idempotency guard
 .flow/bin/flowctl prospect archive <id> # → .flow/prospects/_archive/
 
+# Tracker sync (project a spec to a Linear/GitHub issue — /flow-next:tracker-sync bridge)
+# NOTE: /flow-next:tracker-sync (external tracker bridge) is NOT /flow-next:sync (plan-sync of downstream task specs).
+.flow/bin/flowctl sync active # is the bridge active? (enabled OR type ∈ {linear,github})
+.flow/bin/flowctl sync get-state <spec-id> # per-spec tracker state (id/identifier/url/lastSyncedAt/merge-base)
+.flow/bin/flowctl sync set-tracker-id <spec-id> <uuid> --identifier WOR-17 --url <url> # link (flow-first alias)
+.flow/bin/flowctl sync set-last-synced <spec-id> # advance lastSyncedAt (default: now)
+.flow/bin/flowctl sync set-merge-base <spec-id> --flow-file f.md --tracker-file t.md # paired snapshot (both required)
+.flow/bin/flowctl sync clear <spec-id> # unlink, wipe state atomically
+.flow/bin/flowctl sync list-unsynced # specs with no tracker id (need first push)
+.flow/bin/flowctl sync list-stale --older-than-hours 24 # linked specs with old/missing lastSyncedAt
+.flow/bin/flowctl sync check-collisions # tracker UUIDs shared by >1 spec
+.flow/bin/flowctl sync receipt <spec-id> --status pushed --transport mcp # proof-of-work (status enum: pushed|pulled|merged|updated|diverged|queued|errored|noop)
+.flow/bin/flowctl sync defer <spec-id> --summary "..." # queue a genuine conflict (never blocks; → review-deferred sink)
+# Tracker-first spec (keyed by the tracker identifier instead of fn-NN):
+.flow/bin/flowctl spec create --title "..." --tracker-first --tracker-identifier WOR-17 # canonical wor-17-slug
+
 # Memory (categorized learnings under .flow/memory/, v0.33.0+)
 .flow/bin/flowctl memory list # default: --status active
 .flow/bin/flowctl memory list --status stale # stale entries only

--- a/plugins/flow-next/scripts/flowctl.py
+++ b/plugins/flow-next/scripts/flowctl.py
@@ -16157,11 +16157,25 @@ def _migrate_copy_tree_to_backup(flow_dir: Path, backup_dir: Path) -> None:
     for entry in flow_dir.iterdir():
         if entry.name in excluded:
             continue
+        # Transient writability-probe tempfiles (`.rw-probe-*.tmp` from
+        # `_migrate_writable`) created by a CONCURRENT migrate-rename can surface
+        # in iterdir() then vanish before we open them. Skip them by prefix —
+        # they are scratch, never pre-1.0 state.
+        if entry.name.startswith(".rw-probe-"):
+            continue
         target = backup_dir / entry.name
-        if entry.is_dir():
-            shutil.copytree(entry, target, symlinks=True)
-        else:
-            shutil.copy2(entry, target)
+        try:
+            if entry.is_dir():
+                shutil.copytree(entry, target, symlinks=True)
+            else:
+                shutil.copy2(entry, target)
+        except FileNotFoundError:
+            # TOCTOU: the entry disappeared between iterdir() and copy — a
+            # parallel process cleaned up a transient. Windows widens this
+            # window (slower unlink + file locking), so Scenario 8b of
+            # migration_smoke.sh flaked here. Skipping is safe; a real pre-1.0
+            # file does not vanish mid-migration (the lock dir serialises that).
+            continue
 
 
 def _migrate_clear_partial_backup(backup_dir: Path) -> None:

--- a/plugins/flow-next/skills/flow-next-setup/templates/usage.md
+++ b/plugins/flow-next/skills/flow-next-setup/templates/usage.md
@@ -108,6 +108,22 @@ The project's strategic intent and canonical vocabulary live **outside** `.flow/
 .flow/bin/flowctl prospect promote <id> --idea N --force # override idempotency guard
 .flow/bin/flowctl prospect archive <id>                  # → .flow/prospects/_archive/
 
+# Tracker sync (project a spec to a Linear/GitHub issue — /flow-next:tracker-sync bridge)
+# NOTE: /flow-next:tracker-sync (external tracker bridge) is NOT /flow-next:sync (plan-sync of downstream task specs).
+.flow/bin/flowctl sync active                            # is the bridge active? (enabled OR type ∈ {linear,github})
+.flow/bin/flowctl sync get-state <spec-id>               # per-spec tracker state (id/identifier/url/lastSyncedAt/merge-base)
+.flow/bin/flowctl sync set-tracker-id <spec-id> <uuid> --identifier WOR-17 --url <url>   # link (flow-first alias)
+.flow/bin/flowctl sync set-last-synced <spec-id>         # advance lastSyncedAt (default: now)
+.flow/bin/flowctl sync set-merge-base <spec-id> --flow-file f.md --tracker-file t.md     # paired snapshot (both required)
+.flow/bin/flowctl sync clear <spec-id>                   # unlink, wipe state atomically
+.flow/bin/flowctl sync list-unsynced                     # specs with no tracker id (need first push)
+.flow/bin/flowctl sync list-stale --older-than-hours 24  # linked specs with old/missing lastSyncedAt
+.flow/bin/flowctl sync check-collisions                  # tracker UUIDs shared by >1 spec
+.flow/bin/flowctl sync receipt <spec-id> --status pushed --transport mcp   # proof-of-work (status enum: pushed|pulled|merged|updated|diverged|queued|errored|noop)
+.flow/bin/flowctl sync defer <spec-id> --summary "..."   # queue a genuine conflict (never blocks; → review-deferred sink)
+# Tracker-first spec (keyed by the tracker identifier instead of fn-NN):
+.flow/bin/flowctl spec create --title "..." --tracker-first --tracker-identifier WOR-17  # canonical wor-17-slug
+
 # Memory (categorized learnings under .flow/memory/, v0.33.0+)
 .flow/bin/flowctl memory list                            # default: --status active
 .flow/bin/flowctl memory list --status stale             # stale entries only

--- a/plugins/flow-next/tests/test_dogfood_template_parity.py
+++ b/plugins/flow-next/tests/test_dogfood_template_parity.py
@@ -1,0 +1,77 @@
+"""Drift guard: the repo's own `.flow/` dogfood copies must stay byte-identical
+to the canonical templates that `/flow-next:setup` ships to consumers (1.5.1).
+
+`/flow-next:setup` copies two canonical templates into a consumer's `.flow/`:
+
+    plugins/flow-next/skills/flow-next-setup/templates/usage.md  ->  .flow/usage.md
+    plugins/flow-next/templates/spec.md                          ->  .flow/templates/spec.md
+
+This repo dogfoods flow-next, so it carries its OWN `.flow/usage.md` and
+`.flow/templates/spec.md`. Contributors naturally edit the lived-in dogfood
+copy (it's the visible one) and forget the canonical template — exactly how
+fn-52 (1.5.0) added the tracker-sync command block to `.flow/usage.md` but not
+to the bundled template, so every fresh `/flow-next:setup` shipped a usage.md
+with no `flowctl sync` docs.
+
+This guard makes that class of drift a hard CI failure: dogfood ≡ canonical.
+Edit one, you must edit the other (re-run `/flow-next:setup`, or `cp` the
+template). Line endings are normalized (CRLF -> LF) so a Windows checkout with
+`core.autocrlf` left on does not produce spurious failures.
+
+Run:
+    python3 -m unittest plugins.flow-next.tests.test_dogfood_template_parity -v
+"""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+
+HERE = Path(__file__).resolve()
+PLUGIN_DIR = HERE.parent.parent           # plugins/flow-next
+REPO_ROOT = PLUGIN_DIR.parent.parent      # repo root
+
+# (dogfood copy in `.flow/`, canonical template `/flow-next:setup` copies from)
+PARITY_PAIRS = [
+    (
+        REPO_ROOT / ".flow" / "usage.md",
+        PLUGIN_DIR / "skills" / "flow-next-setup" / "templates" / "usage.md",
+    ),
+    (
+        REPO_ROOT / ".flow" / "templates" / "spec.md",
+        PLUGIN_DIR / "templates" / "spec.md",
+    ),
+]
+
+
+def _normalize(path: Path) -> str:
+    # Compare on content, not line-ending flavor: a Windows runner with
+    # core.autocrlf=true would otherwise diff every line.
+    return path.read_text(encoding="utf-8").replace("\r\n", "\n")
+
+
+class TestDogfoodTemplateParity(unittest.TestCase):
+    def test_dogfood_copies_match_canonical_templates(self) -> None:
+        for dogfood, canonical in PARITY_PAIRS:
+            with self.subTest(dogfood=str(dogfood.relative_to(REPO_ROOT))):
+                self.assertTrue(
+                    canonical.is_file(), f"canonical template missing: {canonical}"
+                )
+                self.assertTrue(
+                    dogfood.is_file(), f"dogfood copy missing: {dogfood}"
+                )
+                self.assertEqual(
+                    _normalize(dogfood),
+                    _normalize(canonical),
+                    f"\n{dogfood.relative_to(REPO_ROOT)} has drifted from its "
+                    f"canonical template\n  {canonical.relative_to(REPO_ROOT)}\n"
+                    f"Every `/flow-next:setup` ships the canonical copy — edit "
+                    f"BOTH. Fix: re-run /flow-next:setup, or "
+                    f"`cp {canonical.relative_to(REPO_ROOT)} "
+                    f"{dogfood.relative_to(REPO_ROOT)}` (or the reverse).",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Patch release **1.5.1**. Closes a docs gap shipped in 1.5.0 and de-flakes Windows CI, plus a deterministic guard so the docs gap can't recur.

`/flow-next:setup` copies a **bundled** `usage.md` template into a consumer's `.flow/`. fn-52 (1.5.0) added the tracker-sync command block to the repo's **dogfood** `.flow/usage.md` but not to that bundled template — so every fresh setup on 1.5.0 documented the whole CLI **except** the `flowctl sync` bridge that shipped in the same release.

## What changed

- **usage.md template sync** — bundled canonical `plugins/flow-next/skills/flow-next-setup/templates/usage.md` is now byte-identical to `.flow/usage.md` (tracker-sync block ported). Codex mirror regenerated via `sync-codex.sh`.
- **Drift guard (prevention)** — new `tests/test_dogfood_template_parity.py` hard-asserts `.flow/usage.md` ≡ its canonical setup template **and** `.flow/templates/spec.md` ≡ `templates/spec.md`. Wired into the ubuntu/macos/windows matrix; `.flow/usage.md` + `.flow/templates/spec.md` added to the workflow `paths` triggers. Editing the lived-in dogfood copy and forgetting the template now hard-fails CI instead of shipping stale docs.
- **Windows race fix** — `_migrate_copy_tree_to_backup` now skips transient `.rw-probe-*` files and tolerates `FileNotFoundError` mid-copy. A concurrent `migrate-rename`'s writability probe drops a `.rw-probe-*.tmp` in `.flow/` that could surface in `iterdir()` then vanish before `shutil.copy2` opened it (TOCTOU). Windows widened the window → flaky `migration_smoke.sh` Scenario 8b. (Not red on `main` currently; latent.)

## Verification

Local (macOS), all green:
- `test_dogfood_template_parity.py` — passes (and fails by construction on drift)
- `test_migrate_rename.py` — 24/24
- `migration_smoke.sh` — 45/45 (incl. the parallel Scenario 8b)
- `ci_test.sh` — 58/58
- `python -m py_compile flowctl.py` — ok

## Version

Bumped 1.5.0 → 1.5.1 across `marketplace.json` + both `plugin.json` + README badge (via `scripts/bump.sh patch flow-next`). Docs-site changelog entry to follow in `flow-next.dev`.
