### PR TITLE
docs(skills): fix two phantom references (export-context command, glossary skill) — fn-56 R2/R3

### DIFF
--- a/plugins/flow-next/codex/skills/flow-next-export-context/SKILL.md
+++ b/plugins/flow-next/codex/skills/flow-next-export-context/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: flow-next-export-context
-description: Export RepoPrompt context for external LLM review (ChatGPT, Claude web, etc.). Use when you want to review code or plans with an external model. Triggers on /flow-next:export-context.
+description: Export RepoPrompt context to a markdown file for review with an external LLM (ChatGPT, Claude web, etc.). Use when you want Carmack-level review but prefer an external model. Triggers on "export context", "export for external review", "export plan for ChatGPT", "export impl review context", "review with an external model", "export review context".
 ---
 
 # Export Context Mode
@@ -27,9 +27,11 @@ Types:
 - `plan <spec-id>` - Export plan review context
 - `impl` - Export implementation review context (current branch)
 
+This skill is phrase-triggered (no slash command) — invoke it by asking in natural language; the host agent parses `<type> <target> [focus areas]` from the request.
+
 Examples:
-- `/flow-next:export-context plan fn-1 focus on security`
-- `/flow-next:export-context impl focus on the auth changes`
+- "export context for plan fn-1, focus on security"
+- "export impl review context, focus on the auth changes"
 
 ## Setup
 

--- a/plugins/flow-next/docs/glossary.md
+++ b/plugins/flow-next/docs/glossary.md
@@ -3,7 +3,7 @@
 `GLOSSARY.md` is a human-readable, project-canonical terminology file shipped in v0.39.0. Lives at the **repo root** (and optionally subdirectories), NOT inside `.flow/`. Survives `rm -rf .flow/` — terminology is the project's, not flow-next's.
 
 > Canonical vocabulary for this repo: [`../../../GLOSSARY.md`](../../../GLOSSARY.md).
-> The skill that writes/maintains glossary files: `plugins/flow-next/skills/flow-next-glossary/` (consumed by `/flow-next:interview`, `/flow-next:audit`, `/flow-next:sync`).
+> Glossary files are written/maintained via the `flowctl glossary` subcommands (`add` / `list` / `read` / `remove`), driven by `/flow-next:interview`, `/flow-next:audit`, and `/flow-next:sync`. (There is no standalone `flow-next-glossary` skill — `flowctl glossary` is the mechanism.)
 
 ## Format
 

--- a/plugins/flow-next/skills/flow-next-export-context/SKILL.md
+++ b/plugins/flow-next/skills/flow-next-export-context/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: flow-next-export-context
-description: Export RepoPrompt context for external LLM review (ChatGPT, Claude web, etc.). Use when you want to review code or plans with an external model. Triggers on /flow-next:export-context.
+description: Export RepoPrompt context to a markdown file for review with an external LLM (ChatGPT, Claude web, etc.). Use when you want Carmack-level review but prefer an external model. Triggers on "export context", "export for external review", "export plan for ChatGPT", "export impl review context", "review with an external model", "export review context".
 ---
 
 # Export Context Mode
@@ -27,9 +27,11 @@ Types:
 - `plan <spec-id>` - Export plan review context
 - `impl` - Export implementation review context (current branch)
 
+This skill is phrase-triggered (no slash command) — invoke it by asking in natural language; the host agent parses `<type> <target> [focus areas]` from the request.
+
 Examples:
-- `/flow-next:export-context plan fn-1 focus on security`
-- `/flow-next:export-context impl focus on the auth changes`
+- "export context for plan fn-1, focus on security"
+- "export impl review context, focus on the auth changes"
 
 ## Setup
 


### PR DESCRIPTION
## Summary

Two phantom doc references, both **verified real** against the repo. Surfaced by a `/flow-next:plan` run executed **on Cursor** (a nice side-proof that multi-agent planning works there). Docs-only — no command added, **no version bump**.

## What changed

**1. `flow-next-export-context` advertised a slash command that doesn't exist** (`skills/flow-next-export-context/SKILL.md`)
- The frontmatter said `Triggers on /flow-next:export-context` and the body gave `/flow-next:export-context …` usage examples, but there is **no `commands/flow-next/export-context.md`** — so the advertised command can't resolve.
- Reconciled by **de-advertising** (per the chosen option): the skill is now phrase-triggered (natural-language `Triggers on "export context", …` + natural-language examples), matching the other command-less skills (`deps` / `rp-explorer` / `worktree-kit` / `drive`). No command file added.

**2. `docs/glossary.md` referenced a nonexistent skill** (`docs/glossary.md`)
- Line 6 pointed at `plugins/flow-next/skills/flow-next-glossary/`, which **does not exist**.
- Repointed at the real mechanism: the `flowctl glossary {add,list,read,remove}` subcommands, driven by `/flow-next:interview`, `/flow-next:audit`, `/flow-next:sync`.

## Verification

- Both claims reproduced before fixing (no command file; no skill dir).
- `flowctl glossary` confirmed as the real subcommand group.
- Codex mirror regenerated (export-context SKILL.md); `python3 -m unittest discover -s plugins/flow-next/tests -q` → **1002 passed, 2 skipped**; export-context frontmatter still valid YAML.

## Context (fn-56)

These are **R2 + R3** of the `fn-56` documentation-improvements spec (the Cursor-authored test plan). They're fixed standalone here; the spec's remaining requirements (R1 skills-catalog, R4 where-to-look parity, R5 `CONTRIBUTING`/`SECURITY` + issue templates, R6 stale-cohort pass, R7 link-check CI gate) stay open + deferred, and the spec's two draft slips (symlink direction; `setup` is actually visible) were corrected. The `fn-56` spec itself is intentionally left uncommitted (your call on adopting / Linear-linking it).
