### PR TITLE
fix(flowctl): auto-ignore .flow/sync-runs/ + self-upgrading managed .gitignore — 1.5.3

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,13 +6,13 @@
   },
   "metadata": {
     "description": "Plan-first workflows for Claude Code and Factory Droid. Ships flow-next: zero-dep, spec-driven, Ralph autonomous mode.",
-    "version": "1.5.2"
+    "version": "1.5.3"
   },
   "plugins": [
     {
       "name": "flow-next",
       "description": "Zero-dependency planning + execution with .flow/ task tracking and Ralph autonomous mode (multi-model review gates). Worker subagent per task for context isolation. Includes 21 subagents, 21 commands, 25 skills.",
-      "version": "1.5.2",
+      "version": "1.5.3",
       "author": {
         "name": "Gordon Mickel",
         "email": "gordon@mickel.tech",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the flow-next.
 
+## [flow-next 1.5.3] - 2026-06-04
+
+### Fixed
+- **Tracker-sync receipts (`.flow/sync-runs/`) are now auto-gitignored, and the managed `.flow/.gitignore` block self-upgrades on `flowctl init`.** The bridge writes a proof-of-work receipt per sync run under `.flow/sync-runs/` — the same class of runtime artifact as `receipts/` (already ignored) — but that dir was missing from flowctl's auto-managed `.flow/.gitignore`, so every sync dropped timestamped receipt files into git where they accumulated. Added `sync-runs/` to the managed pattern set. Also fixed `_ensure_flow_gitignore`: it previously **no-op'd whenever any managed block was present**, so a newly-added pattern only ever reached freshly-`init`'d repos — never existing ones; it now **reconciles** the managed block to the current canonical pattern set (user patterns below the footer preserved untouched). Existing repos pick up `sync-runs/` on their next `flowctl init`. New `test_flow_gitignore` cases cover the stale-block reconcile + the `sync-runs/` pattern. Surfaced dogfooding the bridge.
+
 ## [flow-next 1.5.2] - 2026-06-04
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Flow-Next
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Flow-next](https://img.shields.io/badge/Flow--next-v1.5.2-green)](CHANGELOG.md)
+[![Flow-next](https://img.shields.io/badge/Flow--next-v1.5.3-green)](CHANGELOG.md)
 [![Docs](https://img.shields.io/badge/Docs-📖-informational)](plugins/flow-next/docs/README.md)
 
 [![Author](https://img.shields.io/badge/Author-Gordon_Mickel-orange)](https://mickel.tech)

--- a/plugins/flow-next/.claude-plugin/plugin.json
+++ b/plugins/flow-next/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "flow-next",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "description": "Zero-dependency planning + execution with .flow/ task tracking and Ralph autonomous mode (multi-model review gates). Worker subagent per task for context isolation. Prime assesses 8 pillars (48 criteria) with GitHub API integration. Includes 21 subagents, 21 commands, 25 skills.",
   "author": {
     "name": "Gordon Mickel",

--- a/plugins/flow-next/.codex-plugin/plugin.json
+++ b/plugins/flow-next/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "flow-next",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "description": "Zero-dependency planning + execution with .flow/ task tracking and Ralph autonomous mode. Worker subagent per task for context isolation. Compatible with Codex, Claude Code, and Factory Droid.",
   "author": {
     "name": "Gordon Mickel",

--- a/plugins/flow-next/scripts/flowctl.py
+++ b/plugins/flow-next/scripts/flowctl.py
@@ -4944,6 +4944,9 @@ FLOW_GITIGNORE_AUTO_PATTERNS = [
     ".banner-acknowledged",
     ".migrating",
     ".migration-manifest",
+    # fn-52 tracker-sync per-run receipts (proof-of-work; accumulate per sync,
+    # same class as receipts/ — runtime artifacts, not durable repo state)
+    "sync-runs/",
 ]
 
 
@@ -4962,7 +4965,16 @@ def _ensure_flow_gitignore(flow_dir: Path) -> bool:
         return True
     existing = gi_path.read_text(encoding="utf-8")
     if FLOW_GITIGNORE_AUTO_HEADER in existing and FLOW_GITIGNORE_AUTO_FOOTER in existing:
-        return False  # already managed; user content preserved
+        # Already managed — RECONCILE the block to the current canonical pattern
+        # set so a flowctl upgrade that adds a pattern (e.g. sync-runs/) reaches
+        # existing repos, not just freshly-init'd ones. User patterns below the
+        # footer are spliced through untouched; no-op (no write) when current.
+        start = existing.index(FLOW_GITIGNORE_AUTO_HEADER)
+        end = existing.index(FLOW_GITIGNORE_AUTO_FOOTER) + len(FLOW_GITIGNORE_AUTO_FOOTER)
+        if existing[start:end] == auto_block:
+            return False  # block already current; user content preserved
+        gi_path.write_text(existing[:start] + auto_block + existing[end:], encoding="utf-8")
+        return True
     # File exists but isn't managed — prepend the auto block so user content stays.
     gi_path.write_text(auto_block + "\n\n" + existing, encoding="utf-8")
     return True

--- a/plugins/flow-next/tests/test_flow_gitignore.py
+++ b/plugins/flow-next/tests/test_flow_gitignore.py
@@ -74,6 +74,39 @@ class TestEnsureFlowGitignore(unittest.TestCase):
         ]:
             self.assertIn(pattern, flowctl.FLOW_GITIGNORE_AUTO_PATTERNS, pattern)
 
+    def test_sync_runs_in_pattern_set(self) -> None:
+        """fn-52 tracker-sync receipts dir is auto-ignored (proof-of-work, like receipts/)."""
+        self.assertIn("sync-runs/", flowctl.FLOW_GITIGNORE_AUTO_PATTERNS)
+
+    def test_stale_managed_block_is_reconciled(self) -> None:
+        """A pre-existing managed block missing a newer pattern is upgraded in
+        place — the new pattern is added, user content below the footer survives,
+        and the call reports True (changed)."""
+        with tempfile.TemporaryDirectory() as tmp:
+            flow_dir = Path(tmp) / ".flow"
+            flow_dir.mkdir()
+            # Simulate an older managed block (no sync-runs/) + user content below.
+            stale_block = "\n".join(
+                [
+                    flowctl.FLOW_GITIGNORE_AUTO_HEADER,
+                    ".checkpoint-*.json",
+                    "receipts/",
+                    flowctl.FLOW_GITIGNORE_AUTO_FOOTER,
+                ]
+            )
+            (flow_dir / ".gitignore").write_text(stale_block + "\n\nuser-pattern-Z\n")
+            self.assertTrue(flowctl._ensure_flow_gitignore(flow_dir))
+            content = (flow_dir / ".gitignore").read_text()
+            self.assertIn("sync-runs/", content)
+            self.assertIn("user-pattern-Z", content)  # user content preserved
+            # Footer still precedes user content (block stays at top).
+            self.assertLess(
+                content.index(flowctl.FLOW_GITIGNORE_AUTO_FOOTER),
+                content.index("user-pattern-Z"),
+            )
+            # Second call is now a no-op (block current).
+            self.assertFalse(flowctl._ensure_flow_gitignore(flow_dir))
+
 
 class TestCmdInitWritesGitignore(unittest.TestCase):
     """cmd_init writes .flow/.gitignore on fresh init and reports it."""


### PR DESCRIPTION
## Summary

Patch **1.5.3**. The tracker-sync bridge (1.5.0) writes a proof-of-work receipt per run under `.flow/sync-runs/` — the same class of runtime artifact as `receipts/` (already ignored) — but that dir was missing from flowctl's auto-managed `.flow/.gitignore`, so every sync dropped timestamped receipt files into git, where they accumulate. Surfaced dogfooding the bridge against this repo.

## What changed

- **`sync-runs/` added** to `FLOW_GITIGNORE_AUTO_PATTERNS`.
- **`_ensure_flow_gitignore` now reconciles** the managed block. It previously returned `False` (no-op) **whenever any managed block was present** — so a newly-added pattern only ever reached freshly-`init`'d repos, never existing ones. It now splices the current canonical block in place when it drifts, **preserving user patterns below the footer** untouched, and still no-ops when already current (mtime unchanged). Existing repos pick up `sync-runs/` on their next `flowctl init`.
- **Tests:** new `test_sync_runs_in_pattern_set` + `test_stale_managed_block_is_reconciled` (stale block upgraded in place, user content survives, second call no-ops). The 6 existing `test_flow_gitignore` cases stay green.

## Verification

- `test_flow_gitignore` — 8/8 (6 existing + 2 new).
- `ci_test.sh` — 58/58 (flowctl integration).
- `py_compile flowctl.py` — ok.

## Version

1.5.2 → 1.5.3 (`scripts/bump.sh patch flow-next`). Docs-site changelog to follow. No Codex mirror change (flowctl.py isn't mirrored).

## Follow-up (separate, post-release)

The 4 `.flow/sync-runs/` receipts I committed to main in the dogfood-linkage commit will be `git rm --cached` + the dogfood `.flow/.gitignore` regenerated, once this is released.
