### PR TITLE
fix(flow-next): drop top-level description key from Codex hooks.json mirror (#198)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the flow-next.
 
+## [flow-next 2.7.1] - 2026-07-05
+
+### Fixed
+
+- **Codex hooks config parsed cleanly again — Ralph guards were silently disabled** (GH #198) — the generated Codex mirror `codex/hooks.json` (installed to `~/.codex/hooks.json` by `install-codex.sh`) carried a top-level `"description"` key. Codex's hooks parser (feature `stable` since Codex 0.142.x) accepts only `"hooks"` at the top level and hard-errors on any sibling key (`unknown field 'description', expected 'hooks'`), printing a warning on every invocation and ignoring the Ralph guard hooks entirely. `sync-codex.sh` no longer emits the key into the mirror (reproduced + verified clean against Codex CLI 0.142.5). The canonical `plugins/flow-next/hooks/hooks.json` keeps its `description` — that key is officially documented for Claude Code plugin hooks files; this is exactly the canonical-vs-mirror rewrite `sync-codex.sh` exists for. **Codex users: re-run `scripts/install-codex.sh` to replace the broken `~/.codex/hooks.json`.** Thanks to @TechupBusiness for the report and root-cause analysis (#198).
+
 ## [flow-next 2.7.0] - 2026-07-04
 
 Fleet-wide capability & efficiency release: two adversarial-review passes (fn-87, fn-88) over the skill/agent fleet plus the fn-84 prose work — one new feature, broad correctness/safety fixes, progressive-disclosure efficiency, and seven A/B-verified model downgrades. No breaking changes.

--- a/plugins/flow-next/codex/hooks.json
+++ b/plugins/flow-next/codex/hooks.json
@@ -1,5 +1,4 @@
 {
-  "description": "Ralph workflow guards for Codex - only active when FLOW_RALPH=1 and ralph-init has been run",
   "hooks": {
     "PreToolUse": [
       {

--- a/scripts/sync-codex.sh
+++ b/scripts/sync-codex.sh
@@ -1491,6 +1491,9 @@ echo -e "${BLUE}Generating hooks.json...${NC}"
 # Build Codex hooks from canonical source:
 # - Keep: PreToolUse (Bash only), PostToolUse (Bash only), Stop
 # - Drop: SubagentStop, Edit/Write matchers
+# - Drop: top-level "description" — Codex's hooks parser rejects unknown fields
+#   (`unknown field \`description\`, expected \`hooks\``), which silently disables
+#   all hooks (issue #198)
 # - Invoke via the bash wrapper (`bash scripts/ralph/hooks/ralph-guard`), same as
 #   canonical: the wrapper sources pick-python.sh and runs the guard through a
 #   probed interpreter, so a Windows Store `python3` stub (exits 9009) is skipped
@@ -1499,7 +1502,6 @@ echo -e "${BLUE}Generating hooks.json...${NC}"
 #   ran ralph-init before the wrapper existed; no-op when neither is present.
 cat > "$CODEX_DIR/hooks.json" << 'HOOKS_EOF'
 {
-  "description": "Ralph workflow guards for Codex - only active when FLOW_RALPH=1 and ralph-init has been run",
   "hooks": {
     "PreToolUse": [
       {


### PR DESCRIPTION
Fixes #198.

## Summary

The generated Codex mirror `plugins/flow-next/codex/hooks.json` (installed to `~/.codex/hooks.json` by `install-codex.sh`) carried a top-level `"description"` key. Codex's hooks parser (feature `stable` since 0.142.x) accepts only `"hooks"` at the top level and hard-errors on any sibling key:

```
warning: failed to parse hooks config ~/.codex/hooks.json: unknown field `description`, expected `hooks` at line 2 column 15
```

— printed on every Codex invocation, with the Ralph guard hooks silently ignored.

## What changed

- `scripts/sync-codex.sh` — the hooks.json heredoc no longer emits the top-level `description`; comment block documents why (parser rejects unknown fields, issue #198).
- `plugins/flow-next/codex/hooks.json` — regenerated via `scripts/sync-codex.sh`.
- `CHANGELOG.md` — `[flow-next 2.7.1]` entry (incl. "re-run `scripts/install-codex.sh`" note for affected users).

## Not in this PR (by design)

- The canonical `plugins/flow-next/hooks/hooks.json` keeps its `description` — that key is officially documented for Claude Code plugin hooks files (https://code.claude.com/docs/en/hooks.md shows it in the plugin hooks example). Stripping platform-incompatible shape in the mirror is exactly what `sync-codex.sh` exists for (canonical-vs-mirror rule in CLAUDE.md).
- No installer-side normalization of an existing broken `~/.codex/hooks.json` — `install-codex.sh` overwrites it verbatim on re-run, so re-running the installer is the fix.

## Verification

- Reproduced against Codex CLI 0.142.5 with an isolated `CODEX_HOME`: old mirror → `unknown field 'description'` warning; regenerated mirror → clean parse, warning count 0.
- `jq empty` passes on both canonical and mirror hooks.json.
- `scripts/sync-codex.sh` full validation suite passes (29 skills, 21 agents, hooks.json).
- `plugins/flow-next/scripts/smoke_test.sh`: 139/139 pass.
- `python3 -m unittest discover -s tests`: 1425 tests OK (2 skipped).

## Version note

Ships as patch release **2.7.1** (bump + tag after merge, per `agent_docs/releasing.md`).

https://claude.ai/code/session_01H7QdQjUmVUDNFmPUVB1jfc