### PR TITLE
docs: GitHub docs overhaul — strategy-led README, skills catalog, community health, link-check gate

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,50 @@
+name: Bug report
+description: Something in flow-next is broken
+labels: ["bug"]
+body:
+  - type: input
+    id: version
+    attributes:
+      label: flow-next version
+      placeholder: "2.0.0"
+    validations:
+      required: true
+  - type: dropdown
+    id: platform
+    attributes:
+      label: Platform
+      options:
+        - Claude Code
+        - OpenAI Codex
+        - Factory Droid
+        - Grok Build
+        - Cursor
+        - OpenCode (community port)
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: What did you run, what did you expect, what happened instead. Paste exact commands and exact error output.
+      placeholder: |
+        1. Ran `/flow-next:plan fn-12`
+        2. Expected …
+        3. Got …
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Relevant context
+      description: "OS, Python version, review backend (`flowctl review-backend`), Ralph involved? Relevant `.flow/` state or receipts. Logs from `scripts/ralph/runs/` if autonomous."
+    validations:
+      required: false
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Pre-flight
+      options:
+        - label: I'm on the latest flow-next release
+        - label: I checked [troubleshooting.md](https://github.com/gmickel/flow-next/blob/main/plugins/flow-next/docs/troubleshooting.md)

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: 💬 Discord — questions & discussion
+    url: https://discord.gg/f3DYq8AAm5
+    about: Fastest way to get help or discuss ideas before opening an issue.
+  - name: 🔒 Security issue
+    url: https://github.com/gmickel/flow-next/security/advisories/new
+    about: Please report vulnerabilities privately — see SECURITY.md.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,31 @@
+name: Feature request
+description: Propose an improvement or new capability
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: Describe the workflow gap, not just the feature. flow-next holds the line on command count — features that strengthen an existing skill beat new commands.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What would it look like? Which skill/command/flowctl surface does it touch?
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+    validations:
+      required: false
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Pre-flight
+      options:
+        - label: I checked [STRATEGY.md "Not working on"](https://github.com/gmickel/flow-next/blob/main/STRATEGY.md) — this isn't explicitly out of scope
+        - label: I searched existing issues

--- a/.github/workflows/docs-linkcheck.yml
+++ b/.github/workflows/docs-linkcheck.yml
@@ -1,0 +1,44 @@
+name: docs-linkcheck
+
+on:
+  pull_request:
+    paths:
+      - "**/*.md"
+      - ".github/workflows/docs-linkcheck.yml"
+  push:
+    branches: [main]
+    paths:
+      - "**/*.md"
+
+jobs:
+  linkcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Internal relative links only (--offline) — that is the discipline the
+      # docs tree enforces (relative repo paths, fork-survivable). External
+      # URLs are deliberately not checked here: their flakiness should never
+      # block a PR. The auto-generated Codex mirror and .flow/ work artifacts
+      # are excluded to keep signal high.
+      - name: Check internal markdown links
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: >-
+            --offline
+            --no-progress
+            --root-dir ${{ github.workspace }}
+            --exclude-path plugins/flow-next/codex
+            --exclude-path .flow
+            --exclude-path node_modules
+            --exclude-path flow-next-tui/node_modules
+            README.md
+            CONTRIBUTING.md
+            SECURITY.md
+            GLOSSARY.md
+            STRATEGY.md
+            agent_docs
+            plugins/flow-next/README.md
+            plugins/flow-next/docs
+            plugins/flow-next/skills
+          fail: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,33 @@
+# Contributing to Flow-Next
+
+Thanks for wanting to make flow-next better. This file is a router, not a manual — the real onboarding lives in `agent_docs/` and stays current because the maintainer's agents use it too.
+
+## Quick orientation
+
+- The repo **is** the flow-next plugin (`plugins/flow-next/`), plus the bundled `flowctl` Python CLI and the Ralph TUI (`flow-next-tui/`).
+- Strategic intent: [`STRATEGY.md`](STRATEGY.md). Canonical vocabulary: [`GLOSSARY.md`](GLOSSARY.md). Architecture rules (skill-vs-flowctl split, cross-platform patterns): [`CLAUDE.md`](CLAUDE.md).
+- This repo dogfoods itself — work is tracked as specs/tasks under `.flow/` via flow-next. You don't have to use it for a small PR, but reading [the teams guide](plugins/flow-next/docs/teams.md) explains the artefacts you'll see.
+
+## How to contribute
+
+| You want to… | Read |
+|---|---|
+| Set up local dev, run smoke tests, run the Ralph e2e | [`agent_docs/local-dev.md`](agent_docs/local-dev.md) |
+| Add a new `/flow-next:<name>` skill | [`agent_docs/adding-skills.md`](agent_docs/adding-skills.md) — mind the three-edit rule |
+| Optimize an existing skill/agent prompt | [`agent_docs/optimizing-skills.md`](agent_docs/optimizing-skills.md) |
+| Cut a release (maintainers) | [`agent_docs/releasing.md`](agent_docs/releasing.md) |
+| Report a bug / request a feature | [Open an issue](https://github.com/gmickel/flow-next/issues/new/choose) — templates provided |
+| Report a security issue | [`SECURITY.md`](SECURITY.md) — private channel, please |
+
+## Ground rules
+
+- **Never hand-edit `plugins/flow-next/codex/**`** — it's a generated mirror. Edit the canonical files under `plugins/flow-next/skills/` / `agents/`, then run `./scripts/sync-codex.sh` and commit the regenerated mirror.
+- **Run the gate before pushing:** `bash scripts/ci_test.sh` (vocabulary guard + smoke tests). CI runs the smoke suite on Linux/macOS/Windows — all three must stay green.
+- **Version bumps:** pure docs / `agent_docs/` / README changes do **not** bump the plugin version. Changes to skills, agents, hooks, or flowctl do — keep all manifests in lockstep (see [`agent_docs/releasing.md`](agent_docs/releasing.md)).
+- **Commits:** [Conventional Commits](https://www.conventionalcommits.org/) (`feat|fix|refactor|docs|chore|test|…`).
+- **PR body:** follow [`.github/pull_request_template.md`](.github/pull_request_template.md) — what changed, why, how to test.
+- **Big change?** Open an issue first to align on direction — flow-next deliberately holds the line on command count and scope ([`STRATEGY.md`](STRATEGY.md) "Not working on" is real).
+
+## Community
+
+Questions, ideas, show-and-tell: [Discord](https://discord.gg/f3DYq8AAm5) · [@gmickel](https://twitter.com/gmickel).

--- a/README.md
+++ b/README.md
@@ -112,9 +112,9 @@ That's the inner loop. Branch in (`/flow-next:prospect` for ranked candidates, `
 
 <div align="center">
 
-<img src="assets/flow-next-plan.png" alt="/flow-next:plan fanning out parallel scout subagents" width="720">
+<img src="assets/flow-next-plan.png" alt="/flow-next:plan output — dependency-ordered tasks, cross-model review passed, key decisions documented" width="720">
 
-*`/flow-next:plan` fans out parallel scouts before writing a single task.*
+*A `/flow-next:plan` result: dependency-ordered tasks, cross-model review iterated to SHIP, key decisions documented.*
 
 </div>
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,10 @@
 [![Sponsor](https://img.shields.io/badge/Sponsor-❤-ea4aaa)](https://github.com/sponsors/gmickel)
 [![Discord](https://img.shields.io/badge/Discord-Join-5865F2?logo=discord&logoColor=white)](https://discord.gg/f3DYq8AAm5)
 
-**Plan-first AI workflow. Zero external dependencies.**
+### Repeatable agentic engineering.
+
+**The workflow layer for AI coding agents: durable specs, re-anchored workers, adversarial reviews, receipts.**
+Everything lives in your repo. Zero external dependencies. Uninstall: `rm -rf .flow/`.
 
 </div>
 
@@ -19,19 +22,31 @@
 
 ---
 
-## What is this?
+## Why this exists
 
-Flow-Next is an AI agent orchestration plugin. **Twenty-eight agent-native skills** for the full lifecycle: idea → spec → tasks → review → ship → maintain. Bundled task tracking, dependency graphs, re-anchoring before every task, multi-model reviews, decay-aware project memory, GitHub PR creation and resolution, agent-readiness audits. Everything lives in your repo — no external services, no global config. Uninstall: delete `.flow/`.
+Agentic engineering compresses implementation from weeks to hours — and quietly removes every safety valve pre-agentic Agile relied on. The standups, the hallway clarification, the mid-flight course correction that used to *finish* a vague ticket over a two-week cycle: gone. When an agent can ship the task in one sitting, a rough ticket plus a chat scrollback is the whole work surface.
 
-- **Spec-first.** Every unit of work belongs to a spec `fn-N`. Tasks `fn-N.M` inherit context.
-- **Fresh-context workers.** Each task runs in its own subagent. No token bleed between tasks.
-- **Cross-model reviews.** A different model (RepoPrompt / Codex / Copilot) gates every implementation.
-- **R-IDs frozen at handover.** Acceptance criteria numbered once, never renumbered.
-- **Optional HTML render lenses.** Flip one config key (`artifacts.html.enabled`) and capture / plan / make-pr also emit self-contained HTML review pages under `.flow/artifacts/` — a spec visualizer (task DAG, R-ID coverage) and a PR review instrument. Markdown stays the record; artifacts are regenerable, never parsed back. OFF by default — zero cost when unused. → [`docs/html-artifacts.md`](plugins/flow-next/docs/html-artifacts.md)
+That work surface fails predictably. Agents drift mid-task, forget requirements, overfit to recent context, and hand reviewers 10K-line diffs with no focus signal. The bottleneck didn't disappear — it moved upstream, to requirements, review, and verification. **The spec has to carry the weight.**
 
-First-class on **Claude Code**, **OpenAI Codex** (CLI + Desktop), and **Factory Droid**. Also runs on **xAI Grok Build** and **Cursor** (local plugin), plus **OpenCode** via the [community port](https://github.com/gmickel/flow-next-opencode).
+Flow-Next fixes the operating model, not just the prompt. It turns rough intent into durable specs, specs into context-sized task graphs, task graphs into re-anchored worker runs, and implementation into reviewed PRs with receipts. Between idea and merge it defines **six named handover objects** — each reviewable on its own, verified by a *different* model, and frozen at handover.
 
-> 🆕 **v1.0+ — `flowctl epic` → `flowctl spec`.** The 1.0 release renames the canonical primitive across the entire flow-next surface. **All 0.x scripts and CLAUDE.md examples keep working** — the legacy CLI is preserved as a deprecation alias layer through all of 1.x. See the [CHANGELOG](CHANGELOG.md) for the migration path (interactive via `/flow-next:setup` or deterministic via `flowctl migrate-rename --yes`, both transactional with rollback).
+The artifact chain is not bureaucracy. **It is the conversation that would otherwise be missing.**
+
+## What you get
+
+Flow-Next is an AI agent orchestration plugin: **28 agent-native skills** covering the full lifecycle — idea → spec → tasks → review → ship → maintain — layered on a bundled pure-stdlib Python CLI (`flowctl`). The host agent is the intelligence; flowctl is the deterministic plumbing. No external services, no SaaS, no global config.
+
+| Tenet | What it means |
+|---|---|
+| **Spec-driven** | Intent survives the chat. The unit of work is the spec — not the ticket, not the transcript, not the PR title. One durable document at `.flow/specs/<id>.md`, evolving through layers. |
+| **Context-fit planning** | Right-sized task slices. Specs decompose into dependency-ordered tasks, each sized to one fresh ~100k-token context window. |
+| **Re-anchored work** | Fresh context per task. Every worker subagent re-reads the spec, the task, and git state before touching code — no token bleed, no stale assumptions. |
+| **Adversarial gates** | Fix until SHIP. A *different* model (RepoPrompt / Codex / Copilot) reviews every plan and every implementation. Different models make different mistakes — the disagreement surface is where the gaps live. |
+| **Receipts** | "Done" means there is proof. Commits, tests, review verdicts, and evidence recorded per task — never narration. |
+| **Multi-harness** | One workflow everywhere. First-class on Claude Code, OpenAI Codex, and Factory Droid; runs on Grok Build and Cursor; community OpenCode port. |
+| **Self-improving** | Compounds as you work. Memory, glossary, decision records, and strategy grow as side-effects of the workflow you already run — no manual "refresh" ceremony, ever. |
+
+And one tenet about *trust*: everything lives in your repo under `.flow/`. Specs, tasks, memory, receipts — all of it is yours, in git, code-reviewable. Uninstall is `rm -rf .flow/`.
 
 ---
 
@@ -93,7 +108,15 @@ droid plugin marketplace add \
 /flow-next:resolve-pr <PR#>          # 5. Fetch review threads → triage → resolve
 ```
 
-That's the inner loop. Branch in (`/flow-next:prospect` for ranked candidates, `/flow-next:interview` for structured discovery), branch out (`/flow-next:ralph-init` for autonomous overnight runs, `/flow-next:pilot` for host-driven backlog draining, `/flow-next:land` for babysitting the resulting PRs to merge + release, `/flow-next:audit` for memory garbage collection).
+That's the inner loop. Branch in (`/flow-next:prospect` for ranked candidates, `/flow-next:interview` for structured discovery), branch out (`/flow-next:pilot` + `/flow-next:land` for the autonomous assembly line, `/flow-next:ralph-init` for hardened overnight runs, `/flow-next:audit` for memory garbage collection).
+
+<div align="center">
+
+<img src="assets/flow-next-plan.png" alt="/flow-next:plan fanning out parallel scout subagents" width="720">
+
+*`/flow-next:plan` fans out parallel scouts before writing a single task.*
+
+</div>
 
 ---
 
@@ -125,7 +148,7 @@ The loop is spec-driven. Each step below maps to one skill; click through to flo
 
 ### 1. Capture or prospect a spec
 
-Either synthesize an existing conversation into a structured spec (source-tagged, mandatory read-back), or — when starting from scratch — generate ranked candidate ideas grounded in the repo. Both land in `.flow/specs/<id>.md`.
+Either synthesize an existing conversation into a structured spec, or — when starting from scratch — generate ranked candidate ideas grounded in the repo. Both land in `.flow/specs/<id>.md`. Capture **source-tags every acceptance criterion** as `[user]` / `[paraphrase]` / `[inferred]` and runs a mandatory read-back — you see exactly how much of the spec the agent invented before anything is written.
 
 ```bash
 /flow-next:capture                    # from a conversation
@@ -136,7 +159,7 @@ Either synthesize an existing conversation into a structured spec (source-tagged
 
 ### 2. Interview to refine
 
-Deep Q&A pass over a spec or task: lead-with-recommendation, confidence tiers, codebase-first investigation. Use to flesh out an ambiguous spec before breaking it down. `--scope=business|technical|both` symmetrically narrows the pass.
+Deep Q&A pass over a spec or task: lead-with-recommendation, confidence tiers, codebase-first investigation. Use it to flesh out an ambiguous spec before breaking it down. `--scope=business|technical|both` symmetrically narrows the pass — the same skill serves the PO filling the business layer and the tech lead filling the technical layer, on the same spec file.
 
 ```bash
 /flow-next:interview <spec-id>
@@ -146,7 +169,7 @@ Deep Q&A pass over a spec or task: lead-with-recommendation, confidence tiers, c
 
 ### 3. Plan into dependency-ordered tasks
 
-Research the codebase, then write the spec + tasks together. Tasks `fn-N.M` declare blockers, inherit context from the parent spec, and stay dependency-ordered. This skill does not write code — only the plan.
+Research the codebase via parallel scouts, then write the spec + tasks together. Tasks `fn-N.M` declare blockers, inherit context from the parent spec, and declare which acceptance criteria they satisfy (`satisfies: [R1, R3]`). This skill does not write code — only the plan.
 
 ```bash
 /flow-next:plan <spec-id>             # or <free-form text>
@@ -156,7 +179,7 @@ Research the codebase, then write the spec + tasks together. Tasks `fn-N.M` decl
 
 ### 4. Work through the tasks
 
-Execute tasks systematically: each runs in a fresh-context worker subagent, re-anchors against the spec before starting, then implements + commits + records evidence. Cross-model review gates (`impl-review`, `plan-review`) wrap the loop.
+Execute tasks systematically: each runs in a fresh-context worker subagent, re-anchors against the spec before starting, then implements + commits + records evidence. Cross-model review gates (`impl-review`, `plan-review`) wrap the loop and iterate until SHIP.
 
 ```bash
 /flow-next:work <spec-id>             # or <task-id>
@@ -166,7 +189,7 @@ Execute tasks systematically: each runs in a fresh-context worker subagent, re-a
 
 ### 5. Open the PR with a cognitive-aid body
 
-Render a PR body from nine flow-next input streams (spec R-IDs, per-task evidence, memory hits, glossary changes, strategy alignment, deferred review findings, the diff itself). Optional mermaid diagrams on module-boundary changes. Pushes via `gh`.
+Don't ask a human to skim a 10K-line diff. `/flow-next:make-pr` renders a PR body from nine flow-next input streams (spec R-IDs, per-task evidence, memory hits, glossary changes, strategy alignment, deferred review findings, the diff itself) — with an R-ID coverage table mapping every acceptance criterion to its satisfying task and evidence commit, and a "where to look" list that tells the reviewer which lines matter.
 
 ```bash
 /flow-next:make-pr <spec-id>          # auto-detects from current branch
@@ -188,7 +211,36 @@ Fetch unresolved threads + top-level comments + review-submission bodies, cluste
 
 ---
 
-**Going autonomous?** The default path is the **pilot + land pipeline**: `/flow-next:pilot` builds (one tick advances one ready spec by one pipeline stage — your host `/loop` or `/goal` owns repetition) and `/flow-next:land` ships (babysits the draft PRs the build loop opened — CI green, reviews converged, gated merge, release — on a `/loop 30m` cadence). Run both concurrently — two instances, separate clones — for the full assembly line: board → pilot → draft PR → land → released. Ralph is the **hardened harness** for fully planned specs: `/flow-next:ralph-init` scaffolds an external shell loop with fresh sessions per iteration, hook-enforced guardrails, and receipts — for runs that outlast a session. → [flow-next.dev/autonomous/overview](https://flow-next.dev/autonomous/overview) · [flow-next.dev/skills/pilot](https://flow-next.dev/skills/pilot) · [flow-next.dev/autonomous/land](https://flow-next.dev/autonomous/land) · [flow-next.dev/ralph](https://flow-next.dev/ralph)
+## Going autonomous
+
+Three loops, one quality bar. Multi-model review at every handover, don't-thrash reflexes (two-strike unready, auto-block, bounded CI fix budgets), evidence over narration — invariant across all three. That's the differentiator from "ralph-wiggum"-style loops that run open-loop without gates.
+
+The default path is the **pilot + land pipeline** — in-session, host-driven, zero scaffold:
+
+```bash
+flowctl spec ready fn-12          # bless work (or move its issue on the tracker board)
+/loop 10m /flow-next:pilot        # build loop: ready spec → plan → reviews → work → draft PR
+/loop 30m /flow-next:land         # ship loop: draft PR → CI green → reviews converged → merged → released
+```
+
+Run both concurrently — two instances, **separate clones** — and you have the full assembly line: board → pilot → draft PR → land → released. The `ready` flag (or your tracker's board state) is the consent boundary: humans bless specs, loops drain them. 📖 **[Going autonomous](https://flow-next.dev/autonomous/overview)**
+
+**Ralph** is the hardened harness for **fully planned** specs (it never plans): an external shell loop drives a *fresh* session per iteration — failed attempts die with the session instead of polluting the next one — with hook-enforced guardrails and receipts on disk. Reach for it when a run outlasts a session or prose guardrails aren't enough.
+
+```bash
+/flow-next:ralph-init           # One-time setup
+scripts/ralph/ralph.sh          # Run from terminal
+```
+
+<div align="center">
+
+<img src="assets/tui.png" alt="Ralph TUI monitoring an autonomous run" width="720">
+
+*Ralph mode at night, PRs in the morning. The TUI tracks task progress, streaming logs, and run state.*
+
+</div>
+
+📖 **[Ralph deep dive](plugins/flow-next/docs/ralph.md)** · **[Ralph TUI](flow-next-tui/)** (`bun add -g @gmickel/flow-next-tui`)
 
 ---
 
@@ -199,13 +251,29 @@ Fetch unresolved threads + top-level comments + review-submission bodies, cluste
 | Context drift | **Re-anchoring** before every task — re-reads specs + git state |
 | Context window limits | **Fresh context per task** — worker subagent starts clean |
 | Single-model blind spots | **Cross-model reviews** — RepoPrompt, Codex, or Copilot as second opinion |
-| Forgotten requirements | **Dependency graphs** — tasks declare blockers, run in order |
+| Forgotten requirements | **R-IDs frozen at handover** — numbered once, never renumbered; traced spec → task → commit → PR coverage table |
 | "It worked on my machine" | **Evidence recording** — commits, tests, PRs tracked per task |
 | Infinite retry loops | **Auto-block stuck tasks** — fails after N attempts, moves on |
 | Duplicate implementations | **Pre-implementation search** — worker checks for similar code before writing new |
 | Hallucinated specs from "I think we discussed…" | **Source-tagged capture** — every acceptance criterion marked `[user]` / `[paraphrase]` / `[inferred]`, mandatory read-back loop |
 | Stale project memory polluting future work | **`/flow-next:audit` + categorized memory schema** — agent reviews each entry, flags stale (never deletes) |
+| 10K-line diffs with no focus signal | **PR-as-cognitive-aid** — R-ID coverage, critical changes, decisions, where-to-look |
 | GitHub PR review threads piling up | **`/flow-next:resolve-pr`** — fetch → triage → dispatch resolver agents → reply → resolve via GraphQL |
+
+> *"Flow-next is simply the best coding flow, not even close."* — Tiago Freitas
+>
+> *"The re-anchoring is the quiet superpower. After a long session the agent still knows exactly what it's building."* — @dailyreader
+>
+> *"Ralph mode at night, PRs in the morning. Zero drama. The receipts mean I trust what landed."* — @mfeighery
+
+## What Flow-Next is *not*
+
+Scope honesty, because the architecture depends on it:
+
+- **Not a hosted dashboard or SaaS tier.** Everything is in the repo; a hosted layer would break the uninstall promise.
+- **Not a Jira/Linear replacement for human-only teams.** Flow-Next is for agentic-engineering teams. If your team lives in a tracker, `/flow-next:tracker-sync` *projects* specs to it — **projection, not coordination**: the spec stays the source of truth; the tracker never drives flow state or spawns agents. (Contrast OpenAI Symphony, where the tracker is the control plane — Flow-Next is "Symphony, but with real specs, re-anchoring, and receipts.")
+- **Not split-file specs.** One durable spec document evolving through layers — vs. Kiro-style `requirements.md` / `design.md` / `tasks.md` fragmentation.
+- **Not a replacement for human judgment.** Humans own product decisions, risk tolerance, merge decisions, and production responsibility. Flow-Next makes those decisions easier to verify because the evidence is structured.
 
 ---
 
@@ -221,9 +289,9 @@ Fetch unresolved threads + top-level comments + review-submission bodies, cluste
 | `/flow-next:work` | Execute tasks with re-anchoring + worker subagents + review gates. Opt-in: offload implementation to a local `codex exec` with `delegate:codex` (or `work.delegate=codex` config) — OFF by default, consent-gated, host keeps all judgment ([config keys](plugins/flow-next/docs/flowctl.md#config)) |
 | `/flow-next:impl-review` | Cross-model implementation review (RepoPrompt, Codex, or Copilot) |
 | `/flow-next:plan-review` | Cross-model plan review |
-| `/flow-next:spec-completion-review` | Spec-completion review gate — verify combined implementation matches the spec (renamed from `/flow-next:epic-review` in 1.0.0; soft-removal target 2.0.0) |
+| `/flow-next:spec-completion-review` | Spec-completion review gate — verify combined implementation matches the spec (renamed from `/flow-next:epic-review` in 1.0.0) |
 | `/flow-next:qa` | **Live-app real-user QA** — derives scenarios from the spec (AC / R-IDs / boundaries), drives the running app via `flow-next-drive`, files P0/P1/P2 findings with evidence, ends with a YES/NO ship verdict receipt. Forbidden from marking PASS by reading source. Opt-in — needs a live deploy + a driver |
-| `/flow-next:make-pr` | Render a cognitive-aid PR body (9 input streams) and open via `gh` |
+| `/flow-next:make-pr` | Render a cognitive-aid PR body (9 input streams) and open via `gh`; with HTML artifact mode on, also commits a `pr.html` review instrument |
 | `/flow-next:resolve-pr` | Resolve GitHub PR review threads (fetch → triage → fix → reply → resolve via GraphQL) |
 | `/flow-next:audit` | Agent-native review of `.flow/memory/` entries against current code (Keep / Update / Consolidate / Replace / Delete) |
 | `/flow-next:memory-migrate` | Lift legacy flat memory files into the categorized schema |
@@ -231,34 +299,22 @@ Fetch unresolved threads + top-level comments + review-submission bodies, cluste
 | `/flow-next:pilot` | **Single-tick build-loop conductor** — advances one ready spec by one pipeline stage (plan → plan-review → work → make-pr) per tick, ends with a `PILOT_VERDICT` line; drive it with `/loop` or `/goal` |
 | `/flow-next:land` | **Cadence-tick ship loop** — babysits the build loop's draft PRs: CI tri-state fix loop, reviewer patience window, resolve-pr convergence, gated explicit merge, spec close, release-follow; ends with a `LAND_VERDICT` line; drive it with `/loop 30m /flow-next:land` |
 | `/flow-next:ralph-init` | Scaffold autonomous loop (`scripts/ralph/`) |
+| `/flow-next:setup` | Per-project setup — `.flow/` init, local flowctl install, CLAUDE.md/AGENTS.md instructions, review-backend + config ceremony |
 | `/flow-next:sync` | **Plan-sync** — update downstream *task* specs after implementation drift inside flow-next |
 | `/flow-next:tracker-sync` | **Tracker bridge** (distinct from `/flow-next:sync`) — project a spec to a Linear/GitHub issue and reconcile body/status/comments two-way; projection, not coordination ([docs](plugins/flow-next/docs/tracker-sync.md)) |
 | `/flow-next:map` | Optional — wrap [openclaw/clawpatch](https://github.com/openclaw/clawpatch)'s `clawpatch map` for a semantic feature index (`.clawpatch/features/*.json`); scouts read it when present, fall back to grep/glob when absent. Requires Node 22+ + `pnpm add -g clawpatch` |
 
-Full command reference (every flag, every default) in [`docs/flowctl.md`](plugins/flow-next/docs/flowctl.md).
+**Phrase-triggered skills** (no slash command — just ask): `flow-next-deps` ("what's blocking what?" — dependency graph + execution order), `flow-next-drive` (drive a running app like a real user; powers `/flow-next:qa`), `flow-next-export-context` (export RepoPrompt context for external-LLM review), `flow-next-rp-explorer` (token-efficient codebase exploration via RepoPrompt), `flow-next-worktree-kit` (worktree create/list/switch/cleanup + `.env` copying), and base `flow-next` ("show me my tasks", "what's ready?").
+
+Full catalog of all 28 skills with triggers: [`docs/skills.md`](plugins/flow-next/docs/skills.md). Full CLI reference (every flag, every default): [`docs/flowctl.md`](plugins/flow-next/docs/flowctl.md).
 
 ---
 
-## Autonomous loops
+## Adopting in a team
 
-The default path is the **pilot + land pipeline** — in-session, host-driven, zero scaffold:
+Flow-Next is a methodology, not just a tool. The [teams guide](plugins/flow-next/docs/teams.md) maps the AI-native SDLC onto concrete commands: the six handover objects, **Spec-as-PR** (review the 50-line spec before the 500-line implementation exists), parallel work from one spec, the symmetric interview (PO and tech lead run the *same* skill on the *same* file), and a week-1 → month-1 → quarter-1 adoption ladder.
 
-```bash
-flowctl spec ready fn-12          # bless work (or move its issue on the tracker board)
-/loop 10m /flow-next:pilot        # build loop: ready spec → plan → reviews → work → draft PR
-/loop 30m /flow-next:land         # ship loop: draft PR → CI green → reviews converged → merged → released
-```
-
-Run both concurrently — two instances, **separate clones** — for the full assembly line: board → pilot → draft PR → land → released. 📖 **[Going autonomous](https://flow-next.dev/autonomous/overview)**
-
-**Ralph** is the hardened harness for **fully planned** specs (it never plans): fresh session per iteration, hook-enforced guardrails, receipts on disk — for runs that outlast a session.
-
-```bash
-/flow-next:ralph-init           # One-time setup
-scripts/ralph/ralph.sh          # Run from terminal
-```
-
-📖 **[Ralph deep dive](plugins/flow-next/docs/ralph.md)** · **[Ralph TUI](flow-next-tui/)** (`bun add -g @gmickel/flow-next-tui`)
+Teams that live in Linear keep their board: the tracker bridge projects every spec to an issue, two-way, and `make-pr` output is [Linear Diffs](https://linear.app/docs/diffs)-ready — review the PR inside the issue. → [`docs/teams.md`](plugins/flow-next/docs/teams.md) · [`docs/tracker-sync.md`](plugins/flow-next/docs/tracker-sync.md)
 
 ---
 
@@ -269,22 +325,23 @@ The repo holds the offline-resilient reference. [flow-next.dev](https://flow-nex
 | Looking for… | Repo file | Website |
 |---|---|---|
 | 5-minute pitch + install | `README.md` (this page) | [flow-next.dev](https://flow-next.dev) |
+| Skills catalog — all 28 skills, triggers, one-liners | [`docs/skills.md`](plugins/flow-next/docs/skills.md) | — |
 | Adopting in a team, handover objects, Spec-as-PR, adoption ladder | [`docs/teams.md`](plugins/flow-next/docs/teams.md) | [Teams guide](https://flow-next.dev) |
 | Full `flowctl` CLI reference — every command, every flag | [`docs/flowctl.md`](plugins/flow-next/docs/flowctl.md) | — |
 | Ralph autonomous mode internals — hooks, receipts, DCG | [`docs/ralph.md`](plugins/flow-next/docs/ralph.md) | — |
+| Optional HTML render lenses — spec visualizer + PR review instrument | [`docs/html-artifacts.md`](plugins/flow-next/docs/html-artifacts.md) | — |
 | Live-app QA — `/flow-next:qa`, spec-derived scenarios, P0/P1/P2 findings, `qa_verdict` receipt | [`skills/flow-next-qa/SKILL.md`](plugins/flow-next/skills/flow-next-qa/SKILL.md) | — |
 | `.flow/` directory layout, spec-first task model, ID format | [`docs/architecture.md`](plugins/flow-next/docs/architecture.md) | — |
 | Spec template — R-ID rules, confidence anchors, receipt schema | [`docs/spec-template.md`](plugins/flow-next/docs/spec-template.md) · canonical scaffold at [`templates/spec.md`](plugins/flow-next/templates/spec.md) | — |
 | Memory schema — bug / knowledge tracks, frontmatter, audit lifecycle | [`docs/memory-schema.md`](plugins/flow-next/docs/memory-schema.md) | — |
+| Self-improving loops — memory, glossary, decisions, strategy | [`docs/self-improving.md`](plugins/flow-next/docs/self-improving.md) | — |
 | Tracker-sync bridge — projection model, hybrid id, transport ladder, `/flow-next:tracker-sync` vs `/flow-next:sync` | [`docs/tracker-sync.md`](plugins/flow-next/docs/tracker-sync.md) | — |
 | Project glossary — `GLOSSARY.md` shape, R17 forbidden-vocabulary guard | [`docs/glossary.md`](plugins/flow-next/docs/glossary.md) · [`GLOSSARY.md`](GLOSSARY.md) | — |
 | Project strategy — `STRATEGY.md` shape, downstream skill grounding | [`docs/strategy.md`](plugins/flow-next/docs/strategy.md) · [`STRATEGY.md`](STRATEGY.md) | — |
 | Cross-platform install matrix + Codex / Droid / OpenCode notes | [`docs/platforms.md`](plugins/flow-next/docs/platforms.md) | — |
 | `scripts/sync-codex.sh` pipeline, plain-text transform, validation guards | [`docs/sync-codex.md`](plugins/flow-next/docs/sync-codex.md) | — |
 | Troubleshooting — stuck tasks, Ralph debug, receipt validation, uninstall | [`docs/troubleshooting.md`](plugins/flow-next/docs/troubleshooting.md) | — |
-| Adding a new `/flow-next:<name>` skill | [`agent_docs/adding-skills.md`](agent_docs/adding-skills.md) | — |
-| Cutting a release | [`agent_docs/releasing.md`](agent_docs/releasing.md) | — |
-| Local plugin dev + smoke tests + Ralph e2e | [`agent_docs/local-dev.md`](agent_docs/local-dev.md) | — |
+| Contributing — local dev, adding skills, releasing | [`CONTRIBUTING.md`](CONTRIBUTING.md) | — |
 | Repo strategic intent + active tracks | [`STRATEGY.md`](STRATEGY.md) | — |
 | Canonical vocabulary | [`GLOSSARY.md`](GLOSSARY.md) | — |
 | Visual overview, diagrams, methodology | — | [`flow-next.dev`](https://flow-next.dev) |
@@ -312,6 +369,8 @@ Doc index with one-line descriptions: [`plugins/flow-next/docs/README.md`](plugi
 
 Detailed install + cross-platform patterns in [`docs/platforms.md`](plugins/flow-next/docs/platforms.md).
 
+> **Upgrading from 0.x?** The 1.0 release renamed `flowctl epic` → `flowctl spec` across the entire surface. All 0.x scripts keep working — the legacy CLI is preserved as a deprecation alias layer. Migrate interactively via `/flow-next:setup` or deterministically via `flowctl migrate-rename --yes` (both transactional with rollback). See the [CHANGELOG](CHANGELOG.md).
+
 ## Ecosystem
 
 | Project | Platform |
@@ -319,6 +378,10 @@ Detailed install + cross-platform patterns in [`docs/platforms.md`](plugins/flow
 | [flow-next-opencode](https://github.com/gmickel/flow-next-opencode) | OpenCode |
 | [FlowFactory](https://github.com/Gitmaxd/flowfactory) | Factory.ai Droid |
 | [Ralph TUI](flow-next-tui/) | Cross-platform TUI for Ralph runs |
+
+## Contributing
+
+Bug reports and PRs welcome — start at [`CONTRIBUTING.md`](CONTRIBUTING.md) (local dev, adding skills, the docs-only rule) and [`SECURITY.md`](SECURITY.md) for private disclosure. Or come say hi on [Discord](https://discord.gg/f3DYq8AAm5).
 
 ## Also check out
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,24 @@
+# Security Policy
+
+## Supported versions
+
+Only the latest release of flow-next receives security fixes. The plugin runs locally inside your agent harness (Claude Code / Codex / Droid) with no hosted components — the attack surface is the bundled `flowctl` CLI, the shell scripts, and the skill/hook prompts.
+
+| Version | Supported |
+|---|---|
+| latest release | ✅ |
+| older releases | ❌ — upgrade first |
+
+## Reporting a vulnerability
+
+Please **do not** open a public issue for security problems.
+
+- Preferred: [GitHub private vulnerability reporting](https://github.com/gmickel/flow-next/security/advisories/new)
+- Or email: [gordon@mickel.tech](mailto:gordon@mickel.tech)
+
+Include reproduction steps and the affected version (`flowctl --version` or the README badge). You'll get an acknowledgment within a few days; fixes ship as a normal release with credit unless you prefer otherwise.
+
+## Scope notes
+
+- Prompt-injection hardening of skills (e.g. Ralph guardrails, review gates) is in scope — flow-next's autonomous loops are designed to be gated and receipted, and bypasses are bugs.
+- Vulnerabilities in host platforms (Claude Code, Codex, Droid, Cursor, Grok) or optional third-party tools (`clawpatch`, `lavish-axi`, RepoPrompt) belong upstream — but if flow-next's integration makes them worse, report here too.

--- a/plugins/flow-next/README.md
+++ b/plugins/flow-next/README.md
@@ -1,13 +1,14 @@
 # flow-next
 
-> **Plan-first AI workflow. Zero external dependencies.**
+> **Repeatable agentic engineering.** Durable specs, re-anchored workers, adversarial reviews, receipts — everything in your repo, zero external dependencies.
 
 This is the plugin source directory. The canonical README for flow-next lives at the [repository root](../../README.md).
 
-- Install + 5-command quick start → [root README](../../README.md#quick-start)
+- Install + 5-command happy path → [root README](../../README.md#quick-start)
 - How the flow works (workflow narrative) → [root README → How the flow works](../../README.md#how-the-flow-works)
+- Skills catalog (all 28 skills) → [`docs/skills.md`](docs/skills.md)
 - Adopting in a team → [`docs/teams.md`](docs/teams.md)
 - `flowctl` CLI reference → [`docs/flowctl.md`](docs/flowctl.md)
-- Ralph autonomous mode → [`docs/ralph.md`](docs/ralph.md)
+- Going autonomous (pilot / land / Ralph) → [root README → Going autonomous](../../README.md#going-autonomous) · [`docs/ralph.md`](docs/ralph.md)
 - Architecture + `.flow/` layout → [`docs/architecture.md`](docs/architecture.md)
 - Full doc index → [`docs/README.md`](docs/README.md)

--- a/plugins/flow-next/docs/README.md
+++ b/plugins/flow-next/docs/README.md
@@ -1,14 +1,23 @@
 # Flow-Next docs
 
-Reference material for flow-next. Each file is self-contained, terse, and offline-readable. Cross-links use relative repo paths — fork-survivable, no external URLs.
+The offline-resilient reference for flow-next — **repeatable agentic engineering**: durable specs, re-anchored workers, adversarial reviews, receipts. Each file here is self-contained, terse, and offline-readable. Cross-links use relative repo paths — fork-survivable, no external URLs.
 
-> For the plugin overview, install path, and the 6-step workflow narrative see [`../README.md`](../README.md). For the repo's strategic intent see [`../../../STRATEGY.md`](../../../STRATEGY.md). For canonical vocabulary see [`../../../GLOSSARY.md`](../../../GLOSSARY.md).
+**Start here by intent:**
+
+- *"What is this and how do I install it?"* → [root README](../../../README.md) — pitch, tenets, install, 5-command happy path.
+- *"What skills exist?"* → [`skills.md`](skills.md) — all 28 skills, triggers, one-liners.
+- *"How do we adopt this as a team?"* → [`teams.md`](teams.md) — handover objects, Spec-as-PR, adoption ladder.
+- *"How do I run it autonomously?"* → [`ralph.md`](ralph.md) + the pilot/land skill pages below.
+- *"What's every flag on every command?"* → [`flowctl.md`](flowctl.md).
+
+> For the repo's strategic intent see [`../../../STRATEGY.md`](../../../STRATEGY.md). For canonical vocabulary (Spec, R-ID, Handover object, Receipt, render lens, …) see [`../../../GLOSSARY.md`](../../../GLOSSARY.md).
 
 ## Subsystem references
 
 | Doc | What's in it |
 |-----|--------------|
 | [`architecture.md`](architecture.md) | `.flow/` directory layout, spec-first task model, ID format, separation of concerns, task completion shape |
+| [`skills.md`](skills.md) | Skills catalog — all 28 skills (22 slash-command, 6 phrase-triggered), grouped by lifecycle / autonomy / maintenance, each linked to its `SKILL.md` |
 | [`spec-template.md`](spec-template.md) | Canonical scaffold cross-link, R-ID rules, confidence anchors, introduced-vs-pre-existing, protected artifacts, trivial-diff skip, receipt schema |
 | [`memory-schema.md`](memory-schema.md) | Categorized memory tree (bug / knowledge tracks), frontmatter schemas, decisions subtree, audit lifecycle, legacy migration |
 | [`tracker-sync.md`](tracker-sync.md) | `/flow-next:tracker-sync` bridge — projection-not-coordination, discovery ceremony, hybrid id model, sync-state schema, transport ladder (Linear/GitHub), lifecycle touchpoints, Ralph-safe conflict queueing; distinct from `/flow-next:sync` (plan-sync) |
@@ -44,4 +53,5 @@ Reference material for flow-next. Each file is self-contained, terse, and offlin
 - [`../README.md`](../README.md) — plugin overview, install, workflow narrative.
 - [`../../../STRATEGY.md`](../../../STRATEGY.md) — flow-next's strategic intent + active tracks.
 - [`../../../GLOSSARY.md`](../../../GLOSSARY.md) — canonical vocabulary (Spec, Task, R-ID, ...).
+- [`../../../CONTRIBUTING.md`](../../../CONTRIBUTING.md) — contributor entry point (local dev, adding skills, releasing).
 - [`../../../CLAUDE.md`](../../../CLAUDE.md) — repo-level guide for working in this codebase.

--- a/plugins/flow-next/docs/architecture.md
+++ b/plugins/flow-next/docs/architecture.md
@@ -2,6 +2,8 @@
 
 How flow-next stores state, how the spec-first task model works, and the separation of concerns between metadata and narrative content.
 
+The design tenet behind all of it: **everything lives in the repo**. Specs, tasks, memory, receipts are plain markdown + JSON under `.flow/` — in git, code-reviewable, diff-able, fork-survivable. No external services, no global config, no database. Uninstall is `rm -rf .flow/`.
+
 ## Spec-first task model
 
 Flow-next does not support standalone tasks. Every unit of work belongs to a spec `fn-N-slug` (even if it's a single task). Tasks are always `fn-N-slug.M` and inherit context from the parent spec.

--- a/plugins/flow-next/docs/ralph.md
+++ b/plugins/flow-next/docs/ralph.md
@@ -1,8 +1,10 @@
 # Ralph — Autonomous Loop
 
-Ralph is Flow-Next's repo-local autonomous harness. It loops over tasks, applies multi-model review gates, and produces production-quality code overnight.
+Ralph is Flow-Next's repo-local **hardened** autonomous harness. It exists because long-lived autonomous sessions accumulate failed attempts and stale assumptions — Ralph instead starts a *fresh* session per iteration, re-anchors, and gates every transition on receipts. It consumes **fully planned** specs only (it never plans), applies multi-model review gates, and produces production-quality code overnight.
 
 > **TL;DR**: External shell loop → fresh Claude session per task → cross-model review gates → receipt-based proof-of-work → iterate until SHIP.
+>
+> **Which loop do I want?** The default autonomy path is the in-session **pilot + land pipeline** (`/loop 10m /flow-next:pilot` to build, `/loop 30m /flow-next:land` to ship) — zero scaffold, transcript verdicts, host-driven. Reach for Ralph when a run outlasts a session or prose guardrails aren't enough: Ralph owns the loop in a shell script with hook-enforced guardrails. The two are alternative drivers for the same pipeline and are **never nested**. See [Host-driven loop vs Ralph](#host-driven-loop-vs-ralph).
 
 ---
 

--- a/plugins/flow-next/docs/skills.md
+++ b/plugins/flow-next/docs/skills.md
@@ -1,0 +1,63 @@
+# Skills catalog
+
+Every skill flow-next ships, in one table. 28 skills: 22 slash-command-triggered (`/flow-next:<name>`), 6 phrase-triggered (no command file — describe what you want and the host agent matches the skill description). Each row links the canonical `SKILL.md`.
+
+> Lifecycle position and narrative for the core commands: [root README — How the flow works](../../../README.md#how-the-flow-works). Slash commands also appear in the [root README — Commands table](../../../README.md#commands) with flags and opt-in notes.
+
+## Lifecycle skills
+
+The spec-to-merge pipeline, in order.
+
+| Skill | Trigger | What it does |
+|---|---|---|
+| [`flow-next-strategy`](../skills/flow-next-strategy/SKILL.md) | `/flow-next:strategy` | Create or maintain repo-root `STRATEGY.md` — target problem, approach, who it's for, key metrics, active tracks. Downstream skills read it for grounding. |
+| [`flow-next-prospect`](../skills/flow-next-prospect/SKILL.md) | `/flow-next:prospect` | Generate ranked candidate ideas grounded in the repo, upstream of capture/plan. Optional focus hint (concept, path, constraint, volume). |
+| [`flow-next-capture`](../skills/flow-next-capture/SKILL.md) | `/flow-next:capture` | Synthesize the current conversation into a spec — source-tagged acceptance criteria (`[user]` / `[paraphrase]` / `[inferred]`), mandatory read-back before write. |
+| [`flow-next-interview`](../skills/flow-next-interview/SKILL.md) | `/flow-next:interview` | Deep Q&A over a spec or task to extract complete detail — lead-with-recommendation, confidence tiers, codebase-first investigation; `--scope=business\|technical\|both`. |
+| [`flow-next-plan`](../skills/flow-next-plan/SKILL.md) | `/flow-next:plan` | Research the codebase via parallel scouts, then break a spec into dependency-ordered, context-fit tasks. Writes the plan, never code. |
+| [`flow-next-plan-review`](../skills/flow-next-plan-review/SKILL.md) | `/flow-next:plan-review` | Carmack-level cross-model review of a spec or plan (RepoPrompt / Codex / Copilot backend). |
+| [`flow-next-work`](../skills/flow-next-work/SKILL.md) | `/flow-next:work` | Execute a spec or task — git setup, fresh-context worker subagents, re-anchoring, quality checks, commits, evidence. Opt-in `delegate:codex` implementation offload. |
+| [`flow-next-impl-review`](../skills/flow-next-impl-review/SKILL.md) | `/flow-next:impl-review` | Carmack-level cross-model implementation review — confidence anchors, introduced-vs-pre-existing classification, SHIP / NEEDS_WORK receipt. |
+| [`flow-next-spec-completion-review`](../skills/flow-next-spec-completion-review/SKILL.md) | `/flow-next:spec-completion-review` | End-of-spec gate — verifies the *combined* implementation across all tasks satisfies the spec. |
+| [`flow-next-qa`](../skills/flow-next-qa/SKILL.md) | `/flow-next:qa` | Live-app real-user QA derived from the spec — drives the running app via `flow-next-drive`, files P0/P1/P2 findings with evidence, YES/NO ship verdict receipt. Forbidden from marking PASS by reading source. Opt-in. |
+| [`flow-next-make-pr`](../skills/flow-next-make-pr/SKILL.md) | `/flow-next:make-pr` | Render a cognitive-aid PR body from nine input streams and open via `gh`; with HTML artifact mode on, also commits a `pr.html` review instrument. |
+| [`flow-next-resolve-pr`](../skills/flow-next-resolve-pr/SKILL.md) | `/flow-next:resolve-pr` | Resolve PR review feedback — fetch unresolved threads, triage, dispatch per-thread resolver agents, validate, commit, reply + resolve via GraphQL. |
+
+## Autonomous loops
+
+| Skill | Trigger | What it does |
+|---|---|---|
+| [`flow-next-pilot`](../skills/flow-next-pilot/SKILL.md) | `/flow-next:pilot` | Single-tick build-loop conductor — advances one *ready* spec by one pipeline stage per tick, ends with a `PILOT_VERDICT` line; your host's `/loop` or `/goal` owns iteration. |
+| [`flow-next-land`](../skills/flow-next-land/SKILL.md) | `/flow-next:land` | Cadence-tick ship loop — babysits build-loop-authored PRs through CI fixes, review convergence, gated explicit merge, spec close, and release-follow; ends with a `LAND_VERDICT` line. |
+| [`flow-next-ralph-init`](../skills/flow-next-ralph-init/SKILL.md) | `/flow-next:ralph-init` | Scaffold the repo-local Ralph hardened harness under `scripts/ralph/` — external shell loop, fresh session per iteration, hook guardrails, receipts. |
+
+## Knowledge & maintenance
+
+| Skill | Trigger | What it does |
+|---|---|---|
+| [`flow-next-prime`](../skills/flow-next-prime/SKILL.md) | `/flow-next:prime` | 8-pillar / 48-criteria agent-readiness assessment with parallel scouts — verifies commands actually run, checks GitHub settings, fixes agent readiness with consent. |
+| [`flow-next-audit`](../skills/flow-next-audit/SKILL.md) | `/flow-next:audit` | Memory garbage collection — review each `.flow/memory/` entry against current code; Keep / Update / Consolidate / Replace / Delete. |
+| [`flow-next-memory-migrate`](../skills/flow-next-memory-migrate/SKILL.md) | `/flow-next:memory-migrate` | Lift pre-fn-30 legacy flat memory files into the categorized YAML schema. |
+| [`flow-next-sync`](../skills/flow-next-sync/SKILL.md) | `/flow-next:sync` | Plan-sync — update downstream task specs after implementation drift. Distinct from `tracker-sync`. |
+| [`flow-next-tracker-sync`](../skills/flow-next-tracker-sync/SKILL.md) | `/flow-next:tracker-sync` | Project a spec to a Linear/GitHub issue and reconcile body/status/comments two-way — projection, not coordination; the spec stays the source of truth. |
+| [`flow-next-map`](../skills/flow-next-map/SKILL.md) | `/flow-next:map` | Optional — wrap `clawpatch map` for a semantic feature index at `.clawpatch/features/*.json`; scouts read it when present, fall back to grep/glob when absent. |
+| [`flow-next-setup`](../skills/flow-next-setup/SKILL.md) | `/flow-next:setup` | Per-project setup — `.flow/` init, local flowctl install, CLAUDE.md/AGENTS.md instructions, review-backend + config ceremony. |
+
+## Phrase-triggered skills
+
+No slash command — just describe what you want.
+
+| Skill | Say something like | What it does |
+|---|---|---|
+| [`flow-next`](../skills/flow-next/SKILL.md) | "show me my tasks", "what's ready?", "list specs" | Day-to-day `.flow/` task and spec management via flowctl. |
+| [`flow-next-deps`](../skills/flow-next-deps/SKILL.md) | "what's blocking what?", "execution order", "critical path" | Spec dependency graph and execution order — which specs can run in parallel. |
+| [`flow-next-drive`](../skills/flow-next-drive/SKILL.md) | "drive the app", "verify the deployed UI" | Drive any UI surface like a real user — web, Electron/WebView2 over CDP, or native via Computer Use. Surface-aware driver ladder; powers `/flow-next:qa`. |
+| [`flow-next-export-context`](../skills/flow-next-export-context/SKILL.md) | "export context for external review" | Export RepoPrompt context to markdown for review with an external LLM (ChatGPT, Claude web, …). |
+| [`flow-next-rp-explorer`](../skills/flow-next-rp-explorer/SKILL.md) | "use rp to find …" | Token-efficient codebase exploration through the RepoPrompt CLI. |
+| [`flow-next-worktree-kit`](../skills/flow-next-worktree-kit/SKILL.md) | "create a worktree for …" | Git worktree create/list/switch/cleanup + `.env` copying — parallel feature work, isolated review. |
+
+## See also
+
+- [Root README — Commands](../../../README.md#commands) — the slash-command table with flags and opt-in notes.
+- [`README.md`](README.md) — the doc index (subsystem + workflow references).
+- [`../../../agent_docs/adding-skills.md`](../../../agent_docs/adding-skills.md) — how to add a new skill (the three-edit rule).

--- a/plugins/flow-next/docs/teams.md
+++ b/plugins/flow-next/docs/teams.md
@@ -1,6 +1,6 @@
 # Teams & Spec-Driven Development with Flow-Next
 
-This page maps the AI-native software development lifecycle (SDLC) to Flow-Next commands. If your team is asking *"where does our Agile fit when we adopt this?"*, start here.
+Agentic engineering compresses implementation from weeks to hours — and the touchpoints pre-agentic Agile relied on (standups, refinement, design review, hallway clarification) collapse with it. The collaboration doesn't become unnecessary; it has to move into **explicit artefacts before the run starts**. This page maps that AI-native software development lifecycle (SDLC) onto concrete Flow-Next commands. If your team is asking *"where does our Agile fit when we adopt this?"*, start here.
 
 The vocabulary on this page — *handover objects*, *Delegate / Review / Own*, *lifecycle steps [1]–[9]* — comes from the [AI-x-SDLC Starter-Kit methodology guide](https://github.com/gmickel/AI-x-SDLC-Starter-Kit/blob/main/guides/methodology.md). That document is the *theory*. This page is the *implementation* — the same lifecycle, mapped to concrete `flowctl` commands and `.flow/` artefacts.
 


### PR DESCRIPTION
# GitHub docs overhaul

Full refresh of the repo's GitHub-facing documentation so it carries the core strategy/tenets — repeatable agentic engineering, the touchpoint collapse, specs that carry the weight, receipts — instead of reading as a feature inventory. No spec (maintainer-requested direct chore PR, per CLAUDE.md chore-PR rule).

> Supersedes #174 (auto-closed when its base branch was deleted on the #173 merge). Branch is rebased onto `main` on top of the landed 2.0.0; diff is docs + `.github/` only.

## What changed

- **README.md — ground-up rewrite.** New narrative spine: *Why this exists* (touchpoint collapse → "the spec has to carry the weight" → "the artifact chain is the conversation that would otherwise be missing"), a seven-tenet table (spec-driven / context-fit / re-anchored / adversarial gates / receipts / multi-harness / self-improving), six handover objects, the three-loop autonomy story (pilot + land default, Ralph hardened), a *What Flow-Next is not* section (Symphony / Kiro / SaaS contrasts from STRATEGY.md), testimonials, and the previously unused screenshots (`flow-next-plan.png`, `tui.png`). The four previously invisible phrase-triggered skills (fn-56 R1 finding) now surface in the Commands section. Version badge 2.0.0 + render-lens callouts preserved from #173.
- **New `plugins/flow-next/docs/skills.md`** — catalog of all 28 skills (22 slash, 6 phrase-triggered), grouped lifecycle / autonomous / maintenance / phrase, each linked to its `SKILL.md` (fn-56 R1).
- **`docs/README.md`** — intent-routed hub ("start here by intent") + skills-catalog row; **`plugins/flow-next/README.md`** — new tagline + catalog/autonomy links.
- **`teams.md` / `ralph.md` / `architecture.md`** — narrative framing punch-ups only (touchpoint-collapse opening; "which loop do I want?" router on Ralph; everything-lives-in-the-repo tenet). Reference bodies untouched — they're accurate, reviewed content; regenerating them risks drift for no gain. Same call for `flowctl.md`, `platforms.md`, `tracker-sync.md`, `memory-schema.md` etc. (fn-56 R6 freshness pass stays a separate job).
- **Community health (fn-56 R5):** `CONTRIBUTING.md` (thin router to `agent_docs/`, ground rules incl. never-hand-edit-the-codex-mirror + docs-only version rule), `SECURITY.md` (private advisory channel), `.github/ISSUE_TEMPLATE/` (bug YAML form, feature form with a STRATEGY.md "Not working on" pre-flight, config with Discord/security contact links).
- **Link-check CI gate (fn-56 R7):** `.github/workflows/docs-linkcheck.yml` — lychee `--offline` over internal relative links (the discipline the docs tree already enforces), Codex mirror + `.flow/` excluded, external URLs deliberately unchecked (flakiness shouldn't block PRs).

## Verification

- `plugins/flow-next/scripts/ci_test.sh` — **67/67 green** (includes R17/R19 vocabulary guards).
- Internal relative links verified across the full linkcheck scope (131 md files) — only hits are fenced template examples, which lychee correctly skips.
- Workflow YAML parses; no skill/agent/hook/flowctl files touched → no `sync-codex.sh` run needed.

## Version note

Docs + `.github/` only — **no plugin version bump** per the CLAUDE.md docs-only rule.