### PR TITLE
fix(flowctl): ready --spec honors spec-level depends_on_epics

### DIFF
--- a/.flow/bin/flowctl.py
+++ b/.flow/bin/flowctl.py
@@ -15896,6 +15896,45 @@ def cmd_ready(args: argparse.Namespace) -> None:
     # MU-2: Get current actor for display (marks your tasks)
     current_actor = get_actor()
 
+    # Spec-level dependency gate (GH PR #95): a spec blocked by unfinished
+    # depends_on_epics must not report its tasks as ready. Same dep rule as
+    # cmd_next / cmd_ready_all: blocked when a dep spec is missing or not done.
+    spec_data = normalize_epic(
+        load_json_or_exit(epic_path, f"Spec {spec_id}", use_json=args.json)
+    )
+    blocked_by_specs: list[str] = []
+    for dep in spec_data.get("depends_on_epics", []) or []:
+        if dep == spec_id:
+            continue
+        dep_path = find_spec_json_path(flow_dir, dep)
+        if not dep_path.exists():
+            blocked_by_specs.append(dep)
+            continue
+        dep_data = normalize_epic(
+            load_json_or_exit(dep_path, f"Spec {dep}", use_json=args.json)
+        )
+        if dep_data.get("status") != "done":
+            blocked_by_specs.append(dep)
+    if blocked_by_specs:
+        if args.json:
+            # R31: co-emit canonical "spec"/"blocked_by_specs" + legacy
+            # "epic"/"epic_blocked_by" alias keys.
+            json_output(
+                {
+                    "spec": spec_id,
+                    "epic": spec_id,
+                    "actor": current_actor,
+                    "ready": [],
+                    "in_progress": [],
+                    "blocked": [],
+                    "blocked_by_specs": blocked_by_specs,
+                    "epic_blocked_by": blocked_by_specs,
+                }
+            )
+        else:
+            print(f"Spec {spec_id} is blocked by: {', '.join(blocked_by_specs)}")
+        return
+
     # Get all tasks for spec (with merged runtime state)
     tasks_dir = flow_dir / TASKS_DIR
     if not tasks_dir.exists():

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the flow-next.
 
+## Unreleased
+
+### Fixed
+
+- **`flowctl ready --spec` now honors spec-level dependencies** (GH PR #95) — `ready` only checked task-level `depends_on`, ignoring the spec's own `depends_on_epics`, so a spec blocked by an unfinished prerequisite spec still reported its tasks as ready. `next` and `ready --all` already gated on spec deps; `ready` now applies the same rule (dep spec missing or not `done` ⇒ blocked) and returns empty `ready`/`in_progress`/`blocked` lists plus `blocked_by_specs` (legacy alias `epic_blocked_by` co-emitted through 1.x, per the R31 dual-emit convention). Latent in the default workflow (Ralph uses `next`; `/flow-next:work` calls `ready` only on pre-validated specs) but hit immediately by external consumers calling `ready` per-spec. Regression-tested in `smoke_test.sh`. Thanks to Mike Bannister (@possibilities) for the report and original patch (#95).
+
 ## [flow-next 2.6.1] - 2026-07-02
 
 ### Fixed

--- a/plugins/flow-next/docs/flowctl.md
+++ b/plugins/flow-next/docs/flowctl.md
@@ -439,6 +439,21 @@ Output:
 }
 ```
 
+Spec-level deps gate the whole spec (same rule as `next`): when the spec's `depends_on_epics` include a spec that is missing or not `done`, `ready` returns empty `ready`/`in_progress`/`blocked` lists plus `blocked_by_specs` (legacy alias `epic_blocked_by` co-emitted through 1.x):
+
+```json
+{
+  "success": true,
+  "spec": "fn-2",
+  "actor": "user@example.com",
+  "ready": [],
+  "in_progress": [],
+  "blocked": [],
+  "blocked_by_specs": ["fn-1"],
+  "epic_blocked_by": ["fn-1"]
+}
+```
+
 **`ready --all`** (fn-68, backlog mode) — a **spec-level** backlog-wide eligibility scan (ignores `--spec`), the deterministic substrate `/flow-next:pilot` backlog mode (`pilot.autonomy=backlog`) consumes:
 
 ```bash

--- a/plugins/flow-next/scripts/flowctl.py
+++ b/plugins/flow-next/scripts/flowctl.py
@@ -15896,6 +15896,45 @@ def cmd_ready(args: argparse.Namespace) -> None:
     # MU-2: Get current actor for display (marks your tasks)
     current_actor = get_actor()
 
+    # Spec-level dependency gate (GH PR #95): a spec blocked by unfinished
+    # depends_on_epics must not report its tasks as ready. Same dep rule as
+    # cmd_next / cmd_ready_all: blocked when a dep spec is missing or not done.
+    spec_data = normalize_epic(
+        load_json_or_exit(epic_path, f"Spec {spec_id}", use_json=args.json)
+    )
+    blocked_by_specs: list[str] = []
+    for dep in spec_data.get("depends_on_epics", []) or []:
+        if dep == spec_id:
+            continue
+        dep_path = find_spec_json_path(flow_dir, dep)
+        if not dep_path.exists():
+            blocked_by_specs.append(dep)
+            continue
+        dep_data = normalize_epic(
+            load_json_or_exit(dep_path, f"Spec {dep}", use_json=args.json)
+        )
+        if dep_data.get("status") != "done":
+            blocked_by_specs.append(dep)
+    if blocked_by_specs:
+        if args.json:
+            # R31: co-emit canonical "spec"/"blocked_by_specs" + legacy
+            # "epic"/"epic_blocked_by" alias keys.
+            json_output(
+                {
+                    "spec": spec_id,
+                    "epic": spec_id,
+                    "actor": current_actor,
+                    "ready": [],
+                    "in_progress": [],
+                    "blocked": [],
+                    "blocked_by_specs": blocked_by_specs,
+                    "epic_blocked_by": blocked_by_specs,
+                }
+            )
+        else:
+            print(f"Spec {spec_id} is blocked by: {', '.join(blocked_by_specs)}")
+        return
+
     # Get all tasks for spec (with merged runtime state)
     tasks_dir = flow_dir / TASKS_DIR
     if not tasks_dir.exists():

--- a/plugins/flow-next/scripts/smoke_test.sh
+++ b/plugins/flow-next/scripts/smoke_test.sh
@@ -1846,6 +1846,41 @@ PY
 echo -e "${GREEN}✓${NC} depends_on_specs blocks (R31 dual-emit)"
 PASS=$((PASS + 1))
 
+# GH PR #95 regression: per-spec `ready` must honor the same spec-level dep
+# gate as `next` — a blocked spec reports empty lists + blocked_by_specs,
+# never its tasks as ready.
+scripts/flowctl task create --spec "$DEP_CHILD_ID" --title "Child task" --json >/dev/null
+ready_blocked_json="$(scripts/flowctl ready --spec "$DEP_CHILD_ID" --json)"
+"${FLOW_PY[@]}" - "$DEP_BASE_ID" "$ready_blocked_json" <<'PY'
+import json, sys
+base_id = sys.argv[1]
+data = json.loads(sys.argv[2])
+assert data["ready"] == [], f"blocked spec leaked ready tasks: {data['ready']}"
+assert data["blocked_by_specs"] == [base_id], data.get("blocked_by_specs")
+assert data["epic_blocked_by"] == [base_id], data.get("epic_blocked_by")
+PY
+# Unblock: base spec done → child task becomes ready again.
+DEP_BASE_JSON_PATH="$(spec_json_path "$DEP_BASE_ID")"
+"${FLOW_PY[@]}" - "$DEP_BASE_JSON_PATH" <<'PY'
+import json, sys
+from pathlib import Path
+path = Path(sys.argv[1])
+data = json.loads(path.read_text())
+data["status"] = "done"
+path.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n")
+PY
+ready_open_json="$(scripts/flowctl ready --spec "$DEP_CHILD_ID" --json)"
+"${FLOW_PY[@]}" - "$DEP_CHILD_ID" "$ready_open_json" <<'PY'
+import json, sys
+child_id = sys.argv[1]
+data = json.loads(sys.argv[2])
+ids = [t["id"] for t in data["ready"]]
+assert f"{child_id}.1" in ids, f"unblocked spec's task not ready: {ids}"
+assert "blocked_by_specs" not in data, "gate keys must not appear when unblocked"
+PY
+echo -e "${GREEN}✓${NC} ready honors spec-level deps (GH PR #95)"
+PASS=$((PASS + 1))
+
 echo -e "${YELLOW}--- stdin support ---${NC}"
 cd "$TEST_DIR/repo"
 STDIN_EPIC_JSON="$(scripts/flowctl spec create --title "Stdin test" --json)"


### PR DESCRIPTION
## Summary

`flowctl ready --spec` only checked task-level `depends_on`, so a spec blocked by unfinished `depends_on_epics` still reported its tasks as ready. `next` and `ready --all` already gate on spec deps — this applies the same rule to `ready`.

Re-port of #95 (thanks @possibilities!), which conflicted after the epic→spec rename; this supersedes it with current internals (`resolve_spec_arg` / `find_spec_json_path`, R31 dual-emit).

## What changed

- `cmd_ready`: spec-level dep gate after spec resolution, before the task scan — dep spec missing or not `done` ⇒ blocked. Returns empty `ready`/`in_progress`/`blocked` lists plus `blocked_by_specs` (canonical) and `epic_blocked_by` (legacy alias, R31 dual-emit through 1.x). Human output: `Spec fn-2 is blocked by: fn-1`.
- `smoke_test.sh`: regression in the existing `depends_on_epics gate` section — blocked spec leaks no tasks + emits both keys; base spec done ⇒ task ready again, gate keys absent.
- `docs/flowctl.md`: blocked-output contract documented under `### ready`.
- `CHANGELOG.md`: `## Unreleased` entry crediting Mike Bannister.
- `.flow/bin/flowctl.py`: dogfood copy synced (dual-copy invariant).

## Verification

- Live repro before/after: `ready --spec` on a dep-blocked spec returned its task as ready on main; returns empty + `blocked_by_specs: [fn-1]` after; task ready again once the dep spec is `done`.
- `smoke_test.sh`: **139/139** (baseline 138 + new regression case).
- Full unittest suite: 1395 run, 0 failures after dogfood sync (the 3 dual-copy invariants were the only failures pre-sync); the same 3 suites pass on clean origin/main.
- rp impl-review: **SHIP**, 0 introduced / 0 pre-existing findings.

## Version note

No version bump — staged under `## Unreleased` per batched-release policy; patch release cut after merge.

Closes #95

https://claude.ai/code/session_01Nf4VJPxURPsL54nUXaVTHy