### PR TITLE
fix(flowctl): cp1252 / non-UTF-8 robustness for impl-review + console output (#167)

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "flow-next",
-      "version": "1.10.0",
+      "version": "1.10.1",
       "source": {
         "source": "local",
         "path": "./plugins/flow-next"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,13 +6,13 @@
   },
   "metadata": {
     "description": "Plan-first workflows for Claude Code and Factory Droid. Ships flow-next: zero-dep, spec-driven, Ralph autonomous mode.",
-    "version": "1.10.0"
+    "version": "1.10.1"
   },
   "plugins": [
     {
       "name": "flow-next",
       "description": "Zero-dependency planning + execution with .flow/ task tracking and Ralph autonomous mode (multi-model review gates). Worker subagent per task for context isolation. Includes 21 subagents, 22 commands, 26 skills.",
-      "version": "1.10.0",
+      "version": "1.10.1",
       "author": {
         "name": "Gordon Mickel",
         "email": "gordon@mickel.tech",

--- a/.flow/bin/flowctl.py
+++ b/.flow/bin/flowctl.py
@@ -2670,11 +2670,16 @@ def find_references(
                 "*.cs",
             ],
             capture_output=True,
-            text=True, encoding="utf-8",
             cwd=repo_root,
         )
+        # Decode as bytes with errors="replace" rather than text=True /
+        # encoding="utf-8": git grep emits raw file bytes, so a repo with a
+        # non-UTF-8 source subtree (e.g. a legacy cp1252 C/C++ tree) would
+        # otherwise raise UnicodeDecodeError here and crash impl-review's
+        # context gathering — the read-side counterpart to #123. (#167)
+        stdout = result.stdout.decode("utf-8", errors="replace")
         refs = []
-        for line in result.stdout.strip().split("\n"):
+        for line in stdout.strip().split("\n"):
             if not line:
                 continue
             # Format: file:line:content
@@ -23030,7 +23035,26 @@ def cmd_validate(args: argparse.Namespace) -> None:
 # --- Main ---
 
 
+def _reconfigure_stdio_utf8() -> None:
+    """Force flowctl's own stdout/stderr to UTF-8 so non-ASCII output (e.g.
+    '→', umlauts) doesn't abort on a legacy console codepage such as Windows
+    cp1252 (UnicodeEncodeError: 'charmap'). Guarded with getattr/try so a
+    captured or already-detached stream (e.g. io.StringIO under test) is left
+    untouched rather than crashing the CLI at startup. (#167)
+    """
+    for stream in (sys.stdout, sys.stderr):
+        reconfigure = getattr(stream, "reconfigure", None)
+        if reconfigure is None:
+            continue
+        try:
+            reconfigure(encoding="utf-8", errors="replace")
+        except (ValueError, OSError):
+            # Stream already detached / doesn't support reconfigure — ignore.
+            pass
+
+
 def main() -> None:
+    _reconfigure_stdio_utf8()
     parser = argparse.ArgumentParser(
         description="flowctl - CLI for .flow/ task tracking",
         formatter_class=argparse.RawDescriptionHelpFormatter,

--- a/.github/workflows/test-flow-next.yml
+++ b/.github/workflows/test-flow-next.yml
@@ -182,6 +182,18 @@ jobs:
         # fn-52 desync — tracker-sync docs added to the dogfood copy but not the
         # bundled template — hard-fails CI instead of shipping to consumers.
 
+      - name: Python unit tests — cp1252 / non-UTF-8 robustness (1.10.1, #167)
+        run: |
+          python -m unittest discover \
+            -s plugins/flow-next/tests \
+            -p "test_cp1252_robustness.py" \
+            -v
+        # find_references decodes git-grep bytes defensively (no UnicodeDecodeError
+        # on a legacy cp1252 source subtree — the read-side counterpart to #123),
+        # flowctl forces UTF-8 stdout/stderr at startup, and phase-3d carries the
+        # lost-worker-result recovery heuristic (canonical + Codex mirror). Runs on
+        # the full ubuntu/macos/windows matrix — the fault is Windows-codepage-born.
+
       # ──────────── Cursor local-install (1.9.0) ────────────
       # The bash + PowerShell Cursor installers (scripts/install-cursor.{sh,ps1})
       # must not drift, and must actually produce a complete + clean install on

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to the flow-next.
 
+## [flow-next 1.10.1] - 2026-06-08
+
+### Fixed
+- **`flowctl copilot impl-review` no longer crashes with `UnicodeDecodeError` on a repo containing a non-UTF-8 source subtree** (#167 — the read-side counterpart to #123). `find_references()` (the symbol-cross-reference collector behind `gather_context_hints`) ran `git grep` over a fixed, broad extension set (`*.c *.h *.cpp *.cs *.java *.py …`) and decoded the hits with a hard `text=True, encoding="utf-8"` and **no `errors=`**. Because `gather_context_hints` extracts symbols from the *changed* files and greps each one **repo-wide**, a single legacy file anywhere in the tree — e.g. a German cp1252 C/C++ subtree carrying `0xfc` ü / `0xe4` ä / `0xf6` ö / `0xdf` ß — was enough to abort context gathering, *even when every file you actively edit is UTF-8*. The collector now captures `git grep` output as **bytes** and decodes defensively (`result.stdout.decode("utf-8", errors="replace")`), matching the byte-then-decode pattern the diff readers already use. Behavior is unchanged for valid UTF-8 repos. Reported with measured data by VGottselig (a large Windows CAD codebase: 304 of ~5400 C/C++ files non-UTF-8).
+- **`flowctl` forces its own stdout/stderr to UTF-8 at startup, so non-ASCII output (`→`, umlauts) no longer aborts on a legacy console codepage** such as Windows cp1252 (`UnicodeEncodeError: 'charmap' codec can't encode character '→'`, e.g. from `copilot plan-review`'s `print(output)`) (#167). `main()` now calls `sys.stdout/stderr.reconfigure(encoding="utf-8", errors="replace")` first thing, guarded so a captured or already-detached stream is left untouched. This removes the need for the `PYTHONIOENCODING=utf-8` workaround.
+
+### Changed
+- **`/flow-next:work` Verify-Completion (phase 3d) now carries a recovery heuristic for a lost/errored worker result** (#167). When the host (Agent-tool) drops a long-running worker's completion report (`[Tool result missing due to internal error]`) — its *work* may be complete even though the report never arrived — the loop no longer blocks waiting for a result that will never come. It diagnoses from ground truth (`flowctl show` + `git log` + `git status`) and classifies: **already done** → proceed to plan-sync; **code present but not finalized** → spawn a re-anchoring continuation worker that resumes from the late phase (build → review → `flowctl done`) instead of restarting; **nothing landed** → retry normally. Skill prose only; Codex mirror regenerated.
+
+### Notes
+- Both `flowctl.py` copies (canonical `scripts/` + dogfood `.flow/bin/`) updated in lockstep (byte-identical invariant held). New regression suite: `tests/test_cp1252_robustness.py` (reproduces the cp1252 `find_references` crash against a staged non-UTF-8 fixture; locks the stdio reconfigure guard and the phase-3d recovery prose, canonical + Codex mirror).
+
 ## [flow-next 1.10.0] - 2026-06-06
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Flow-Next
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Flow-next](https://img.shields.io/badge/Flow--next-v1.10.0-green)](CHANGELOG.md)
+[![Flow-next](https://img.shields.io/badge/Flow--next-v1.10.1-green)](CHANGELOG.md)
 [![Docs](https://img.shields.io/badge/Docs-📖-informational)](plugins/flow-next/docs/README.md)
 
 [![Author](https://img.shields.io/badge/Author-Gordon_Mickel-orange)](https://mickel.tech)

--- a/plugins/flow-next/.claude-plugin/plugin.json
+++ b/plugins/flow-next/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "flow-next",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "Zero-dependency planning + execution with .flow/ task tracking and Ralph autonomous mode (multi-model review gates). Worker subagent per task for context isolation. Prime assesses 8 pillars (48 criteria) with GitHub API integration. Includes 21 subagents, 22 commands, 26 skills.",
   "author": {
     "name": "Gordon Mickel",

--- a/plugins/flow-next/.codex-plugin/plugin.json
+++ b/plugins/flow-next/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "flow-next",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "Zero-dependency planning + execution with .flow/ task tracking and Ralph autonomous mode. Worker subagent per task for context isolation. Compatible with Codex, Claude Code, and Factory Droid.",
   "author": {
     "name": "Gordon Mickel",

--- a/plugins/flow-next/.cursor-plugin/plugin.json
+++ b/plugins/flow-next/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "flow-next",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "Zero-dependency, spec-driven agentic SDLC: durable specs, context-fit plans, re-anchored workers, adversarial cross-model review, receipts, and Ralph autonomous mode.",
   "author": {
     "name": "Gordon Mickel",

--- a/plugins/flow-next/codex/skills/flow-next-work/phases.md
+++ b/plugins/flow-next/codex/skills/flow-next-work/phases.md
@@ -254,6 +254,19 @@ $FLOWCTL show <task-id> --json
 
 If status is not `done`, the worker agent failed. Check output and retry or investigate.
 
+**Lost / errored worker result (`[Tool result missing due to internal error]`).** On long runs the host (Agent-tool) can drop the worker's completion report — you get an error placeholder instead of the report, even though the worker's *work* may be complete. Don't block waiting for a result that will never arrive. Treat a missing/errored result the same as "status not `done`" and **diagnose from ground truth** before retrying:
+
+```bash
+$FLOWCTL show <task-id> --json # status + evidence the worker recorded
+git log --oneline -5 # did the worker leave commits?
+git status --short # uncommitted-but-complete changes?
+```
+
+Classify and act:
+- **Already `done`** (status `done`, clean worktree at HEAD) — the report was lost but the task finished. Proceed to plan-sync (3e) as normal.
+- **Code present but not finalized** (commits and/or uncommitted changes exist, but status is still `in_progress` and build/review/`flowctl done` never ran) — spawn a **re-anchoring continuation worker** that re-reads the spec + current task status + `git status`/`git diff` and resumes from the late phase (verify build → review → `flowctl done`), rather than restarting the task from scratch.
+- **Nothing landed** (no commits, clean worktree, still `in_progress`) — the worker aborted early; retry the task normally.
+
 #### 3d.1 Tracker sync (opt-in) — task done → status comment + evidence
 
 **Optional. Runs only when the tracker bridge is active AND `work.done` is opted in, and only when the task reached `done` (from 3d). With no tracker configured this is a no-op.** Posts a structured status comment + evidence (tests / PR links from the task's evidence) to the linked issue; appends-only (R8), deduped by marker — never a conflict.

--- a/plugins/flow-next/scripts/flowctl.py
+++ b/plugins/flow-next/scripts/flowctl.py
@@ -2670,11 +2670,16 @@ def find_references(
                 "*.cs",
             ],
             capture_output=True,
-            text=True, encoding="utf-8",
             cwd=repo_root,
         )
+        # Decode as bytes with errors="replace" rather than text=True /
+        # encoding="utf-8": git grep emits raw file bytes, so a repo with a
+        # non-UTF-8 source subtree (e.g. a legacy cp1252 C/C++ tree) would
+        # otherwise raise UnicodeDecodeError here and crash impl-review's
+        # context gathering — the read-side counterpart to #123. (#167)
+        stdout = result.stdout.decode("utf-8", errors="replace")
         refs = []
-        for line in result.stdout.strip().split("\n"):
+        for line in stdout.strip().split("\n"):
             if not line:
                 continue
             # Format: file:line:content
@@ -23030,7 +23035,26 @@ def cmd_validate(args: argparse.Namespace) -> None:
 # --- Main ---
 
 
+def _reconfigure_stdio_utf8() -> None:
+    """Force flowctl's own stdout/stderr to UTF-8 so non-ASCII output (e.g.
+    '→', umlauts) doesn't abort on a legacy console codepage such as Windows
+    cp1252 (UnicodeEncodeError: 'charmap'). Guarded with getattr/try so a
+    captured or already-detached stream (e.g. io.StringIO under test) is left
+    untouched rather than crashing the CLI at startup. (#167)
+    """
+    for stream in (sys.stdout, sys.stderr):
+        reconfigure = getattr(stream, "reconfigure", None)
+        if reconfigure is None:
+            continue
+        try:
+            reconfigure(encoding="utf-8", errors="replace")
+        except (ValueError, OSError):
+            # Stream already detached / doesn't support reconfigure — ignore.
+            pass
+
+
 def main() -> None:
+    _reconfigure_stdio_utf8()
     parser = argparse.ArgumentParser(
         description="flowctl - CLI for .flow/ task tracking",
         formatter_class=argparse.RawDescriptionHelpFormatter,

--- a/plugins/flow-next/skills/flow-next-work/phases.md
+++ b/plugins/flow-next/skills/flow-next-work/phases.md
@@ -274,6 +274,19 @@ $FLOWCTL show <task-id> --json
 
 If status is not `done`, the worker failed. Check output and retry or investigate.
 
+**Lost / errored worker result (`[Tool result missing due to internal error]`).** On long runs the host (Agent-tool) can drop the worker's completion report — you get an error placeholder instead of the report, even though the worker's *work* may be complete. Don't block waiting for a result that will never arrive. Treat a missing/errored result the same as "status not `done`" and **diagnose from ground truth** before retrying:
+
+```bash
+$FLOWCTL show <task-id> --json          # status + evidence the worker recorded
+git log --oneline -5                     # did the worker leave commits?
+git status --short                       # uncommitted-but-complete changes?
+```
+
+Classify and act:
+- **Already `done`** (status `done`, clean worktree at HEAD) — the report was lost but the task finished. Proceed to plan-sync (3e) as normal.
+- **Code present but not finalized** (commits and/or uncommitted changes exist, but status is still `in_progress` and build/review/`flowctl done` never ran) — spawn a **re-anchoring continuation worker** that re-reads the spec + current task status + `git status`/`git diff` and resumes from the late phase (verify build → review → `flowctl done`), rather than restarting the task from scratch.
+- **Nothing landed** (no commits, clean worktree, still `in_progress`) — the worker aborted early; retry the task normally.
+
 #### 3d.1 Tracker sync (opt-in) — task done → status comment + evidence
 
 **Optional. Runs only when the tracker bridge is active AND `work.done` is opted in, and only when the task reached `done` (from 3d). With no tracker configured this is a no-op.** Posts a structured status comment + evidence (tests / PR links from the task's evidence) to the linked issue; appends-only (R8), deduped by marker — never a conflict.

--- a/plugins/flow-next/tests/test_cp1252_robustness.py
+++ b/plugins/flow-next/tests/test_cp1252_robustness.py
@@ -1,0 +1,188 @@
+"""cp1252 / non-UTF-8 robustness for flowctl (issue #167).
+
+A legacy Windows console codepage (cp1252) plus a non-UTF-8 source subtree
+(e.g. a German C/C++ tree carrying 0xfc ü / 0xe4 ä / 0xf6 ö / 0xdf ß) triggers
+two independent flowctl faults:
+
+  1. ``find_references()`` decodes ``git grep`` output with a hard
+     ``encoding="utf-8"`` and no ``errors=`` — any grep hit whose file bytes
+     are not valid UTF-8 raises ``UnicodeDecodeError`` (the impl-review
+     read-side counterpart to #123). This is unavoidable by keeping edited
+     files UTF-8: ``gather_context_hints`` greps each symbol repo-wide, so one
+     legacy file anywhere is enough.
+  2. flowctl's own stdout/stderr on a cp1252 console raises
+     ``UnicodeEncodeError`` when printing non-ASCII ('→', umlauts).
+
+These tests lock the read-side defensive decode and the startup stdio
+reconfigure. Pure Python — no real codepage required.
+"""
+
+import io
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from contextlib import contextmanager
+from pathlib import Path
+from unittest import mock
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPTS_DIR = REPO_ROOT / "plugins" / "flow-next" / "scripts"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+import flowctl  # noqa: E402
+
+
+@contextmanager
+def _chdir(path: Path):
+    prev = os.getcwd()
+    os.chdir(path)
+    try:
+        yield
+    finally:
+        os.chdir(prev)
+
+
+def _init_repo_with_cp1252_file(root: Path) -> None:
+    """A throwaway git repo whose one tracked file carries non-UTF-8 bytes.
+
+    git grep searches tracked files, so staging is enough — no commit (which
+    keeps the fixture independent of commit-signing setups)."""
+    subprocess.run(["git", "init", "-q"], cwd=root, check=True)
+    subprocess.run(["git", "config", "user.email", "t@t.t"], cwd=root, check=True)
+    subprocess.run(["git", "config", "user.name", "t"], cwd=root, check=True)
+    # The searched symbol sits on the SAME non-UTF-8 line so the cp1252 bytes
+    # land on git grep's stdout.
+    (root / "legacy.c").write_bytes(
+        b"int widget = 1;\n// \xfc\xe4\xf6 umlaut comment mentioning widget\n"
+    )
+    subprocess.run(["git", "add", "-A"], cwd=root, check=True)
+
+
+class FindReferencesCp1252(unittest.TestCase):
+    def test_find_references_tolerates_non_utf8_grep_output(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td).resolve()
+            _init_repo_with_cp1252_file(root)
+            with _chdir(root):
+                # Must not raise UnicodeDecodeError, and must still locate the
+                # reference despite the offending bytes on the matched line.
+                refs = flowctl.find_references("widget", [])
+        self.assertTrue(
+            any(p.endswith("legacy.c") for p, _ in refs),
+            f"expected a legacy.c hit, got {refs!r}",
+        )
+
+
+class StdioReconfigureUtf8(unittest.TestCase):
+    def test_helper_forces_utf8_on_reconfigurable_streams(self):
+        fake_out = mock.Mock()
+        fake_err = mock.Mock()
+        with mock.patch.object(sys, "stdout", fake_out), mock.patch.object(
+            sys, "stderr", fake_err
+        ):
+            flowctl._reconfigure_stdio_utf8()
+        fake_out.reconfigure.assert_called_once_with(
+            encoding="utf-8", errors="replace"
+        )
+        fake_err.reconfigure.assert_called_once_with(
+            encoding="utf-8", errors="replace"
+        )
+
+    def test_helper_is_noop_on_streams_without_reconfigure(self):
+        # io.StringIO (unittest / pytest capture) has no reconfigure attribute —
+        # the helper must leave such streams untouched, never raise.
+        with mock.patch.object(sys, "stdout", io.StringIO()), mock.patch.object(
+            sys, "stderr", io.StringIO()
+        ):
+            flowctl._reconfigure_stdio_utf8()
+
+    def test_helper_swallows_reconfigure_failure(self):
+        boom = mock.Mock()
+        boom.reconfigure.side_effect = ValueError("already detached")
+        with mock.patch.object(sys, "stdout", boom), mock.patch.object(
+            sys, "stderr", boom
+        ):
+            flowctl._reconfigure_stdio_utf8()  # must not propagate
+
+    def test_main_reconfigures_stdio_at_startup(self):
+        # main() must force UTF-8 stdio before doing any work; verify the wiring
+        # (argparse aborts on the missing subcommand, which is fine here).
+        with mock.patch.object(flowctl, "_reconfigure_stdio_utf8") as m, mock.patch.object(
+            sys, "argv", ["flowctl"]
+        ):
+            with self.assertRaises(SystemExit):
+                flowctl.main()
+        m.assert_called_once()
+
+
+class DualCopyInvariant(unittest.TestCase):
+    """The repo dogfoods a byte-identical ``.flow/bin/flowctl.py``; the #167
+    fixes must land in BOTH copies or the live dogfood CLI runs stale code."""
+
+    CANONICAL = REPO_ROOT / "plugins" / "flow-next" / "scripts" / "flowctl.py"
+    DOGFOOD = REPO_ROOT / ".flow" / "bin" / "flowctl.py"
+
+    def test_two_copies_byte_identical(self):
+        self.assertEqual(
+            self.CANONICAL.read_bytes(),
+            self.DOGFOOD.read_bytes(),
+            "scripts/flowctl.py and .flow/bin/flowctl.py must be byte-identical",
+        )
+
+    def test_both_copies_carry_the_167_fixes(self):
+        for p in (self.CANONICAL, self.DOGFOOD):
+            text = p.read_text(encoding="utf-8")
+            self.assertIn("_reconfigure_stdio_utf8", text)
+            self.assertIn(
+                'result.stdout.decode("utf-8", errors="replace")',
+                text,
+                "find_references must decode git-grep bytes defensively",
+            )
+
+
+class WorkerResultRecoveryProse(unittest.TestCase):
+    """Issue #167 item 1 — the work loop's Verify-Completion step must carry a
+    recovery heuristic for a lost/error worker result (the harness-level
+    ``[Tool result missing due to internal error]`` case), not just the
+    status-not-done case."""
+
+    PHASES = (
+        REPO_ROOT
+        / "plugins"
+        / "flow-next"
+        / "skills"
+        / "flow-next-work"
+        / "phases.md"
+    )
+    CODEX_PHASES = (
+        REPO_ROOT
+        / "plugins"
+        / "flow-next"
+        / "codex"
+        / "skills"
+        / "flow-next-work"
+        / "phases.md"
+    )
+
+    def test_3d_documents_missing_result_recovery(self):
+        text = self.PHASES.read_text(encoding="utf-8")
+        lower = text.lower()
+        self.assertIn("result missing", lower)
+        # Distinguish already-done vs code-present-but-unfinalized via git.
+        self.assertIn("git log", text)
+        self.assertIn("git status", text)
+        # Spawn a re-anchoring continuation worker rather than blocking.
+        self.assertIn("continuation", lower)
+        self.assertIn("re-anchor", lower)
+
+    def test_codex_mirror_carries_recovery_prose(self):
+        text = self.CODEX_PHASES.read_text(encoding="utf-8").lower()
+        self.assertIn("result missing", text)
+        self.assertIn("continuation", text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes the three faults in #167 (Windows / cp1252). Validated against current code (1.10.0); each claim traced to a stable function anchor before fixing. No spec exists for this third-party-reported regression, so this body is hand-written to the make-pr structure (per CLAUDE.md's chore/regression rule).

## Summary

A legacy Windows console codepage (cp1252) + a non-UTF-8 source subtree triggered two hard crashes and exposed one missing recovery path. All three are fixed; behavior is unchanged on UTF-8 repos.

## What changed

**1. `find_references()` UnicodeDecodeError — read-side counterpart to #123 (the crash).**
`gather_context_hints` (behind `copilot impl-review`) extracts symbols from the *changed* files and `git grep`s each one **repo-wide**, then decoded the hits with a hard `text=True, encoding="utf-8"` and **no `errors=`**. One legacy file anywhere in the tree (e.g. a German cp1252 C/C++ subtree: `0xfc` ü / `0xe4` ä / `0xf6` ö / `0xdf` ß) aborted context gathering — *even when every file you edit is UTF-8*. Now captures `git grep` output as **bytes** and decodes with `errors="replace"`, matching the byte-then-decode pattern the diff readers already use. `flowctl.py:find_references`.

**2. flowctl stdout/stderr not forced to UTF-8.**
Printing non-ASCII (`→`, umlauts) aborted on a cp1252 console (`UnicodeEncodeError: 'charmap'`, e.g. `copilot plan-review`'s `print(output)`). `main()` now calls `sys.stdout/stderr.reconfigure(encoding="utf-8", errors="replace")` first thing, guarded so a captured/detached stream (StringIO under test) is left untouched. Removes the `PYTHONIOENCODING=utf-8` workaround. `flowctl.py:_reconfigure_stdio_utf8`.

**3. `/flow-next:work` phase-3d lost-worker-result recovery (enhancement).**
When the host (Agent-tool) drops a long worker's report (`[Tool result missing due to internal error]`) the loop no longer blocks. It diagnoses from ground truth (`flowctl show` + `git log` + `git status`) and classifies: **already done** → plan-sync; **code present but not finalized** → re-anchoring continuation worker resuming the late phase; **nothing landed** → retry. Skill prose only. `skills/flow-next-work/phases.md` (+ Codex mirror).

## Verification

- New regression suite `tests/test_cp1252_robustness.py` (9 tests, all green) — reproduces the cp1252 `find_references` crash against a staged non-UTF-8 git fixture (red→green), locks the stdio reconfigure guard (forces UTF-8 on reconfigurable streams, no-op on StringIO, swallows reconfigure failure, wired into `main()`), the dual-copy byte-identical invariant, and the phase-3d recovery prose (canonical + Codex mirror).
- Wired into CI on the full ubuntu/macos/windows matrix (`.github/workflows/test-flow-next.yml`).
- Real `flowctl specs` run + non-ASCII print path smoke-tested locally.
- Both `flowctl.py` copies (canonical `scripts/` + dogfood `.flow/bin/`) updated in lockstep — byte-identical invariant held. Codex mirror regenerated via `sync-codex.sh` (only the intended phase-3d prose changed).

## Version

Patch bump **1.10.0 → 1.10.1** (manifests + marketplace + README badge + CHANGELOG). Skill/flowctl behavior changed, so a bump is required per CLAUDE.md.

## Where to look

| Concern | File |
|---|---|
| The crash fix (bytes + `errors="replace"`) | `plugins/flow-next/scripts/flowctl.py` → `find_references` |
| Startup UTF-8 stdio | `plugins/flow-next/scripts/flowctl.py` → `_reconfigure_stdio_utf8`, called first in `main()` |
| Lost-worker recovery prose | `plugins/flow-next/skills/flow-next-work/phases.md` §3d |
| Tests | `plugins/flow-next/tests/test_cp1252_robustness.py` |

Reported with measured data by @VGottselig. Closes #167.

https://claude.ai/code/session_016d2wKC5Ch5nYXqgiKuBTFx

---
_Generated by [Claude Code](https://claude.ai/code/session_016d2wKC5Ch5nYXqgiKuBTFx)_