### PR TITLE
fix(flow-next): tracker-sync renders the COMPLETE spec — render guardrail — 1.5.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,13 +6,13 @@
   },
   "metadata": {
     "description": "Plan-first workflows for Claude Code and Factory Droid. Ships flow-next: zero-dep, spec-driven, Ralph autonomous mode.",
-    "version": "1.5.1"
+    "version": "1.5.2"
   },
   "plugins": [
     {
       "name": "flow-next",
       "description": "Zero-dependency planning + execution with .flow/ task tracking and Ralph autonomous mode (multi-model review gates). Worker subagent per task for context isolation. Includes 21 subagents, 21 commands, 25 skills.",
-      "version": "1.5.1",
+      "version": "1.5.2",
       "author": {
         "name": "Gordon Mickel",
         "email": "gordon@mickel.tech",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the flow-next.
 
+## [flow-next 1.5.2] - 2026-06-04
+
+### Fixed
+- **Tracker-sync now projects the ENTIRE spec to the issue body — render guardrail against summarization.** The flow→tracker push (`/flow-next:tracker-sync`) defines `renderFlowToTracker` as a full format-translation of the spec, and the body-merge Step 3.5 structural gate forbids dropping sections — but the *call sites* (`steps.md` Phase 2a + Phase 3 push skeleton) only pointed at the reference, so a host agent under token pressure could improvise a **condensed** issue body instead of mirroring the whole spec (projection is supposed to be projection-in-full). Added explicit "render the COMPLETE spec — every section, in full; never summarize/truncate" guardrails at both call sites and as the leading rule of `references/body-merge.md` Step 3 (flow→tracker), so the full-body requirement is unmissable at the point of action. No behavior change for an agent that already read the reference; closes the gap for one that didn't. Surfaced dogfooding the bridge against flow-next's own specs. Codex mirror regenerated.
+
 ## [flow-next 1.5.1] - 2026-06-03
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Flow-Next
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Flow-next](https://img.shields.io/badge/Flow--next-v1.5.1-green)](CHANGELOG.md)
+[![Flow-next](https://img.shields.io/badge/Flow--next-v1.5.2-green)](CHANGELOG.md)
 [![Docs](https://img.shields.io/badge/Docs-📖-informational)](plugins/flow-next/docs/README.md)
 
 [![Author](https://img.shields.io/badge/Author-Gordon_Mickel-orange)](https://mickel.tech)

--- a/plugins/flow-next/.claude-plugin/plugin.json
+++ b/plugins/flow-next/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "flow-next",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Zero-dependency planning + execution with .flow/ task tracking and Ralph autonomous mode (multi-model review gates). Worker subagent per task for context isolation. Prime assesses 8 pillars (48 criteria) with GitHub API integration. Includes 21 subagents, 21 commands, 25 skills.",
   "author": {
     "name": "Gordon Mickel",

--- a/plugins/flow-next/.codex-plugin/plugin.json
+++ b/plugins/flow-next/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "flow-next",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Zero-dependency planning + execution with .flow/ task tracking and Ralph autonomous mode. Worker subagent per task for context isolation. Compatible with Codex, Claude Code, and Factory Droid.",
   "author": {
     "name": "Gordon Mickel",

--- a/plugins/flow-next/codex/skills/flow-next-tracker-sync/references/body-merge.md
+++ b/plugins/flow-next/codex/skills/flow-next-tracker-sync/references/body-merge.md
@@ -115,6 +115,7 @@ The two sides are in different formats; the merge spans the translation. The age
 
 ### flow → tracker (render structure into a readable issue)
 
+- **Project the ENTIRE spec — every section, in full.** The render is a *format translation*, NOT a summary: never condense, truncate, abbreviate, or omit a section, an R-ID, or a paragraph. A reader of the issue must see the same content as the spec, just as clean free-form markdown. "Projection, not coordination" also means projection-in-full — a summarized issue is a data-loss bug, and the Step 3.5 structural gate ("no section silently dropped") fails it. The ONLY content intentionally not surfaced is the flow-internal scaffolding called out below (scope HTML comments, source-tag breakdown comment); everything else is rendered.
 - Render the structured spec into clean free-form markdown a PM reads comfortably:
  keep the section headings as plain `##` headings, render acceptance criteria as a
  checklist, keep links/code spans intact.

--- a/plugins/flow-next/codex/skills/flow-next-tracker-sync/steps.md
+++ b/plugins/flow-next/codex/skills/flow-next-tracker-sync/steps.md
@@ -52,7 +52,9 @@ Attach sync state **on link**. Pick the flow by where the user is starting:
 
 ### 2a — Flow-first (author-in-flow-then-push)
 
-A `fn-NN` spec already exists. Keep the `fn-NN` id (never rename). Push body via the body-sync hook **[→ ref: body-merge.md]**, which creates the issue via `writeIssue` **[→ ref: linear-ladder.md / github.md]**, then attach state:
+A `fn-NN` spec already exists. Keep the `fn-NN` id (never rename). Push body via the body-sync hook **[→ ref: body-merge.md]**, which creates the issue via `writeIssue` **[→ ref: linear-ladder.md / github.md]**, then attach state.
+
+> **The pushed body is the COMPLETE spec — every section, in full.** The render (`renderFlowToTracker`, body-merge.md Step 3) is a *format translation*, NOT a summary: never condense, truncate, abbreviate, or drop a section. Projection means the issue mirrors the whole spec (the Step 3.5 structural gate enforces "no section silently dropped"). If you find yourself summarizing to save tokens, stop — read body-merge.md Step 3 and render the full body.
 
 ```bash
 $FLOWCTL sync set-tracker-id "$SPEC_ID" "$ISSUE_UUID" --identifier "WOR-17" --url "$ISSUE_URL"
@@ -96,7 +98,7 @@ Route the operation; each layer calls hooks that operate on the normalized struc
 
 ```
 push(spec):
- body = renderFlowToTracker(spec) → body-merge.md Step 3 (flow→tracker)
+ body = renderFlowToTracker(spec) → body-merge.md Step 3 (flow→tracker) — COMPLETE spec, ALL sections; never summarize/truncate
  writeIssue(issue{... body ...}) [→ ref: transport]
  setStatus(map flow status → tracker status) → status-sync.md (who-wins)
  postComment(lifecycle event marker) → comments-sync.md (append + dedup)

--- a/plugins/flow-next/skills/flow-next-tracker-sync/references/body-merge.md
+++ b/plugins/flow-next/skills/flow-next-tracker-sync/references/body-merge.md
@@ -115,6 +115,7 @@ The two sides are in different formats; the merge spans the translation. The age
 
 ### flow → tracker (render structure into a readable issue)
 
+- **Project the ENTIRE spec — every section, in full.** The render is a *format translation*, NOT a summary: never condense, truncate, abbreviate, or omit a section, an R-ID, or a paragraph. A reader of the issue must see the same content as the spec, just as clean free-form markdown. "Projection, not coordination" also means projection-in-full — a summarized issue is a data-loss bug, and the Step 3.5 structural gate ("no section silently dropped") fails it. The ONLY content intentionally not surfaced is the flow-internal scaffolding called out below (scope HTML comments, source-tag breakdown comment); everything else is rendered.
 - Render the structured spec into clean free-form markdown a PM reads comfortably:
   keep the section headings as plain `##` headings, render acceptance criteria as a
   checklist, keep links/code spans intact.

--- a/plugins/flow-next/skills/flow-next-tracker-sync/steps.md
+++ b/plugins/flow-next/skills/flow-next-tracker-sync/steps.md
@@ -50,7 +50,9 @@ Attach sync state **on link**. Pick the flow by where the user is starting:
 
 ### 2a — Flow-first (author-in-flow-then-push)
 
-A `fn-NN` spec already exists. Keep the `fn-NN` id (never rename). Push body via the body-sync hook **[→ ref: body-merge.md]**, which creates the issue via `writeIssue` **[→ ref: linear-ladder.md / github.md]**, then attach state:
+A `fn-NN` spec already exists. Keep the `fn-NN` id (never rename). Push body via the body-sync hook **[→ ref: body-merge.md]**, which creates the issue via `writeIssue` **[→ ref: linear-ladder.md / github.md]**, then attach state.
+
+> **The pushed body is the COMPLETE spec — every section, in full.** The render (`renderFlowToTracker`, body-merge.md Step 3) is a *format translation*, NOT a summary: never condense, truncate, abbreviate, or drop a section. Projection means the issue mirrors the whole spec (the Step 3.5 structural gate enforces "no section silently dropped"). If you find yourself summarizing to save tokens, stop — read body-merge.md Step 3 and render the full body.
 
 ```bash
 $FLOWCTL sync set-tracker-id "$SPEC_ID" "$ISSUE_UUID" --identifier "WOR-17" --url "$ISSUE_URL"
@@ -94,7 +96,7 @@ Route the operation; each layer calls hooks that operate on the normalized struc
 
 ```
 push(spec):
-  body    = renderFlowToTracker(spec)            → body-merge.md Step 3 (flow→tracker)
+  body    = renderFlowToTracker(spec)            → body-merge.md Step 3 (flow→tracker) — COMPLETE spec, ALL sections; never summarize/truncate
   writeIssue(issue{... body ...})                [→ ref: transport]
   setStatus(map flow status → tracker status)    → status-sync.md (who-wins)
   postComment(lifecycle event marker)            → comments-sync.md (append + dedup)


### PR DESCRIPTION
## Summary

Patch **1.5.2**. Hardens the `/flow-next:tracker-sync` flow→tracker render so the host agent **projects the entire spec to the issue body — never a summary**. Surfaced dogfooding the bridge against flow-next's own specs (the first push wrote condensed issue bodies).

## Root cause

The render contract was correct but only stated in the reference: `references/body-merge.md` Step 3 defines `renderFlowToTracker` as a full format-translation, and Step 3.5's structural gate forbids dropping sections. But the **call sites** — `steps.md` Phase 2a (flow-first push) and the Phase 3 push skeleton — only said `renderFlowToTracker(spec)` and pointed at the reference. An agent that didn't drill into the reference (e.g. under token pressure) could improvise a condensed body. Projection is supposed to be projection-*in-full*.

## What changed

- **`steps.md` Phase 2a** — added a blockquote guardrail: the pushed body is the COMPLETE spec, every section, never summarize/truncate; if tempted to summarize, stop and read body-merge.md Step 3.
- **`steps.md` Phase 3 push skeleton** — annotated `renderFlowToTracker(spec)` with "COMPLETE spec, ALL sections; never summarize/truncate".
- **`references/body-merge.md` Step 3 (flow→tracker)** — added the leading rule: project the ENTIRE spec; the render is a format translation, not a summary; a summarized issue is a data-loss bug the structural gate fails.
- Codex mirror regenerated (`sync-codex.sh`).

No behavior change for an agent that already followed the reference; closes the gap for one that didn't.

## Verification

- `sync-codex.sh` regenerated clean (R21/R30 guards pass); guardrails present in both canonical + Codex mirror.
- Prose-only skill change; no `flowctl.py` change (no smoke/unit surface affected).

## Version

1.5.1 → 1.5.2 across `marketplace.json` + both `plugin.json` + README badge (`scripts/bump.sh patch flow-next`). Docs-site changelog entry to follow.
