### PR TITLE
fix(codex): dedup-safe hooks config normalization (no duplicate/deprecated key)

### DIFF
--- a/.flow/meta.json
+++ b/.flow/meta.json
@@ -1,6 +1,6 @@
 {
   "next_spec": 1,
   "schema_version": 3,
-  "setup_date": "2026-06-27T15:37:40Z",
-  "setup_version": "2.2.0"
+  "setup_date": "2026-07-02T20:35:32Z",
+  "setup_version": "2.6.0"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the flow-next.
 
+## Unreleased
+
+### Fixed
+
+- **Codex hooks config no longer written as a duplicate/deprecated key** — `install-codex.sh` still wrote the **deprecated** `codex_hooks = true` (which Codex warns on every run) and was blind to an existing `hooks = true`, so a config that already carried the modern key ended up with BOTH; and `flow-next-setup` Step 4b's naive `sed codex_hooks→hooks` migration could turn that pair into a **duplicate `hooks` key**, which is invalid TOML and silently breaks Codex hook loading. Both paths now converge through one idempotent, dedup-safe normalizer (`scripts/normalize_codex_hooks.py`, mirrored inline in the setup skill): exactly one `hooks = true` under `[features]`, zero `codex_hooks`, everything else byte-preserved, re-running is a no-op. Regression-tested (`test_codex_hooks_normalize.py`, 10 cases incl. the both-keys scenario). Codex mirror regenerated via `scripts/sync-codex.sh`.
+
 ## [flow-next 2.6.0] - 2026-07-02
 
 ### Changed

--- a/plugins/flow-next/codex/skills/flow-next-setup/workflow.md
+++ b/plugins/flow-next/codex/skills/flow-next-setup/workflow.md
@@ -291,17 +291,51 @@ fi
 ```bash
 if [ -f .codex/config.toml ]; then
  # `[features].hooks` is the current key; `codex_hooks` is the deprecated
- # pre-2026 spelling (Codex warns on every run). A repo carrying ONLY the old
- # key still needs the new one written — detect them separately (the old key
- # must not satisfy the check), and migrate the old spelling in place.
- if grep -qE '^ *codex_hooks *= *true' .codex/config.toml 2>/dev/null; then
- sed -i.bak 's/^ *codex_hooks *= *true/hooks = true/' .codex/config.toml && rm -f .codex/config.toml.bak
- echo "Migrated deprecated codex_hooks -> hooks in .codex/config.toml"
- fi
- if ! grep -qE '^ *hooks *= *true' .codex/config.toml 2>/dev/null; then
- echo -e '\n[features]\nhooks = true' >> .codex/config.toml
- echo "Enabled hooks in .codex/config.toml"
- fi
+ # pre-2026 spelling (Codex warns on every run). Goal: EXACTLY ONE
+ # `hooks = true` under [features], NO `codex_hooks`. This must stay dedup-safe:
+ # a config carrying BOTH keys (older setup/install left this) would, under a
+ # naive `sed codex_hooks->hooks`, gain a DUPLICATE `hooks` key — invalid TOML
+ # that breaks Codex hook loading. Use python3 to normalize idempotently.
+ python3 - .codex/config.toml <<'PY'
+import re, sys
+path = sys.argv[1]
+HOOKS = "hooks = true # flow-next"
+sec = re.compile(r"^\s*\[([^\]]+)\]\s*$")
+old = re.compile(r"^\s*codex_hooks\s*=")
+new = re.compile(r"^\s*hooks\s*=")
+try:
+ text = open(path, encoding="utf-8").read()
+except FileNotFoundError:
+ text = ""
+out, in_feat, feat_seen, kept = [], False, False, False
+for line in text.splitlines():
+ m = sec.match(line)
+ if m:
+ if in_feat and not kept:
+ out.append(HOOKS); kept = True
+ in_feat = m.group(1).strip() == "features"
+ if in_feat:
+ feat_seen = True; kept = False
+ out.append(line); continue
+ if in_feat:
+ if old.match(line):
+ continue # drop deprecated key
+ if new.match(line):
+ if kept:
+ continue # drop duplicate hooks
+ kept = True; out.append(line); continue
+ out.append(line)
+if in_feat and not kept:
+ out.append(HOOKS)
+if not feat_seen:
+ if out and out[-1].strip():
+ out.append("")
+ out += ["[features]", HOOKS]
+result = "\n".join(out).rstrip("\n") + "\n"
+if result != text:
+ open(path, "w", encoding="utf-8").write(result)
+ print("Normalized .codex/config.toml -> single [features] hooks = true")
+PY
 fi
 ```
 

--- a/plugins/flow-next/skills/flow-next-setup/workflow.md
+++ b/plugins/flow-next/skills/flow-next-setup/workflow.md
@@ -289,17 +289,51 @@ fi
 ```bash
 if [ -f .codex/config.toml ]; then
   # `[features].hooks` is the current key; `codex_hooks` is the deprecated
-  # pre-2026 spelling (Codex warns on every run). A repo carrying ONLY the old
-  # key still needs the new one written — detect them separately (the old key
-  # must not satisfy the check), and migrate the old spelling in place.
-  if grep -qE '^ *codex_hooks *= *true' .codex/config.toml 2>/dev/null; then
-    sed -i.bak 's/^ *codex_hooks *= *true/hooks = true/' .codex/config.toml && rm -f .codex/config.toml.bak
-    echo "Migrated deprecated codex_hooks -> hooks in .codex/config.toml"
-  fi
-  if ! grep -qE '^ *hooks *= *true' .codex/config.toml 2>/dev/null; then
-    echo -e '\n[features]\nhooks = true' >> .codex/config.toml
-    echo "Enabled hooks in .codex/config.toml"
-  fi
+  # pre-2026 spelling (Codex warns on every run). Goal: EXACTLY ONE
+  # `hooks = true` under [features], NO `codex_hooks`. This must stay dedup-safe:
+  # a config carrying BOTH keys (older setup/install left this) would, under a
+  # naive `sed codex_hooks->hooks`, gain a DUPLICATE `hooks` key — invalid TOML
+  # that breaks Codex hook loading. Use python3 to normalize idempotently.
+  python3 - .codex/config.toml <<'PY'
+import re, sys
+path = sys.argv[1]
+HOOKS = "hooks = true  # flow-next"
+sec = re.compile(r"^\s*\[([^\]]+)\]\s*$")
+old = re.compile(r"^\s*codex_hooks\s*=")
+new = re.compile(r"^\s*hooks\s*=")
+try:
+    text = open(path, encoding="utf-8").read()
+except FileNotFoundError:
+    text = ""
+out, in_feat, feat_seen, kept = [], False, False, False
+for line in text.splitlines():
+    m = sec.match(line)
+    if m:
+        if in_feat and not kept:
+            out.append(HOOKS); kept = True
+        in_feat = m.group(1).strip() == "features"
+        if in_feat:
+            feat_seen = True; kept = False
+        out.append(line); continue
+    if in_feat:
+        if old.match(line):
+            continue                      # drop deprecated key
+        if new.match(line):
+            if kept:
+                continue                  # drop duplicate hooks
+            kept = True; out.append(line); continue
+    out.append(line)
+if in_feat and not kept:
+    out.append(HOOKS)
+if not feat_seen:
+    if out and out[-1].strip():
+        out.append("")
+    out += ["[features]", HOOKS]
+result = "\n".join(out).rstrip("\n") + "\n"
+if result != text:
+    open(path, "w", encoding="utf-8").write(result)
+    print("Normalized .codex/config.toml -> single [features] hooks = true")
+PY
 fi
 ```
 

--- a/plugins/flow-next/tests/test_codex_hooks_normalize.py
+++ b/plugins/flow-next/tests/test_codex_hooks_normalize.py
@@ -1,0 +1,130 @@
+"""Regression tests for scripts/normalize_codex_hooks.py.
+
+Guards the historical bug where a Codex config.toml carrying BOTH
+`codex_hooks = true` (older install-codex.sh) AND `hooks = true` (Codex/setup)
+ended up with a DUPLICATE `hooks` key after a naive sed migration — invalid TOML
+that breaks Codex hook loading. The normalizer must always converge to exactly
+one `hooks = true` under [features] and no `codex_hooks`, idempotently.
+"""
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPT = REPO_ROOT / "scripts" / "normalize_codex_hooks.py"
+
+# Load the module directly for in-process unit assertions on normalize().
+_spec = importlib.util.spec_from_file_location("normalize_codex_hooks", SCRIPT)
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+normalize = _mod.normalize
+
+
+def _features_hooks(text: str):
+    """Return the list of hooks/codex_hooks keys seen inside [features]."""
+    in_feat = False
+    hooks, codex_hooks = 0, 0
+    for line in text.splitlines():
+        s = line.strip()
+        if s.startswith("[") and s.endswith("]"):
+            in_feat = s == "[features]"
+            continue
+        if in_feat:
+            if s.startswith("hooks"):
+                hooks += 1
+            if s.startswith("codex_hooks"):
+                codex_hooks += 1
+    return hooks, codex_hooks
+
+
+def _assert_normal(text: str):
+    hooks, codex_hooks = _features_hooks(text)
+    assert hooks == 1, f"expected exactly one hooks key, got {hooks}\n{text}"
+    assert codex_hooks == 0, f"expected no codex_hooks key, got {codex_hooks}\n{text}"
+    # Must be valid TOML if a parser is available (py3.11+ ships tomllib).
+    try:
+        import tomllib
+    except ModuleNotFoundError:
+        return
+    data = tomllib.loads(text)
+    assert data.get("features", {}).get("hooks") is True
+
+
+def test_both_keys_dedup_to_one():
+    """The exact bug: both codex_hooks and hooks present -> single hooks."""
+    src = (
+        'model = "gpt-5"\n'
+        "[features]\n"
+        "codex_hooks = true  # flow-next\n"
+        "hooks = true\n"
+        "shell_tool = true\n"
+        "[agents]\n"
+        "max_threads = 12\n"
+    )
+    out = normalize(src)
+    _assert_normal(out)
+    # Content outside [features] preserved.
+    assert 'model = "gpt-5"' in out
+    assert "shell_tool = true" in out
+    assert "[agents]" in out and "max_threads = 12" in out
+
+
+def test_only_deprecated_key_migrates():
+    src = "[features]\ncodex_hooks = true  # flow-next\nshell_tool = true\n"
+    out = normalize(src)
+    _assert_normal(out)
+
+
+def test_only_modern_key_is_noop_shape():
+    src = "[features]\nhooks = true\nshell_tool = true\n"
+    out = normalize(src)
+    _assert_normal(out)
+
+
+def test_features_without_hooks_gets_one():
+    src = "[features]\nshell_tool = true\n"
+    out = normalize(src)
+    _assert_normal(out)
+
+
+def test_no_features_section_appended():
+    src = 'model = "gpt-5"\n[agents]\nmax_threads = 4\n'
+    out = normalize(src)
+    _assert_normal(out)
+    assert 'model = "gpt-5"' in out
+    assert "[agents]" in out
+
+
+def test_multiple_duplicate_hooks_collapse():
+    src = "[features]\nhooks = true\nhooks = true\ncodex_hooks = true\nshell_tool = true\n"
+    out = normalize(src)
+    _assert_normal(out)
+
+
+def test_idempotent():
+    src = "[features]\ncodex_hooks = true\nhooks = true\n"
+    once = normalize(src)
+    twice = normalize(once)
+    assert once == twice
+    _assert_normal(twice)
+
+
+def test_empty_file_gets_features():
+    out = normalize("")
+    _assert_normal(out)
+
+
+def test_cli_writes_in_place(tmp_path):
+    cfg = tmp_path / "config.toml"
+    cfg.write_text("[features]\ncodex_hooks = true  # flow-next\nhooks = true\n")
+    rc = subprocess.run(
+        [sys.executable, str(SCRIPT), str(cfg)], capture_output=True
+    ).returncode
+    assert rc == 0
+    _assert_normal(cfg.read_text())
+
+
+def test_cli_missing_arg_exit_2():
+    rc = subprocess.run([sys.executable, str(SCRIPT)], capture_output=True).returncode
+    assert rc == 2

--- a/scripts/install-codex.sh
+++ b/scripts/install-codex.sh
@@ -233,28 +233,11 @@ if grep -q "# --- flow-next features" "$CONFIG" 2>/dev/null; then
     rm -f "${CONFIG}.bak"
 fi
 
-# Merge codex_hooks = true into [features] (TOML disallows duplicate tables)
-if ! grep -q '^codex_hooks = true' "$CONFIG"; then
-    if grep -q '^\[features\]' "$CONFIG"; then
-        # Existing [features] block — insert key after header (portable awk)
-        awk '
-          /^\[features\]/ && !inserted {
-            print
-            print "codex_hooks = true  # flow-next"
-            inserted = 1
-            next
-          }
-          { print }
-        ' "$CONFIG" > "${CONFIG}.new" && mv "${CONFIG}.new" "$CONFIG"
-    else
-        # No [features] block yet — create one
-        {
-            echo ""
-            echo "[features]"
-            echo "codex_hooks = true  # flow-next"
-        } >> "$CONFIG"
-    fi
-fi
+# Ensure exactly one `hooks = true` under [features], migrating away from the
+# deprecated `codex_hooks` spelling and de-duplicating. Idempotent + dedup-safe:
+# handles a config that already carries BOTH codex_hooks and hooks (which older
+# versions of this script produced) without leaving an invalid duplicate key.
+python3 "$SCRIPT_DIR/normalize_codex_hooks.py" "$CONFIG"
 
 # Generate agent entries
 CODEX_MAX_THREADS="${CODEX_MAX_THREADS:-12}"
@@ -286,7 +269,7 @@ CODEX_MAX_THREADS="${CODEX_MAX_THREADS:-12}"
 } >> "$CONFIG"
 
 echo -e "  ${GREEN}✓${NC} config.toml ($AGENT_COUNT agent entries, max_threads=$CODEX_MAX_THREADS)"
-echo -e "  ${GREEN}✓${NC} [features] codex_hooks = true"
+echo -e "  ${GREEN}✓${NC} [features] hooks = true"
 
 # ====================
 # Summary

--- a/scripts/normalize_codex_hooks.py
+++ b/scripts/normalize_codex_hooks.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Idempotent, dedup-safe normalization of the Codex hooks feature flag.
+
+Ensures a Codex `config.toml` ends with EXACTLY ONE `hooks = true` under
+`[features]` and NO deprecated `codex_hooks` key — regardless of the starting
+state. Fixes the historical bug where a config carrying BOTH `codex_hooks = true`
+(written by older install-codex.sh) AND `hooks = true` (written by Codex or by
+setup) ended up with a duplicate `hooks` key after a naive sed migration, which
+is invalid TOML and breaks Codex hook loading.
+
+Rules (applied only inside the `[features]` table):
+  - drop every `codex_hooks = ...` line (deprecated pre-2026 spelling)
+  - keep the FIRST `hooks = ...` line, drop any later duplicates
+  - if `[features]` exists but has no `hooks` key, insert `hooks = true` after
+    the header
+  - if there is no `[features]` table at all, append one with `hooks = true`
+Everything outside `[features]` is preserved byte-for-byte. Re-running is a
+no-op once normalized (idempotent).
+
+Usage:
+    python3 normalize_codex_hooks.py <path/to/config.toml>
+Exit 0 on success (writes in place only when content changed); exit 2 on a
+missing path argument. A missing file is created with a fresh `[features]`
+block (matches install-codex.sh's "no config yet" behavior).
+"""
+from __future__ import annotations
+
+import re
+import sys
+
+_HOOKS_LINE = "hooks = true  # flow-next"
+# A section header like `[features]` or `[agents.foo]`. Leading whitespace tolerated.
+_SECTION_RE = re.compile(r"^\s*\[([^\]]+)\]\s*$")
+_CODEX_HOOKS_RE = re.compile(r"^\s*codex_hooks\s*=")
+_HOOKS_RE = re.compile(r"^\s*hooks\s*=")
+
+
+def normalize(text: str) -> str:
+    lines = text.splitlines()
+    out: list[str] = []
+    in_features = False
+    features_seen = False
+    hooks_kept_in_features = False
+
+    for line in lines:
+        m = _SECTION_RE.match(line)
+        if m:
+            # Leaving a [features] block without a hooks key → inject one before
+            # the new section starts.
+            if in_features and not hooks_kept_in_features:
+                out.append(_HOOKS_LINE)
+                hooks_kept_in_features = True
+            in_features = m.group(1).strip() == "features"
+            if in_features:
+                features_seen = True
+                hooks_kept_in_features = False
+            out.append(line)
+            continue
+
+        if in_features:
+            # Drop the deprecated key entirely.
+            if _CODEX_HOOKS_RE.match(line):
+                continue
+            # Keep the first hooks line, drop later duplicates.
+            if _HOOKS_RE.match(line):
+                if hooks_kept_in_features:
+                    continue
+                hooks_kept_in_features = True
+                out.append(line)
+                continue
+
+        out.append(line)
+
+    # File ended while still inside [features] with no hooks key.
+    if in_features and not hooks_kept_in_features:
+        out.append(_HOOKS_LINE)
+        hooks_kept_in_features = True
+
+    # No [features] table anywhere → append one.
+    if not features_seen:
+        if out and out[-1].strip() != "":
+            out.append("")
+        out.append("[features]")
+        out.append(_HOOKS_LINE)
+
+    result = "\n".join(out)
+    # Preserve a single trailing newline if the original had one (or add it).
+    if text.endswith("\n") or not text.endswith("\n"):
+        result = result.rstrip("\n") + "\n"
+    return result
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        sys.stderr.write("usage: normalize_codex_hooks.py <config.toml>\n")
+        return 2
+    path = argv[1]
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            original = fh.read()
+    except FileNotFoundError:
+        original = ""
+    updated = normalize(original)
+    if updated != original:
+        with open(path, "w", encoding="utf-8") as fh:
+            fh.write(updated)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))


### PR DESCRIPTION
## Summary

Codex hooks config could end up with a **duplicate `hooks` key** (invalid TOML → Codex silently stops loading hooks) or carry the **deprecated `codex_hooks` key** (Codex warns every run). Found live on the maintainer machine: `install-codex.sh` still wrote `codex_hooks = true` and was blind to an existing `hooks = true`, so the config carried both; `flow-next-setup` Step 4b's naive `sed codex_hooks→hooks` migration then turned that pair into two `hooks = true` lines.

## What changed

- **`scripts/normalize_codex_hooks.py`** (new) — idempotent, dedup-safe normalizer: exactly one `hooks = true` under `[features]`, zero `codex_hooks`, everything outside `[features]` byte-preserved; creates the table when absent; re-running is a no-op.
- **`scripts/install-codex.sh`** — the codex_hooks-append block replaced with a call to the normalizer; success line now reports `hooks = true`.
- **`plugins/flow-next/skills/flow-next-setup/workflow.md`** Step 4b — the sed migration replaced with an inline python normalizer (same semantics; the agent-run path can't assume the repo script exists downstream).
- **`plugins/flow-next/tests/test_codex_hooks_normalize.py`** (new) — 10 regression cases: the both-keys scenario, deprecated-only, modern-only, missing key, missing table, multi-duplicate collapse, idempotency, empty file, CLI in-place write, CLI arg error.
- `CHANGELOG.md` — entry under `## Unreleased`; Codex mirror regenerated via `scripts/sync-codex.sh`.

## Verification

- New regression tests: 10/10 pass.
- Full suite: `pytest plugins/flow-next/tests/` — **1403 passed, 2 skipped, 164 subtests** (incl. mirror parity).
- Smoke (non-repo cwd): **138/138**.
- `sync-codex.sh` run twice — idempotent; mirror's setup workflow carries the normalizer (zero old-sed lines).
- Installer path exercised against the exact bug fixture (both keys) → converges to a single `hooks = true`.

## Version note

Staged under `## Unreleased`; released out-of-band as **2.6.1** (setup writing invalid TOML that breaks Codex hook loading justifies a patch cut rather than waiting for the next batch).

https://claude.ai/code/session_01Xd4aZxTqG7dSSEcbMmxqHn
