### PR TITLE
fix: post-fn-111/119 review findings (silent 0-test guard, resurrected hooks-normalize tests, TUI alias migration)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the flow-next.
 
 ## [Unreleased]
 
+### Fixed
+
+- **fn-111/fn-119 follow-ups (PR-review findings).** The parallel runner fails loudly on files where unittest discovers zero tests (rc-0 no-op guard); `test_codex_hooks_normalize.py` converted from pytest-style module functions to unittest (its 10 tests had silently never run in CI); the bundled TUI migrated off the removed epic aliases (`specs --json`, `--spec` flags, boundary mapping of the canonical `spec` wire key).
+
 ### Removed
 
 - **flowctl dead-surface sweep (fn-111).** ~2.7k LOC of zero-caller CLI surface removed across three cuts, plus docs drift corrected. Dual-copy flowctl mirrored. No version bump (batched).

--- a/flow-next-tui/src/lib/flowctl.test.ts
+++ b/flow-next-tui/src/lib/flowctl.test.ts
@@ -110,12 +110,12 @@ describe('isFlowctlAvailable', () => {
 describe('flowctl', () => {
   it('parses JSON output from flowctl command', async () => {
     if (!canRunFlowctlJson) return;
-    const result = await flowctl<{ success: boolean; epics: unknown[] }>([
-      'epics',
+    const result = await flowctl<{ success: boolean; specs: unknown[] }>([
+      'specs',
       '--json',
     ]);
     expect(result).toHaveProperty('success');
-    expect(result).toHaveProperty('epics');
+    expect(result).toHaveProperty('specs');
   });
 });
 

--- a/flow-next-tui/src/lib/flowctl.ts
+++ b/flow-next-tui/src/lib/flowctl.ts
@@ -338,20 +338,21 @@ function assertSuccess<T extends { success: boolean; error?: string }>(
  * Get all epics (list items with counts)
  */
 export async function getEpics(): Promise<EpicListItem[]> {
-  const args = ['epics', '--json'];
+  const args = ['specs', '--json'];
   const { result, cmd } = await flowctlWithCmd<EpicsResponse>(args);
   assertSuccess(result, cmd, args);
-  return result.epics;
+  return result.specs;
 }
 
 /**
  * Get tasks for an epic
  */
 export async function getTasks(epicId: string): Promise<TaskListItem[]> {
-  const args = ['tasks', '--epic', epicId, '--json'];
+  const args = ['tasks', '--spec', epicId, '--json'];
   const { result, cmd } = await flowctlWithCmd<TasksResponse>(args);
   assertSuccess(result, cmd, args);
-  return result.tasks;
+  // fn-111: wire is canonical `spec`; TUI internals still use `epic` naming.
+  return result.tasks.map((t) => ({ ...t, epic: (t as { spec?: string }).spec ?? t.epic }));
 }
 
 /**
@@ -375,7 +376,7 @@ export async function getTaskSpec(taskId: string): Promise<string> {
  * Get ready/in_progress/blocked tasks for an epic
  */
 export async function getReadyTasks(epicId: string): Promise<ReadyResponse> {
-  const args = ['ready', '--epic', epicId, '--json'];
+  const args = ['ready', '--spec', epicId, '--json'];
   const { result, cmd } = await flowctlWithCmd<ReadyResponse>(args);
   assertSuccess(result, cmd, args);
   return result;
@@ -400,7 +401,9 @@ export async function getTask(taskId: string): Promise<Task> {
   const { result, cmd } = await flowctlWithCmd<TaskShowResponse>(args);
   assertSuccess(result, cmd, args);
   const { success: _, ...task } = result;
-  return task as Task;
+  // fn-111: wire is canonical `spec`; TUI internals still use `epic` naming.
+  const spec = (task as { spec?: string }).spec;
+  return { ...task, epic: spec ?? (task as { epic?: string }).epic } as Task;
 }
 
 /**

--- a/flow-next-tui/src/lib/types.ts
+++ b/flow-next-tui/src/lib/types.ts
@@ -83,7 +83,7 @@ export interface TasksResponse {
 }
 
 /**
- * Epic list item as returned by flowctl epics --json
+ * Spec list item as returned by flowctl specs --json (fn-111: epics alias removed)
  * (minimal fields for listing)
  */
 export interface EpicListItem {
@@ -95,11 +95,11 @@ export interface EpicListItem {
 }
 
 /**
- * Response from flowctl epics command
+ * Response from flowctl specs command
  */
 export interface EpicsResponse {
   success: boolean;
-  epics: EpicListItem[];
+  specs: EpicListItem[];
   count: number;
 }
 

--- a/plugins/flow-next/tests/test_codex_hooks_normalize.py
+++ b/plugins/flow-next/tests/test_codex_hooks_normalize.py
@@ -9,6 +9,8 @@ one `hooks = true` under [features] and no `codex_hooks`, idempotently.
 import importlib.util
 import subprocess
 import sys
+import tempfile
+import unittest
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
@@ -51,80 +53,91 @@ def _assert_normal(text: str):
     assert data.get("features", {}).get("hooks") is True
 
 
-def test_both_keys_dedup_to_one():
-    """The exact bug: both codex_hooks and hooks present -> single hooks."""
-    src = (
-        'model = "gpt-5"\n'
-        "[features]\n"
-        "codex_hooks = true  # flow-next\n"
-        "hooks = true\n"
-        "shell_tool = true\n"
-        "[agents]\n"
-        "max_threads = 12\n"
-    )
-    out = normalize(src)
-    _assert_normal(out)
-    # Content outside [features] preserved.
-    assert 'model = "gpt-5"' in out
-    assert "shell_tool = true" in out
-    assert "[agents]" in out and "max_threads = 12" in out
+# unittest-style (fn-111 follow-up): module-level pytest functions were
+# invisible to unittest discover - these tests silently never ran in CI.
+class TestCodexHooksNormalize(unittest.TestCase):
+    def test_both_keys_dedup_to_one(self):
+        """The exact bug: both codex_hooks and hooks present -> single hooks."""
+        src = (
+            'model = "gpt-5"\n'
+            "[features]\n"
+            "codex_hooks = true  # flow-next\n"
+            "hooks = true\n"
+            "shell_tool = true\n"
+            "[agents]\n"
+            "max_threads = 12\n"
+        )
+        out = normalize(src)
+        _assert_normal(out)
+        # Content outside [features] preserved.
+        assert 'model = "gpt-5"' in out
+        assert "shell_tool = true" in out
+        assert "[agents]" in out and "max_threads = 12" in out
 
 
-def test_only_deprecated_key_migrates():
-    src = "[features]\ncodex_hooks = true  # flow-next\nshell_tool = true\n"
-    out = normalize(src)
-    _assert_normal(out)
+    def test_only_deprecated_key_migrates(self):
+        src = "[features]\ncodex_hooks = true  # flow-next\nshell_tool = true\n"
+        out = normalize(src)
+        _assert_normal(out)
 
 
-def test_only_modern_key_is_noop_shape():
-    src = "[features]\nhooks = true\nshell_tool = true\n"
-    out = normalize(src)
-    _assert_normal(out)
+    def test_only_modern_key_is_noop_shape(self):
+        src = "[features]\nhooks = true\nshell_tool = true\n"
+        out = normalize(src)
+        _assert_normal(out)
 
 
-def test_features_without_hooks_gets_one():
-    src = "[features]\nshell_tool = true\n"
-    out = normalize(src)
-    _assert_normal(out)
+    def test_features_without_hooks_gets_one(self):
+        src = "[features]\nshell_tool = true\n"
+        out = normalize(src)
+        _assert_normal(out)
 
 
-def test_no_features_section_appended():
-    src = 'model = "gpt-5"\n[agents]\nmax_threads = 4\n'
-    out = normalize(src)
-    _assert_normal(out)
-    assert 'model = "gpt-5"' in out
-    assert "[agents]" in out
+    def test_no_features_section_appended(self):
+        src = 'model = "gpt-5"\n[agents]\nmax_threads = 4\n'
+        out = normalize(src)
+        _assert_normal(out)
+        assert 'model = "gpt-5"' in out
+        assert "[agents]" in out
 
 
-def test_multiple_duplicate_hooks_collapse():
-    src = "[features]\nhooks = true\nhooks = true\ncodex_hooks = true\nshell_tool = true\n"
-    out = normalize(src)
-    _assert_normal(out)
+    def test_multiple_duplicate_hooks_collapse(self):
+        src = "[features]\nhooks = true\nhooks = true\ncodex_hooks = true\nshell_tool = true\n"
+        out = normalize(src)
+        _assert_normal(out)
 
 
-def test_idempotent():
-    src = "[features]\ncodex_hooks = true\nhooks = true\n"
-    once = normalize(src)
-    twice = normalize(once)
-    assert once == twice
-    _assert_normal(twice)
+    def test_idempotent(self):
+        src = "[features]\ncodex_hooks = true\nhooks = true\n"
+        once = normalize(src)
+        twice = normalize(once)
+        assert once == twice
+        _assert_normal(twice)
 
 
-def test_empty_file_gets_features():
-    out = normalize("")
-    _assert_normal(out)
+    def test_empty_file_gets_features(self):
+        out = normalize("")
+        _assert_normal(out)
 
 
-def test_cli_writes_in_place(tmp_path):
-    cfg = tmp_path / "config.toml"
-    cfg.write_text("[features]\ncodex_hooks = true  # flow-next\nhooks = true\n")
-    rc = subprocess.run(
-        [sys.executable, str(SCRIPT), str(cfg)], capture_output=True
-    ).returncode
-    assert rc == 0
-    _assert_normal(cfg.read_text())
+    def test_cli_writes_in_place(self):
+        with tempfile.TemporaryDirectory() as td:
+            self._cli_writes_in_place(Path(td))
+
+    def _cli_writes_in_place(self, tmp_path: Path) -> None:
+        cfg = tmp_path / "config.toml"
+        cfg.write_text("[features]\ncodex_hooks = true  # flow-next\nhooks = true\n")
+        rc = subprocess.run(
+            [sys.executable, str(SCRIPT), str(cfg)], capture_output=True
+        ).returncode
+        assert rc == 0
+        _assert_normal(cfg.read_text())
 
 
-def test_cli_missing_arg_exit_2():
-    rc = subprocess.run([sys.executable, str(SCRIPT)], capture_output=True).returncode
-    assert rc == 2
+    def test_cli_missing_arg_exit_2(self):
+        rc = subprocess.run([sys.executable, str(SCRIPT)], capture_output=True).returncode
+        assert rc == 2
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/run_tests_parallel.py
+++ b/scripts/run_tests_parallel.py
@@ -57,7 +57,9 @@ class FileResult:
 
     @property
     def ok(self) -> bool:
-        return self.returncode == 0
+        # ran == 0 with a zero exit is a silent no-op file (e.g. pytest-style
+        # module-level functions unittest cannot discover) - fail it loudly.
+        return self.returncode == 0 and self.ran > 0
 
 
 def _default_jobs() -> int:
@@ -157,6 +159,10 @@ def _format_status(result: FileResult) -> str:
             ran=result.ran,
             extra=extra,
             elapsed=result.elapsed_s,
+        )
+    if result.returncode == 0 and result.ran == 0:
+        return "FAIL  {name}  rc=0 ran=0 (no tests discovered - unittest cannot see pytest-style module functions)  {elapsed:.2f}s".format(
+            name=result.path.name, elapsed=result.elapsed_s
         )
     return "FAIL  {name}  rc={rc} ran={ran} failures={f} errors={e}  {elapsed:.2f}s".format(
         name=result.path.name,


### PR DESCRIPTION
## Summary

Post-merge fixes for the two bot-review findings on #219 and #220 (both verified real in substance, merged past during the fast-track lands), plus the guard that prevents the class.

## What changed

- **Runner `ran==0` guard** (`scripts/run_tests_parallel.py`): a file where unittest discovers zero tests now FAILS loudly (`rc=0 ran=0 (no tests discovered ...)`) instead of passing silently. This is the generic fix for the #219 finding.
- **`test_codex_hooks_normalize.py` converted to unittest**: its 10 module-level pytest-style test functions were invisible to `unittest discover` - they had silently never run in any CI. All 10 now run and pass.
- **TUI migrated off removed epic aliases** (the #220 finding - a live caller the fn-101 audit missed): `flow-next-tui/src/lib/flowctl.ts` now calls `specs --json` / `tasks --spec` / `ready --spec` and maps the canonical `spec` wire key to the TUI's internal `epic` field naming at the boundary; raw-wire test updated.

## Verification

- Full parallel suite: 83 files, **1825 tests** (the 10 resurrected ones included), 0 failures, 81.6s.
- TUI: `tsc --noEmit` clean, `bun test` 382/382.
- Guard proven: pre-conversion the runner now fails `test_codex_hooks_normalize.py`; post-conversion it passes with `ran=10`.

## Version note

No version bump - rides `## [Unreleased]` with the fn-111 sweep (batched release per CLAUDE.md).
