### PR TITLE
Grok Build host fidelity: GROK_AGENT detection + host profile (fn-126)

### DIFF
--- a/.flow/tasks/fn-126-grok-build-host-fidelity-positive.1.md
+++ b/.flow/tasks/fn-126-grok-build-host-fidelity-positive.1.md
@@ -16,9 +16,8 @@ Setup: add the positive Grok detection rung + the Grok host profile. In plugins/
 - Full-profile assertion matrix (not detection-only) locks manifest/copy-mode/snippet-family+target/no-.codex-agents/review-menu/routing-target/Ralph-handling/Step-8-summary for platform=grok.
 - NEEDS-HUMAN smoke: standalone grok session -> `/flow-next:setup` reports platform=grok, slash snippet to CLAUDE.md, no `.codex/agents`, Ralph not offered.
 ## Done summary
-TBD
-
+GROK_AGENT detection rung added after Droid/Claude/Cursor, before else->codex, with evidence-backed rationale (probe: GROK_AGENT=1 set by grok; ~/.grok + PATH rejected non-signals) + Droid-nesting known-edge + matrix cases 5/6/7. Grok profile wired through every PLATFORM consumer: slash snippet, CLAUDE.md lifecycle + AGENTS.md routing target, copy mode, .flow/bin/flowctl, no .codex/agents, no Ralph (CONVERT-recommend list), review menu with host (fail-closed caveat), host-native model-routing scaffold extended to platform=grok. Grok row added to host-review dispatch in plan-review/impl-review/spec-completion-review. Implemented by grok-4.5 high (1 pass); reviewed by session model. sync-codex twice-idempotent; test_setup_cursor_host/snippet-lockstep/model-routing green. NEEDS-HUMAN smokes deferred to T3/standalone-grok.
 ## Evidence
-- Commits:
-- Tests:
+- Commits: 33b71791
+- Tests: cd plugins/flow-next/tests && python3 -m unittest test_setup_cursor_host test_setup_snippet_lockstep test_model_routing_scaffold -q
 - PRs:

--- a/.flow/tasks/fn-126-grok-build-host-fidelity-positive.2.md
+++ b/.flow/tasks/fn-126-grok-build-host-fidelity-positive.2.md
@@ -12,9 +12,8 @@ Testability + Codex mirror. Add an EXECUTABLE detection test (plugins/flow-next/
 - `./scripts/sync-codex.sh` twice-idempotent (byte-identical 2nd pass).
 - Focused suites green: `cd plugins/flow-next/tests && python3 -m unittest test_setup_grok_host test_setup_cursor_host -q`.
 ## Done summary
-TBD
-
+Executable detection test (test_setup_grok_host.py): extracts the Step-0 bash fence (one-match assert), runs it via subprocess under fake envs - GROK_AGENT=1->grok; +higher signal->higher host wins; plain->codex; no droid/claude/cursor/codex regression. 32 tests green w/ cursor-host. Codex mirror Step-0 flattened to UNCONDITIONAL PLATFORM=codex (mirror consumed only by Codex); sync-codex.sh new hard-fail guard asserts no host-detection branches in the mirror fence; twice-idempotent byte-identical. grok-4.5 high (1 pass); reviewed by session model (note: mirror still carries dead cascade RATIONALE prose below the fence - flagged for impl-review, non-executable/cosmetic).
 ## Evidence
-- Commits:
-- Tests:
+- Commits: a7596038
+- Tests: cd plugins/flow-next/tests && python3 -m unittest test_setup_grok_host test_setup_cursor_host -q
 - PRs:

--- a/.flow/tasks/fn-126-grok-build-host-fidelity-positive.3.md
+++ b/.flow/tasks/fn-126-grok-build-host-fidelity-positive.3.md
@@ -14,9 +14,8 @@ Downstream + command-discovery validation + release staging. Docs: plugins/flow-
 
 
 ## Done summary
-TBD
-
+platforms.md Grok section: GROK_AGENT detection signal table, instruction-file probe (loads BOTH CLAUDE.md+AGENTS.md), slash syntax, copy mode, host review + single-family fail-closed note, no-Ralph (intentional), Droid-nesting NEEDS-HUMAN edge; stale codex-fallback claims corrected. CHANGELOG Unreleased fn-126 entry (plain hyphens, no bump). flow-next.dev: 6 existing pages updated (install/introduction/changelog/review-workflow/setup/architecture) + customer-register Unreleased entry, pnpm build green, committed separately (8561874). Command-discovery expected-fixed by fn-124 (3.3.1), live grok validation = NEEDS-HUMAN (recorded, not claimed). Vault Platforms note = release-time downstream (deferred to fn-126 release walk). grok-4.5 high (2 passes); reviewed by session model; no em dashes.
 ## Evidence
-- Commits:
-- Tests:
+- Commits: 8872b744
+- Tests: cd plugins/flow-next/tests && python3 -m unittest test_cursor_docs_contract -q, cd ~/work/flow-next.dev && pnpm build
 - PRs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the flow-next.
 
 ## [Unreleased]
 
+### Added
+
+- **Grok Build host detection + profile (fn-126).** `/flow-next:setup` detects Grok via positive `GROK_AGENT=1` (probe-verified; `~/.grok` and PATH are not signals), ordered after Droid/Claude/Cursor and before the `else → codex` fallback. Profile: copy mode, `.flow/bin/flowctl`, `/flow-next:` slash syntax (not Codex `$flow-next-`), lifecycle docs default to CLAUDE.md, model-routing scaffold to AGENTS.md (Grok loads both), review menu includes `host` with single-native-family fail-closed (`grok-4.5` only - cross-family via bridges), no Ralph (intentional, same posture as Cursor), no `.codex/agents` copy. Nested Droid→Grok is unsupported if `DROID_PLUGIN_ROOT` propagates. Docs: `platforms.md` Grok section. No version bump (batched).
+
 ## [flow-next 3.3.3] - 2026-07-22
 
 ### Fixed

--- a/plugins/flow-next/codex/skills/flow-next-impl-review/SKILL.md
+++ b/plugins/flow-next/codex/skills/flow-next-impl-review/SKILL.md
@@ -94,9 +94,13 @@ When `RP_ELIGIBLE=0`, omit the **rp** line below from any guidance you surface (
 3. Model resolved via (first match wins): `--spec cursor:<model>` flag, per-task `review`, `FLOW_REVIEW_BACKEND` spec, `FLOW_CURSOR_MODEL` env var, registry default (`gpt-5.5-high`). **No effort** — Cursor bakes effort into the model name; `cursor:<model>:<effort>` is rejected
 4. Parse verdict from command output
 
-**For host backend (fn-123 R5):**
+**For host backend (fn-123 R5 / fn-126):**
 1. **DO NOT REVIEW CODE YOURSELF** — you coordinate; a fresh-context host-native subagent reviews (see [workflow-host.md](workflow-host.md))
-2. Dispatch a **read-only** reviewer subagent pinned to a **cross-family** model slug from AGENTS.md model-routing (Claude Code: native `model` param; Cursor: in-prompt slug pin; elsewhere: generic fresh-context reviewer with host-dependent note)
+2. Dispatch a **read-only** reviewer subagent pinned to a **cross-family** model slug from AGENTS.md model-routing:
+ - **Claude Code**: native `model` param + tool-enforced read-only
+ - **Cursor**: in-prompt slug pin + tool-enforced read-only
+ - **Grok**: in-prompt / host model pin + tool-enforced read-only; single-native-family (`grok-4.5`) fails closed unless the writer is non-Grok (cross-family via bridges); receipt `mode: "host"` + actual model + `session_id: null`
+ - **Elsewhere**: generic fresh-context reviewer with host-dependent note
 3. Record actual reviewer model + `"mode": "host"` in the receipt
 4. **Every re-review is a fresh subagent** — no context reuse, no fabricated resume ids
 5. **Fail closed on missing cross-family pin:** interactive → ask user explicitly; autonomous → `NEEDS_HUMAN` (never silent same-family self-review)

--- a/plugins/flow-next/codex/skills/flow-next-impl-review/workflow-host.md
+++ b/plugins/flow-next/codex/skills/flow-next-impl-review/workflow-host.md
@@ -30,6 +30,7 @@ Dispatch a **fresh** read-only reviewer subagent with the resolved pin:
 |------|------------|
 | Claude Code | Native subagent `model` param (existing reviewer-subagent arrangement); `disallowedTools: Edit, Write, Task` (or host read-only equivalent) |
 | Cursor | In-prompt slug pin on the subagent + TOOL-enforced read-only (dispatch via a `readonly: true` agent definition or Cursor's read-only subagent mode — never a mutation-capable subagent; the reviewer reads untrusted diff content, so read-only cannot be prompt-requested only) |
+| Grok | In-prompt / host model pin from AGENTS.md model-routing + TOOL-enforced read-only (never mutation-capable). Single-native-family (`grok-4.5`) — host review fails closed unless the writer is non-Grok; cross-family via bridge backends. Receipt: `mode: "host"`, actual reviewer model, `session_id: null` (same shape as Claude/Cursor) |
 | Codex | Fresh read-only reviewer subagent via the platform subagent primitive (`spawn_agent` on Codex) with the cross-family pin stated in the prompt; read-only via the platform sandbox |
 | Other | Generic fresh-context reviewer; note in the receipt that pin enforcement is host-dependent |
 

--- a/plugins/flow-next/codex/skills/flow-next-plan-review/SKILL.md
+++ b/plugins/flow-next/codex/skills/flow-next-plan-review/SKILL.md
@@ -122,11 +122,12 @@ When `RP_ELIGIBLE=0`, omit the **rp** line below from any guidance you surface (
 3. Model resolved via (first match wins): `--spec cursor:<model>` flag, per-spec `default_review`, `FLOW_REVIEW_BACKEND` spec, `FLOW_CURSOR_MODEL` env var, registry default (`gpt-5.5-high`). **No effort** — Cursor bakes effort into the model name; `cursor:<model>:<effort>` is rejected
 4. Parse verdict from command output
 
-**For host backend (fn-123 R5):**
+**For host backend (fn-123 R5 / fn-126):**
 1. **DO NOT REVIEW THE PLAN YOURSELF** — you coordinate; a fresh-context host-native subagent reviews
 2. Dispatch a **read-only** reviewer subagent pinned to a **cross-family** model slug (family that did not write the plan) from the AGENTS.md model-routing section:
- - **Claude Code**: native subagent `model` param (existing reviewer-subagent arrangement)
- - **Cursor**: in-prompt slug pin on the subagent (host honors Cursor slugs)
+ - **Claude Code**: native subagent `model` param (existing reviewer-subagent arrangement); `disallowedTools: Edit, Write, Task` (or host equivalent read-only)
+ - **Cursor**: in-prompt slug pin on the subagent (host honors Cursor slugs) AND tool-enforced read-only
+ - **Grok**: in-prompt / host model pin from AGENTS.md model-routing + tool-enforced read-only (Grok is single-native-family `grok-4.5` — host review fails closed unless the writer is non-Grok; cross-family via bridge backends). Receipt semantics identical to Claude/Cursor (`mode: "host"`, actual reviewer model, `session_id: null`)
  - **Other hosts**: generic fresh-context reviewer with an explicit note that the pin is best-effort / host-dependent
 3. Reuse the existing plan-review rubrics + prior-finding convergence context (same verdict grammar as other backends)
 4. Write receipt with actual reviewer model + `"mode": "host"` (shape compatible with existing convergence/cap/pilot/land consumers)
@@ -182,6 +183,7 @@ When `BACKEND="host"`, do **not** call any `flowctl <backend> plan-review` — t
 3. **Dispatch** a fresh read-only reviewer subagent with the pin:
  - Claude Code: `Task` / subagent with `model: <cross-family-slug>`, `disallowedTools: Edit, Write, Task` (or host equivalent read-only)
  - Cursor: subagent with the slug stated in the prompt (Cursor honors in-prompt model pins) AND `readonly: true` enforcement — dispatch via a read-only agent definition (the fn-123 R4 `readonly: true` agents) or Cursor's read-only subagent mode; never a mutation-capable subagent. The reviewer analyzes untrusted diff content — read-only must be TOOL-enforced, not prompt-requested
+ - Grok: subagent / fresh-context reviewer with the AGENTS.md pin stated in the prompt AND tool-enforced read-only (never mutation-capable). Grok is single-native-family (`grok-4.5`) — if the pin is same-family as the writer, fail closed (interactive ask / autonomous NEEDS_HUMAN); cross-family review on Grok prefers bridge backends. Receipt: `mode: "host"`, actual reviewer model, `session_id: null`
  - Codex: fresh read-only reviewer via the platform subagent primitive (`spawn_agent`) with the pin stated in the prompt; read-only via the platform sandbox
  - Elsewhere: fresh-context reviewer; note in the receipt that pin enforcement is host-dependent
 4. Give the subagent the plan-review rubric ([references/plan-review-prompt.md](references/plan-review-prompt.md)), the spec content, and any prior findings for convergence. Require the same verdict tags (`SHIP` / `NEEDS_WORK` / `MAJOR_RETHINK`).

--- a/plugins/flow-next/codex/skills/flow-next-setup/workflow.md
+++ b/plugins/flow-next/codex/skills/flow-next-setup/workflow.md
@@ -15,30 +15,10 @@ Store this as `PLUGIN_ROOT` for use in later steps.
 Detect which platform is running:
 
 ```bash
-# Positive Cursor install signal: resolved PLUGIN_ROOT lives under ~/.cursor/
-# (local install-cursor.sh OR team-marketplace repo-import cache). Do NOT key
-# on codex/ absence — marketplace whole-repo imports contain codex/ and still
-# classify as cursor. Codex installs resolve under $CODEX_HOME (~/.codex) and
-# the shared source tree resolves to a workspace path; neither matches.
-PLUGIN_ROOT_ABS="$(cd "${PLUGIN_ROOT}" 2>/dev/null && pwd -P || printf '%s' "${PLUGIN_ROOT}")"
-CURSOR_HOME_ABS="$(cd "${HOME}/.cursor" 2>/dev/null && pwd -P || printf '%s' "${HOME}/.cursor")"
-
-if [ -n "${DROID_PLUGIN_ROOT:-}" ]; then
- PLATFORM="droid"
-elif [ -n "${CLAUDE_PLUGIN_ROOT:-}" ]; then
- PLATFORM="claude-code"
-elif [ -n "${CURSOR_AGENT:-}" ] \
- && [ -f "${PLUGIN_ROOT}/.cursor-plugin/plugin.json" ] \
- && case "${PLUGIN_ROOT_ABS}" in \
- "${CURSOR_HOME_ABS}"|"${CURSOR_HOME_ABS}"/*) true ;; \
- *) false ;; \
- esac; then
- PLATFORM="cursor"
-elif [ -n "${GROK_AGENT:-}" ]; then
- PLATFORM="grok"
-else
- PLATFORM="codex"
-fi
+# Codex mirror: this workflow is consumed only by Codex.
+# Host detection is irrelevant — always PLATFORM=codex
+# (canonical Claude-format hosts never read this mirror).
+PLATFORM="codex"
 ```
 
 **Cursor ordering matters.** Cursor exposes **no** plugin-root env var, so without the `CURSOR_AGENT` check it would fall through to the `codex` branch and get Codex-shaped project instructions (`$flow-next-plan` command names + `.codex/` setup) — wrong, because a Cursor install (local or team-marketplace) drives the workflow with `/flow-next:*` slash commands and resolves `flowctl` via `.flow/bin/flowctl`. `CURSOR_AGENT` is Cursor's own signal (set in its agent shell; it also sets `CI=1` / `CURSOR_TRACE_ID`, but `CURSOR_AGENT` is the canonical one). The `CURSOR_AGENT` branch MUST come before the `else → codex` fallback.

--- a/plugins/flow-next/codex/skills/flow-next-setup/workflow.md
+++ b/plugins/flow-next/codex/skills/flow-next-setup/workflow.md
@@ -34,6 +34,8 @@ elif [ -n "${CURSOR_AGENT:-}" ] \
  *) false ;; \
  esac; then
  PLATFORM="cursor"
+elif [ -n "${GROK_AGENT:-}" ]; then
+ PLATFORM="grok"
 else
  PLATFORM="codex"
 fi
@@ -45,13 +47,17 @@ fi
 
 **Positive path discriminator — `PLUGIN_ROOT` under `~/.cursor/` (never `codex/` absence).** The manifest + env checks alone are not enough when Codex runs from the **checked-in plugin source** inside a Cursor shell (Codex marketplace points at `./plugins/flow-next`, which carries `.cursor-plugin/`, `.codex-plugin/`, and the `codex/` mirror) — there the Cursor manifest is present in the workspace tree, so env+manifest would misfire. The positive signal is that a **real Cursor install** resolves `PLUGIN_ROOT` under `~/.cursor/` — local `install-cursor.sh`/`.ps1` → `~/.cursor/plugins/local/flow-next/`; team-marketplace repo-import → Cursor's marketplace plugin cache under `~/.cursor/` (and that cache **may contain `codex/`** because the whole plugin source is imported; explicit component paths in `.cursor-plugin/plugin.json` keep Cursor from loading the mirror as skills). A genuine Codex install resolves under `$CODEX_HOME` (default `~/.codex`); the shared source tree resolves to a workspace path. Neither is under `~/.cursor/`, so both correctly fall through to `codex` even with inherited `CURSOR_AGENT`. **Do not** key detection on the `codex/` directory being absent — that misclassifies marketplace repo-imports as Codex.
 
-**Matrix (detection fixtures):** (1) marketplace whole-repo import under `~/.cursor/` + may have `codex/` → `cursor`; (2) local `install-cursor` under `~/.cursor/plugins/local/` (no `codex/`) → `cursor`; (3) Codex under `$CODEX_HOME` / `~/.codex` with inherited `CURSOR_AGENT` → `codex`; (4) Claude (`CLAUDE_PLUGIN_ROOT`) / Droid (`DROID_PLUGIN_ROOT`) still win first — precedence unchanged.
+**Grok ordering matters (fn-126).** Grok Build (xAI's `grok` CLI) reads the canonical Claude plugin format AS-IS and drives with `/flow-next-*` / `/flow-next:` slash commands — not the Codex `$flow-next-` mirror. Without a positive signal it fell through to `else → codex` and setup wrote Codex-shaped `$flow-next-` snippets into AGENTS.md (dogfood 2026-07-22). **Probe-verified signal:** `GROK_AGENT=1` is set BY grok in its agent shell (absent from a plain-shell control on the same machine). **Rejected non-signals:** `~/.grok/` exists on the machine regardless (install dir), and `~/.grok/bin` on `PATH` is profile-level — neither distinguishes a grok session. The `GROK_AGENT` branch MUST come after Droid / Claude / Cursor (so a real Claude/Cursor/Droid host that merely inherited `GROK_AGENT` from a parent grok shell still classifies by its own higher-precedence signal) and BEFORE the `else → codex` fallback.
+
+**Known nesting edge (Droid → Grok) — NEEDS-HUMAN.** The probe disproved `CLAUDE_PLUGIN_ROOT` propagation into a grok child, so Claude-from-parent does not misfire. It did **not** disprove `DROID_PLUGIN_ROOT` propagation: if a grok child inherits `DROID_PLUGIN_ROOT` from a Droid parent shell, the cascade classifies as `droid` (higher precedence). Treat nested Droid→Grok as **unsupported pending a this-process-is-grok discriminator** unless a NEEDS-HUMAN smoke confirms `DROID_PLUGIN_ROOT` does not propagate. Claude/Cursor-from-grok remain correct via higher-precedence signals.
+
+**Matrix (detection fixtures):** (1) marketplace whole-repo import under `~/.cursor/` + may have `codex/` → `cursor`; (2) local `install-cursor` under `~/.cursor/plugins/local/` (no `codex/`) → `cursor`; (3) Codex under `$CODEX_HOME` / `~/.codex` with inherited `CURSOR_AGENT` → `codex`; (4) Claude (`CLAUDE_PLUGIN_ROOT`) / Droid (`DROID_PLUGIN_ROOT`) still win first — precedence unchanged; (5) standalone `GROK_AGENT=1` (no higher signal) → `grok`; (6) `GROK_AGENT=1` + `CLAUDE_PLUGIN_ROOT` / `CURSOR_AGENT`(+cursor install) / `DROID_PLUGIN_ROOT` → higher host wins; (7) plain shell (no host signal) → `codex`.
 
 Store `PLATFORM` for use in later steps. This determines:
 - Which manifest to read for version (`plugin.json`)
 - Which docs file to prefer (CLAUDE.md vs AGENTS.md)
 - Whether to copy Codex agents to project (hooks are **not** copied here — Ralph is opt-in via the Ralph question + `/flow-next:ralph-init`)
-- Which command-name syntax the docs snippet uses (`/flow-next:plan` for Claude Code / Droid / **Cursor**; `$flow-next-plan` for Codex)
+- Which command-name syntax the docs snippet uses (`/flow-next:plan` for Claude Code / Droid / **Cursor** / **Grok**; `$flow-next-plan` for Codex)
 
 ## Step 1: Initialize .flow/
 
@@ -77,6 +83,7 @@ Also read plugin version from the platform-specific manifest:
 - Claude Code: `${PLUGIN_ROOT}/.claude-plugin/plugin.json`
 - Factory Droid: `${PLUGIN_ROOT}/.claude-plugin/plugin.json` (Droid's interop layer reads the Claude Code manifest directly for Claude-first plugins like flow-next)
 - Cursor: `${PLUGIN_ROOT}/.cursor-plugin/plugin.json`
+- Grok: `${PLUGIN_ROOT}/.claude-plugin/plugin.json` (Grok reads the canonical Claude plugin format AS-IS — no separate Grok manifest)
 
 Check whichever matches `PLATFORM`. Fall back to `.claude-plugin/plugin.json` if the platform-specific file doesn't exist.
 
@@ -216,7 +223,7 @@ Then handle `.flow/usage.md` — preserve any repo-customized variant:
 
 ## Step 4b: Codex-specific project setup (PLATFORM=codex only)
 
-**Skip this step entirely if PLATFORM is not `codex`.** (Claude Code / Droid / Cursor all skip it — Cursor drives the workflow with `/flow-next:*` slash commands and resolves `flowctl` via `.flow/bin/flowctl`, not project-scoped `.codex/` agents.)
+**Skip this step entirely if PLATFORM is not `codex`.** (Claude Code / Droid / Cursor / Grok all skip it — Cursor and Grok drive the workflow with `/flow-next:*` slash commands and resolve `flowctl` via `.flow/bin/flowctl`, not project-scoped `.codex/` agents. Grok never copies `.codex/agents`.)
 
 On Codex, agents live in project-scoped `.codex/` directories (not in the plugin cache). Copy them. **Do not copy or enable Ralph hooks here** — hooks are opt-in via the Ralph question (Step 6d, always asked) and `/flow-next:ralph-init` registration prose.
 
@@ -265,11 +272,12 @@ HAVE_CURSOR=$(which cursor-agent >/dev/null 2>&1 && echo 1 || echo 0)
 HAVE_GROK=$(which grok >/dev/null 2>&1 && echo 1 || echo 0)
 
 # fn-97: at least one bridge CLI on PATH gates the Model Routing question in 6d
-# on non-Cursor hosts (with zero bridges every wiring route in the scaffold
+# on non-host-native hosts (with zero bridges every wiring route in the scaffold
 # would be an inert install-note comment, so the question is not offered —
 # install a bridge CLI and re-run /flow-next:setup to get it).
-# fn-123 R6: PLATFORM=cursor is the exception — host-native AGENTS.md pins need
-# no external bridge CLI, so Model Routing is still offered when ROUTING_ASK=1.
+# fn-123 R6 / fn-126: PLATFORM=cursor or PLATFORM=grok is the exception —
+# host-native AGENTS.md pins need no external bridge CLI, so Model Routing is
+# still offered when ROUTING_ASK=1.
 BRIDGE_DETECTED=0
 if [[ "$HAVE_CODEX" == "1" || "$HAVE_CURSOR" == "1" || "$HAVE_GROK" == "1" ]]; then
  BRIDGE_DETECTED=1
@@ -298,13 +306,13 @@ CURRENT_GITHUB_SCOUT=$("${PLUGIN_ROOT}/scripts/flowctl" config get scouts.github
 CURRENT_HTML_ARTIFACTS=$("${PLUGIN_ROOT}/scripts/flowctl" config get artifacts.html.enabled --raw --json 2>/dev/null | jq -r 'if .value == null then "" else (.value | tostring) end')
 
 # Optional model-routing scaffold ceremony (Step 6d question + Step 7 processing)
-# is offered ONLY in an interactive setup. On non-Cursor hosts also require a
-# bridge CLI (BRIDGE_DETECTED=1, fn-97). On PLATFORM=cursor offer when interactive
-# regardless of bridges (fn-123 R6 host-native pins). Under ANY non-interactive /
-# autonomous marker, the question is skipped SILENTLY — setup must never block a
-# headless driver. Scan the WHOLE autonomy-marker family (Ralph / receipt-path /
-# autonomous / mode token), not a fixed pair — the same family every lifecycle
-# skill honors.
+# is offered ONLY in an interactive setup. On non-host-native hosts also require a
+# bridge CLI (BRIDGE_DETECTED=1, fn-97). On PLATFORM=cursor or PLATFORM=grok offer
+# when interactive regardless of bridges (fn-123 R6 / fn-126 host-native pins).
+# Under ANY non-interactive / autonomous marker, the question is skipped SILENTLY
+# — setup must never block a headless driver. Scan the WHOLE autonomy-marker
+# family (Ralph / receipt-path / autonomous / mode token), not a fixed pair —
+# the same family every lifecycle skill honors.
 ROUTING_ASK=1
 if [[ "${FLOW_RALPH:-}" == "1" || -n "${REVIEW_RECEIPT_PATH:-}" \
  || "${FLOW_AUTONOMOUS:-}" == "1" || "${ARGUMENTS:-}" == *mode:autonomous* ]]; then
@@ -318,7 +326,7 @@ Store detection results for use in questions. When showing options, indicate cur
 
 Choose the correct template based on platform:
 - **Codex** (`PLATFORM=codex`): read [templates/agents-md-snippet.md](templates/agents-md-snippet.md) — uses `$flow-next-plan` syntax
-- **Claude Code / Droid / Cursor**: read [templates/claude-md-snippet.md](templates/claude-md-snippet.md) — uses `/flow-next:plan` syntax (Cursor runs the same slash commands; on Cursor the snippet lands in AGENTS.md, which Cursor reads)
+- **Claude Code (copy mode) / Droid / Cursor / Grok**: read [templates/claude-md-snippet.md](templates/claude-md-snippet.md) — uses `/flow-next:plan` slash syntax (Cursor runs the same slash commands; on Cursor the snippet lands in AGENTS.md. Grok drives with `/flow-next-` slash commands and reads BOTH CLAUDE.md and AGENTS.md — lifecycle snippet targets CLAUDE.md by default; a pre-existing wrong Codex `$flow-next-` marker block is consent-refreshed to the slash form, marker-scoped)
 
 For each of CLAUDE.md and AGENTS.md:
 1. Check if file exists
@@ -350,7 +358,7 @@ Only include lines for config values that are set. If no config is set, skip thi
 
 Build the prompt content (question text + numbered option list) dynamically. **Only include questions for config values that are NOT already set** — existing config is preserved, never overwritten. To change an already-set value, the user runs `flowctl config set <key> <value>` directly (the commands are surfaced in 6c's current-config notice).
 
-Skipped questions = config values already persisted from a prior run. Asking again would either no-op (same answer) or silently flip a deliberate user choice — both are wrong. The grouped single-prompt design (a single `plain-text numbered prompt` call below, with one questions array containing only the unset entries) means a re-run with all config set produces zero config questions and asks only the always-include Docs + Ralph (except `PLATFORM=cursor`) + Star questions (plus the interactive-only Model Routing scaffold question, when `ROUTING_ASK=1` and the platform/bridge gate passes).
+Skipped questions = config values already persisted from a prior run. Asking again would either no-op (same answer) or silently flip a deliberate user choice — both are wrong. The grouped single-prompt design (a single `plain-text numbered prompt` call below, with one questions array containing only the unset entries) means a re-run with all config set produces zero config questions and asks only the always-include Docs + Ralph (except `PLATFORM=cursor` / `PLATFORM=grok`) + Star questions (plus the interactive-only Model Routing scaffold question, when `ROUTING_ASK=1` and the platform/bridge gate passes).
 
 Available questions (include only if corresponding config is unset):
 
@@ -440,7 +448,24 @@ Available questions (include only if corresponding config is unset):
 }
 ```
 
-**When `PLATFORM` is NOT `cursor`** (Claude Code / Droid / Codex — unchanged):
+**When `PLATFORM=grok`** (fn-126) — offer `host` with the fail-closed cross-family caveat (Grok is single-native-family `grok-4.5`) plus every external backend; when `HAVE_CODEX=1` mark Codex Recommended (true cross-family vs a Grok writer):
+```json
+{
+ "header": "Review",
+ "question": "Which review backend? Plans and implementations get reviewed before they land. Grok's only native model family is grok-4.5 — host-native review fails closed unless the writer is non-Grok; cross-family review comes via bridge backends (codex/cursor/copilot). Guide: https://flow-next.dev/review/workflow/",
+ "options": [
+ {"label": "Host", "description": "Fresh-context host-native subagent; pin from AGENTS.md model-routing (setup scaffolds). Fail-closed: Grok is single-native-family (grok-4.5) — native host review refuses same-family self-review (interactive → ask; autonomous → NEEDS_HUMAN) unless the writer is non-Grok. Cross-family via bridges."},
+ {"label": "Codex CLI", "description": "OpenAI's codex CLI, reviews on its top reasoning tier (GPT family). Cross-platform, simple setup. <detected if HAVE_CODEX=1, (not detected) if HAVE_CODEX=0>"},
+ {"label": "Copilot CLI", "description": "Routes to Claude- or GPT-family reviewers via your GitHub Copilot plan. Requires gh copilot auth. <detected if HAVE_COPILOT=1, (not detected) if HAVE_COPILOT=0>"},
+ {"label": "Cursor CLI", "description": "Runs cursor-agent with a multi-family model menu (pick the family that did not write the diff). Billed to your Cursor subscription. <detected if HAVE_CURSOR=1, (not detected) if HAVE_CURSOR=0>"},
+ {"label": "RepoPrompt", "description": "macOS only. Auto-discovers git diffs + context, reviews scoped to actual changes, far fewer tokens than full-repo approaches. <detected if HAVE_RP=1, (not detected) if HAVE_RP=0>"},
+ {"label": "None", "description": "Skip AI reviews for now. Set later with flowctl config set review.backend <name>, or per-run via --review"}
+ ],
+ "multiSelect": false
+}
+```
+
+**When `PLATFORM` is NOT `cursor`** (Claude Code / Droid / Codex — unchanged; Grok uses the dedicated menu above):
 ```json
 {
  "header": "Review",
@@ -456,17 +481,18 @@ Available questions (include only if corresponding config is unset):
 }
 ```
 
-When `HAVE_CODEX=1` AND `PLATFORM` is NOT `codex` AND `PLATFORM` is NOT `cursor`, append ` (Recommended - cross-family default)` to the `Codex CLI` label: the recommended multi-model pipeline reviews cross-family FROM THE WRITER, and on a Claude Code / Droid host codex review is a different family than the session writer - so this question carries the ceremony's `review.backend codex` offer while the key is unset (fn-97). On `PLATFORM=cursor` do NOT add the Codex Recommended label — `Host (Recommended)` already leads. On a Codex host (`PLATFORM=codex`) do NOT add the label: the writer is GPT-family (the session model, or the optional terra worker pin), so codex review would be SAME-family - prefer a detected non-GPT backend there (copilot / cursor with a Claude-family model) and leave the options unannotated when none is detected. When `review.backend` is ALREADY set to something else, this question is skipped (existing config is never silently overwritten) - the offer instead rides the Model Routing scaffold as an explicit opt-in switch, Step 7's step 8 below.
+When `HAVE_CODEX=1` AND `PLATFORM` is NOT `codex` AND `PLATFORM` is NOT `cursor`, append ` (Recommended - cross-family default)` to the `Codex CLI` label: the recommended multi-model pipeline reviews cross-family FROM THE WRITER, and on a Claude Code / Droid / Grok host codex review is a different family than the session writer - so this question carries the ceremony's `review.backend codex` offer while the key is unset (fn-97). On `PLATFORM=cursor` do NOT add the Codex Recommended label — `Host (Recommended)` already leads. On a Codex host (`PLATFORM=codex`) do NOT add the label: the writer is GPT-family (the session model, or the optional terra worker pin), so codex review would be SAME-family - prefer a detected non-GPT backend there (copilot / cursor with a Claude-family model) and leave the options unannotated when none is detected. When `review.backend` is ALREADY set to something else, this question is skipped (existing config is never silently overwritten) - the offer instead rides the Model Routing scaffold as an explicit opt-in switch, Step 7's step 8 below.
 
 Stored value is a bare backend name by default (`host` / `codex` / `copilot` / `cursor` / `rp` / `none`). Power users can also write a full spec like `codex:gpt-5.4:high`, `copilot:claude-opus-4.5:xhigh`, or `cursor:gpt-5.5-high` (cursor takes a model only — no `:effort`) via `flowctl config set review.backend <spec>` after setup — the review commands accept both forms. Backend `host` is bare only (no `host:<model>` — pins live in the AGENTS.md model-routing section).
 
-**Model Routing question** — include when `ROUTING_ASK=1` AND (`BRIDGE_DETECTED=1` OR `PLATFORM=cursor`):
-- **Non-Cursor:** require `ROUTING_ASK=1` AND `BRIDGE_DETECTED=1` — interactive setup with at least one bridge CLI (`codex` / `cursor-agent` / `grok`) detected per 6a; skipped silently under any non-interactive/autonomous marker, and skipped without a detected bridge CLI — the scaffold's wiring routes would all be inert install notes (fn-97).
+**Model Routing question** — include when `ROUTING_ASK=1` AND (`BRIDGE_DETECTED=1` OR `PLATFORM=cursor` OR `PLATFORM=grok`):
+- **Non-host-native** (not cursor, not grok): require `ROUTING_ASK=1` AND `BRIDGE_DETECTED=1` — interactive setup with at least one bridge CLI (`codex` / `cursor-agent` / `grok`) detected per 6a; skipped silently under any non-interactive/autonomous marker, and skipped without a detected bridge CLI — the scaffold's wiring routes would all be inert install notes (fn-97).
 - **Cursor (`PLATFORM=cursor`):** offer when `ROUTING_ASK=1` even with zero bridge CLIs — host-native AGENTS.md pins use Cursor subagent model slugs, not external bridges (fn-123 R6).
+- **Grok (`PLATFORM=grok`):** offer when `ROUTING_ASK=1` even with zero bridge CLIs — host-native AGENTS.md pins enumerate Grok's available models at setup (fn-126); single-native-family so host-review pin is TODO/fail-closed unless a cross-family bridge is also available.
 
 Offers the recommended multi-model pipeline scaffold (composed + written in Step 7). The frozen option set is `Scaffold` / `Scaffold + enable codex delegation` / `Skip`; **include the `Scaffold + enable codex delegation` option ONLY when `HAVE_CODEX=1`** (drop that one object entirely when `HAVE_CODEX=0` — never show a delegation route to a missing binary).
 
-**Non-Cursor question body** (bridge-wired scores table):
+**Non-host-native question body** (bridge-wired scores table; Claude Code / Droid / Codex):
 ```json
 {
  "header": "Model Routing",
@@ -487,6 +513,20 @@ Offers the recommended multi-model pipeline scaffold (composed + written in Step
  "question": "Scaffold host-native model routing into AGENTS.md? Enumerates real Cursor model slugs available on this host, then pins a cheap slug for read-only scouts and a cross-family slug for host review (everything else inherits the session model). Date-stamped; re-run setup to refresh volatile ids. Shown in FULL before writing. Background: https://flow-next.dev/orchestration/",
  "options": [
  {"label": "Scaffold", "description": "Write the Cursor host-native model-routing section into AGENTS.md (or the Docs target). Host agent enumerates slugs and picks the pins — never Python."},
+ {"label": "Scaffold + enable codex delegation", "description": "Also set work.delegate=codex so /flow-next:work can offload bulk implementation to the codex CLI. First-use consent is still required — this never pre-approves it. INCLUDE THIS OPTION ONLY WHEN HAVE_CODEX=1."},
+ {"label": "Skip", "description": "Don't scaffold a routing section (default). Re-run /flow-next:setup later to add it."}
+ ],
+ "multiSelect": false
+}
+```
+
+**Grok question body** (`PLATFORM=grok` — host-native model pins; no bridge CLI required; single-native-family caveat):
+```json
+{
+ "header": "Model Routing",
+ "question": "Scaffold host-native model routing into AGENTS.md? Enumerates Grok's available models at setup (typically grok-4.5 only — single native family), pins a scout slug, and documents that host review fails closed for same-family writers unless a cross-family bridge pin is available. Date-stamped; re-run setup to refresh. Shown in FULL before writing. Background: https://flow-next.dev/orchestration/",
+ "options": [
+ {"label": "Scaffold", "description": "Write the Grok host-native model-routing section into AGENTS.md (host-review reads this; lifecycle docs may live in CLAUDE.md — Grok loads both). Host agent enumerates models and picks the pins — never Python."},
  {"label": "Scaffold + enable codex delegation", "description": "Also set work.delegate=codex so /flow-next:work can offload bulk implementation to the codex CLI. First-use consent is still required — this never pre-approves it. INCLUDE THIS OPTION ONLY WHEN HAVE_CODEX=1."},
  {"label": "Skip", "description": "Don't scaffold a routing section (default). Re-run /flow-next:setup later to add it."}
  ],
@@ -541,7 +581,22 @@ For **Cursor** (`PLATFORM=cursor`) — Cursor reads AGENTS.md, so recommend it (
 }
 ```
 
-**Ralph question** — **skip entirely when `PLATFORM=cursor`** (fn-123: no Ralph support on Cursor; never offer, never register hooks, never run `/flow-next:ralph-init` from this ceremony). On Cursor set `RALPH_OUTCOME="off (unsupported on Cursor)"` and do not include the question. On every other platform: always include (fresh setup AND re-run). Ralph is fully opt-in: default install ships zero hooks. Detect whether the project already has a Ralph surface (`scripts/ralph/` present, or any settings file with a hook command containing `scripts/ralph/hooks/ralph-guard`) and adjust the question wording (enable vs keep). **Default is No.**
+For **Grok** (`PLATFORM=grok`) — Grok reads BOTH CLAUDE.md and AGENTS.md; lifecycle snippet defaults to CLAUDE.md (canonical Claude-format target, `/flow-next:` slash syntax — NOT the Codex `$flow-next-` one). A pre-existing wrong Codex `$flow-next-` marker block is consent-refreshed to the slash form (marker-scoped; text outside markers untouched). Model-routing block still targets AGENTS.md (where host-review workflows read it):
+```json
+{
+ "header": "Docs",
+ "question": "Update project documentation with Flow-Next instructions? Adds a marker-bounded section teaching any agent that opens this repo how to track work via flowctl; your text outside the markers is never touched. Grok loads both CLAUDE.md and AGENTS.md.",
+ "options": [
+ {"label": "CLAUDE.md only (Recommended)", "description": "Add flow-next section to CLAUDE.md (canonical Grok lifecycle target; /flow-next: slash syntax)"},
+ {"label": "AGENTS.md only", "description": "Add flow-next section to AGENTS.md"},
+ {"label": "Both", "description": "Add flow-next section to both files (recommended when you also want the model-routing block's sibling lifecycle snippet nearby)"},
+ {"label": "Skip", "description": "Don't update documentation"}
+ ],
+ "multiSelect": false
+}
+```
+
+**Ralph question** — **skip entirely when `PLATFORM=cursor` or `PLATFORM=grok`** (fn-123 / fn-126: no Ralph support on Cursor or Grok; never offer, never register hooks, never run `/flow-next:ralph-init` from this ceremony). On Cursor set `RALPH_OUTCOME="off (unsupported on Cursor)"`; on Grok set `RALPH_OUTCOME="off (unsupported on Grok)"`; do not include the question. On every other platform: always include (fresh setup AND re-run). Ralph is fully opt-in: default install ships zero hooks. Detect whether the project already has a Ralph surface (`scripts/ralph/` present, or any settings file with a hook command containing `scripts/ralph/hooks/ralph-guard`) and adjust the question wording (enable vs keep). **Default is No.**
 
 ```json
 {
@@ -769,8 +824,8 @@ esac
 
 Use the correct template based on **target file** and **platform**:
 - AGENTS.md on **Codex**: use [templates/agents-md-snippet.md](templates/agents-md-snippet.md) (uses `$flow-next-plan` syntax)
-- AGENTS.md on **Claude Code / Droid / Cursor**: use [templates/claude-md-snippet.md](templates/claude-md-snippet.md) (uses `/flow-next:plan` syntax — Cursor runs the slash commands, so its AGENTS.md must carry the `/flow-next:` snippet, NOT the Codex `$flow-next-` one)
-- CLAUDE.md (any platform): use [templates/claude-md-snippet.md](templates/claude-md-snippet.md)
+- AGENTS.md on **Claude Code (copy mode) / Droid / Cursor / Grok**: use [templates/claude-md-snippet.md](templates/claude-md-snippet.md) (uses `/flow-next:plan` slash syntax — Cursor and Grok run the slash commands, so their AGENTS.md must carry the `/flow-next:` snippet, NOT the Codex `$flow-next-` one; a wrong Codex `$` block is consent-refreshed marker-scoped)
+- CLAUDE.md (any platform, copy mode — including Grok's default lifecycle target): use [templates/claude-md-snippet.md](templates/claude-md-snippet.md)
 
 **Resolve the target file set:** an explicit Docs-question answer is authoritative - if the user is asked and selects specific files (or declines one), honor exactly that; never touch a file the user just deselected. The one addition is a backfill for the SKIPPED case: when the Docs question is omitted entirely because the block is already current (per the Note above), still run `apply` on each already-marker-bearing file. Rationale (R8): a current-but-hashless block (written by a pre-hash plugin version) would otherwise never reach `apply`, so its pristine hash never gets backfilled and the NEXT template change wrongly prompts "Overwrite customized?". `apply` on a current block is cheap and idempotent - it returns `unchanged` and records the missing hash. So: resolve targets = files chosen by the Docs question when it was asked; OR, when the Docs question was skipped, the files already carrying the `<!-- BEGIN FLOW-NEXT -->` marker. Run the helper once per resolved file.
 
@@ -798,7 +853,7 @@ For each resolved file (CLAUDE.md and/or AGENTS.md) - the block mechanics (marke
 
 The marker-block boundaries are load-bearing: pre-existing prose outside `<!-- BEGIN FLOW-NEXT -->` … `<!-- END FLOW-NEXT -->` is **never** modified by this step, and only the flowctl helper performs writes. Only the bytes between (and including) those markers are candidates for replacement.
 
-**Model Routing scaffold** (only if the Model Routing question was asked — i.e. `ROUTING_ASK=1` AND (`BRIDGE_DETECTED=1` OR `PLATFORM=cursor`); when the question was never shown, this step is a silent no-op — record `not offered` for the summary and skip to Star). Keep the non-Cursor gate string load-bearing for bridge hosts: non-Cursor still requires `ROUTING_ASK=1` AND `BRIDGE_DETECTED=1`.
+**Model Routing scaffold** (only if the Model Routing question was asked — i.e. `ROUTING_ASK=1` AND (`BRIDGE_DETECTED=1` OR `PLATFORM=cursor` OR `PLATFORM=grok`); when the question was never shown, this step is a silent no-op — record `not offered` for the summary and skip to Star). Keep the non-host-native gate string load-bearing for bridge hosts: non-cursor/non-grok still requires `ROUTING_ASK=1` AND `BRIDGE_DETECTED=1`.
 
 Run this **after** the Docs block above and **before** Star. It may touch the **same** file the Docs block just wrote this run — always **re-read the target from disk here**; never reuse an in-memory copy and never interleave the two writes. Set `ROUTING_OUTCOME=""` for the Step 8 summary and update it at each terminal branch below. Every "done with the block pipeline" terminal below still falls through to **step 7 (delegation)** — the delegation opt-in is independent of whether the block was written — then on to Star.
 
@@ -850,14 +905,59 @@ _Scaffolded by `/flow-next:setup` on Cursor (<YYYY-MM-DD>). Model ids are volati
 
 **C4. Target + write** — the model-routing block ALWAYS targets AGENTS.md on Cursor, regardless of the Docs answer or where existing markers live (the host-review workflows resolve the cross-family pin from AGENTS.md model-routing, and Cursor reads AGENTS.md — a block scaffolded only into CLAUDE.md would leave `review.backend host` failing closed despite a completed scaffold). When the Docs choice also selected CLAUDE.md, write the block to BOTH files (AGENTS.md is the load-bearing copy). Apply the shim guard. Then the same marker/byte-compare/read-back/write discipline as steps 4–6 (identical, Keep mine / Overwrite / skip; never silent write). On write, print: `Model-routing section written to <file> — Cursor host-native pins; re-run /flow-next:setup to refresh volatile ids.` Set `ROUTING_OUTCOME` accordingly. Then run **step 7 (delegation)** if the answer included codex delegation, skip step 8's codex review-backend switch entirely on `PLATFORM=cursor` regardless of `CURRENT_BACKEND` (Host is the Cursor recommended default and the Codex-switch offer contradicts the Host-first / cursor-CLI-is-circular policy; if the user wants a different backend they pick it in the review-backend question, never via this offer), and continue to Ralph/Star.
 
-##### Non-Cursor bridge path (Claude Code / Droid / Codex — unchanged)
+##### Grok host-native path (`PLATFORM=grok` only — fn-126)
 
-For non-Cursor platforms, run the block pipeline (step 1 once, then steps 2–6 **per resolved target file** — see the per-file loop below), then always run step 7 once:
+When `PLATFORM=grok`, do **not** use the bridge-probe template transform below. Compose a host-native AGENTS.md block from enumerated Grok models. **The HOST AGENT picks the pins — never Python / never flowctl ranking.** Grok is **single-native-family** (`grok-4.5` is the only native family per `grok models` / equivalent) — native host review fails closed for a Grok writer unless a cross-family bridge pin is available; document that honesty in the block.
+
+**G1. Enumerate available Grok models** (in order; first success wins):
+1. Host agent catalogs its own available models (session model list / host knowledge — typically `grok-4.5` only).
+2. Fallback: if `HAVE_GROK=1`, run `grok models` (or the host's equivalent model-list command; foreground, short timeout; capture up to ~50 lines).
+3. If both fail, still scaffold listing `grok-4.5` with a note that ids could not be live-enumerated — user edits later; re-run setup to refresh.
+
+**G2. HOST AGENT picks pins** from the enumerated set (judgment, not a fixed table):
+- `SCOUT_PIN` — cheapest / fastest suitable slug for **read-only scouts** (on single-family Grok this is typically `grok-4.5`).
+- `REVIEW_PIN` — strongest acceptable slug from a **different family than the session/writer** for **host review** (`review.backend host`). **On single-family Grok this pin is almost always unavailable natively** — leave `REVIEW_PIN` as an explicit TODO (or a bridge-model note) and state that host review fails closed (interactive → ask; autonomous → NEEDS_HUMAN) unless the writer is non-Grok or a bridge backend is used for review. Never invent a fake cross-family native slug.
+
+**G3. Compose the block** (verbatim structure; substitute today's ISO date, the enumerated list, and the pins). Markers and provenance are load-bearing:
+
+```markdown
+<!-- flow-next:model-routing:start -->
+## Picking models for flow-next workflows and subagents
+
+_Scaffolded by `/flow-next:setup` on Grok (<YYYY-MM-DD>). Grok is single-native-family (grok-4.5); model ids may change — re-run setup to refresh. Edit freely; this section is yours now._
+
+### Available models (enumerated at setup)
+
+- <bullet list of enumerated Grok models — typically just grok-4.5>
+
+### Dispatch pins (host agent picked)
+
+| role | pin | rule |
+|------|-----|------|
+| read-only scouts | `<SCOUT_PIN>` | cheap / fast |
+| host review | `<REVIEW_PIN or TODO>` | cross-family vs the writer — fails closed on same-family Grok |
+| everything else | inherit | session model |
+
+### Routing rules
+
+- Read-only scouts (repo-scout, context-scout, and any read-only Explore-class subagent): pin `<SCOUT_PIN>` (cheap).
+- Host review (`review.backend host`): pin `<REVIEW_PIN>` only when it is a **different family than the writer**. Grok's only native family is grok — native host review **fails closed** for a Grok writer (interactive → ask for a bridge/replacement pin; autonomous → NEEDS_HUMAN). Cross-family review on Grok comes through bridge backends (`codex` / `cursor` / `copilot`), not a native multi-family subagent.
+- Implementation, plan, judgment, and all other work: **inherit** the session model unless the user pins otherwise.
+- Reviews prefer a different family than the writer — uncorrelated blind spots.
+- Graceful degrade: unavailable slug → fall back to the session model; never block. **EXCEPTION — host review:** the `REVIEW_PIN` never degrades to the session model (that would silently turn the required cross-family review into same-family self-review). If the pin is unavailable, host review fails closed. Re-run `/flow-next:setup` to refresh the pin.
+<!-- flow-next:model-routing:end -->
+```
+
+**G4. Target + write** — the model-routing block ALWAYS targets **AGENTS.md** on Grok (where host-review workflows resolve the cross-family pin), even though the lifecycle docs snippet defaults to **CLAUDE.md** — Grok loads BOTH instruction files (probe-verified 2026-07-22), so the pin resolves either way; AGENTS.md is the load-bearing copy for host-review consistency with Cursor. When the Docs choice also selected CLAUDE.md (or Both), write the routing block to AGENTS.md always; optionally also to CLAUDE.md when Docs selected it. Apply the shim guard. Then the same marker/byte-compare/read-back/write discipline as steps 4–6 (identical, Keep mine / Overwrite / skip; never silent write). On write, print: `Model-routing section written to <file> — Grok host-native pins (single-family fail-closed for host review); re-run /flow-next:setup to refresh.` Set `ROUTING_OUTCOME` accordingly. Then run **step 7 (delegation)** if the answer included codex delegation. On `PLATFORM=grok`, step 8's codex review-backend switch MAY still run when `HAVE_CODEX=1` and `CURRENT_BACKEND` is non-empty and not already codex (unlike Cursor — on Grok, Codex is the real cross-family default when available). Continue to Ralph/Star.
+
+##### Non-host-native bridge path (Claude Code / Droid / Codex — unchanged)
+
+For platforms that are neither cursor nor grok, run the block pipeline (step 1 once, then steps 2–6 **per resolved target file** — see the per-file loop below), then always run step 7 once:
 
 **1. Resolve target file(s)** via this deterministic ladder (independent of whether the Docs question fired — evaluate in order, first match wins):
  a. **Docs answered this run** → mirror that choice: `CLAUDE.md only` → CLAUDE.md; `AGENTS.md only` → AGENTS.md; `Both` → the same block to **both** files; `Skip` → fall through to (b).
  b. **Docs skipped or already-current** → the file(s) that already carry the `<!-- BEGIN FLOW-NEXT -->` docs marker (marker in both → both).
- c. **Neither** → the platform-default mapping (the Step 6b buckets): Codex → AGENTS.md; Claude Code / Droid → CLAUDE.md; Cursor → AGENTS.md.
+ c. **Neither** → the platform-default mapping (the Step 6b buckets): Codex → AGENTS.md; Claude Code / Droid → CLAUDE.md; Cursor → AGENTS.md. (Grok never reaches this ladder — it uses the host-native path above, which always targets AGENTS.md for the routing block.)
 
  **Shim guard** (apply to each resolved target before writing): read the file and take its non-empty content lines. If there is exactly **one** non-empty content line and it matches either `@<path>.md` **or** `See[:] <path>.md` (case-insensitive, `<path>` repo-relative), the target is a **shim** — do **not** write into it. Instead follow the pointer: if `<path>.md` exists in-repo, retarget to it (and re-apply the shim guard to that file); if it does not exist, print `Model-routing scaffold: <file> is a shim pointing at a missing <path>.md — skipping` and drop this target. Any other content = a normal file, proceed. Never turn a shim into a mixed file. If every resolved target drops out (all shims to missing files), `ROUTING_OUTCOME="skipped (shim)"`; done with the block pipeline (proceed to step 7).
 
@@ -871,7 +971,7 @@ For non-Cursor platforms, run the block pipeline (step 1 once, then steps 2–6 
 
  Result invariant (R10): after the transform the composed block contains **no** `<!-- probe:` sentinel and **no active (non-comment) line that invokes a CLI whose probe failed** — every failed-probe route is fully enclosed in an HTML comment with an install note. All three probes (codex, cursor, grok) failing → every probe-gated wiring route is a commented-out note (the scores table + the native routes + always-on escalation/graceful-degrade rules still stand); you MAY note in the read-back that with none of the CLIs installed, `Skip` is reasonable — but still honor the user's choice.
 
-**3. Substitute the invocation syntax per target file** — keyed on the target file's snippet family from the Docs mapping above, NOT on platform alone: rewrite every `/flow-next:<cmd>` → `$flow-next-<cmd>` (this covers the provenance line's `/flow-next:setup` **and** the `delegate:codex` work route's `/flow-next:work`) **only** when the target is AGENTS.md on **Codex** (the `agents-md-snippet.md` family); keep `/flow-next:` verbatim for CLAUDE.md on **every** platform and for AGENTS.md on **Claude Code / Droid / Cursor** (the `claude-md-snippet.md` family — Cursor runs the slash commands). When step 1 resolved **both** files on Codex, compose one copy per file: AGENTS.md gets `$flow-next-`, CLAUDE.md keeps `/flow-next:`.
+**3. Substitute the invocation syntax per target file** — keyed on the target file's snippet family from the Docs mapping above, NOT on platform alone: rewrite every `/flow-next:<cmd>` → `$flow-next-<cmd>` (this covers the provenance line's `/flow-next:setup` **and** the `delegate:codex` work route's `/flow-next:work`) **only** when the target is AGENTS.md on **Codex** (the `agents-md-snippet.md` family); keep `/flow-next:` verbatim for CLAUDE.md on **every** platform and for AGENTS.md on **Claude Code / Droid / Cursor / Grok** (the `claude-md-snippet.md` family — Cursor and Grok run the slash commands). When step 1 resolved **both** files on Codex, compose one copy per file: AGENTS.md gets `$flow-next-`, CLAUDE.md keeps `/flow-next:`.
 
 **4. Inspect marker + byte-compare FIRST — before any read-back.** Read the resolved target from disk:
  - **Marker present** (`<!-- flow-next:model-routing:start -->` … `<!-- flow-next:model-routing:end -->`): extract that block inclusive and **byte-compare** it against the block composed in 2–3 **for this target file** (today's probe state + this file's invocation syntax — this is the *current composed canonical*):
@@ -909,7 +1009,7 @@ For non-Cursor platforms, run the block pipeline (step 1 once, then steps 2–6 
 
 `Keep current` → no write, done. `Switch to codex` → run `"${PLUGIN_ROOT}/scripts/flowctl" config set review.backend codex --json`, then read the persisted value back (same read-back pattern as step 7); if it did not persist as `codex`, print `Warning: review.backend did not persist as codex — set it manually with flowctl config set review.backend codex`. This step never runs non-interactively (the whole scaffold pipeline is gated on `ROUTING_ASK=1`) and never fires when the user skipped the scaffold — declining the scaffold declines its pipeline too.
 
-**Ralph** (processed when the Ralph question was asked — i.e. `PLATFORM` is NOT `cursor`. On `PLATFORM=cursor`: never offer, never register, never run ralph-init; print `Ralph: off (unsupported on Cursor)` and skip this whole block — fn-123):
+**Ralph** (processed when the Ralph question was asked — i.e. `PLATFORM` is NOT `cursor` and NOT `grok`. On `PLATFORM=cursor`: never offer, never register, never run ralph-init; print `Ralph: off (unsupported on Cursor)` and skip this whole block — fn-123. On `PLATFORM=grok`: same posture — print `Ralph: off (unsupported on Grok)` and skip this whole block — fn-126):
 
 - **Yes, enable or keep:**
  1. Tell the user Ralph is opt-in and that the next step is `/flow-next:ralph-init` (or `$flow-next-ralph-init` on Codex).
@@ -945,7 +1045,7 @@ Include `Setup mode: copy` in the Step 8 summary.
 ```
 Flow-Next setup complete!
 
-Platform: <claude-code|codex|droid|cursor>
+Platform: <claude-code|codex|droid|cursor|grok>
 
 Installed:
 - .flow/bin/flowctl (v<VERSION>)
@@ -962,6 +1062,17 @@ Cursor host notes:
 - Copy mode only (.flow/bin/flowctl) — Cursor exposes no plugin-root env vars / bin PATH injection
 - Review default: host (host-native cross-family subagent pins in AGENTS.md model-routing)
 - Ralph: unsupported on Cursor (not offered; not registered)
+```
+
+**If PLATFORM=grok, also show:**
+```
+Grok host notes:
+- Copy mode only (.flow/bin/flowctl) — Grok exposes no plugin-root bin PATH injection
+- Docs: /flow-next: slash snippet (CLAUDE.md default lifecycle target; Grok also reads AGENTS.md)
+- Model-routing block: AGENTS.md (host-review pin target)
+- Review: host offered (single-native-family fail-closed for Grok writers) + rp/codex/copilot/cursor/none
+- No .codex/agents copy; Ralph: unsupported on Grok (not offered; not registered)
+- Detection: GROK_AGENT=1 (not ~/.grok or PATH)
 ```
 
 **If PLATFORM=codex, also show:**
@@ -998,7 +1109,7 @@ Model-pin ceremony (fn-115.2): <MODELS_CEREMONY — "written" | "stamped" | "ski
 
 Notes:
 - Re-run /flow-next:setup after plugin updates to refresh scripts
-- Ralph: answered in the setup ceremony (default off; skipped entirely on Cursor — unsupported). To enable later on supported hosts: /flow-next:ralph-init (merges project hooks; plugin ships none)
+- Ralph: answered in the setup ceremony (default off; skipped entirely on Cursor and Grok — unsupported). To enable later on supported hosts: /flow-next:ralph-init (merges project hooks; plugin ships none)
 - Use Linear / GitHub Issues / GitLab / Jira for project management? Run /flow-next:tracker-sync to configure the (opt-in) two-way tracker bridge — it runs a discovery ceremony (detects Linear MCP / LINEAR_API_KEY / gh auth / glab auth or GITLAB_TOKEN / JIRA_BASE_URL + credential, asks, writes config), then syncs specs ⇄ issues; on Linear it additionally makes your PRs reviewable as Linear Diffs. Skips cleanly if you don't use a tracker; adds nothing to the base install until enabled.
 - Uninstall (run manually): rm -rf .flow/bin .flow/templates .flow/usage.md and remove the <!-- BEGIN/END FLOW-NEXT --> and <!-- flow-next:model-routing:start/end --> blocks from docs — or run /flow-next:uninstall for full cleanup (also strips Ralph guard hook entries from project settings)
 - This setup is optional - plugin works without it

--- a/plugins/flow-next/codex/skills/flow-next-setup/workflow.md
+++ b/plugins/flow-next/codex/skills/flow-next-setup/workflow.md
@@ -445,7 +445,7 @@ Available questions (include only if corresponding config is unset):
 }
 ```
 
-**When `PLATFORM` is NOT `cursor`** (Claude Code / Droid / Codex — unchanged; Grok uses the dedicated menu above):
+**When `PLATFORM` is neither `cursor` nor `grok`** (Claude Code / Droid / Codex — unchanged; Cursor and Grok each use their dedicated menu above):
 ```json
 {
  "header": "Review",

--- a/plugins/flow-next/codex/skills/flow-next-spec-completion-review/SKILL.md
+++ b/plugins/flow-next/codex/skills/flow-next-spec-completion-review/SKILL.md
@@ -93,9 +93,13 @@ When `RP_ELIGIBLE=0`, omit the **rp** line below from any guidance you surface (
 3. Model resolved via (first match wins): `--spec cursor:<model>` flag, per-spec `default_review`, `FLOW_REVIEW_BACKEND` spec, `FLOW_CURSOR_MODEL` env var, registry default (`gpt-5.5-high`). **No effort** — Cursor bakes effort into the model name; `cursor:<model>:<effort>` is rejected
 4. Parse verdict from command output
 
-**For host backend (fn-123 R5):**
+**For host backend (fn-123 R5 / fn-126):**
 1. **DO NOT REVIEW COMPLETION YOURSELF** — you coordinate; a fresh-context host-native subagent reviews (see [workflow-host.md](workflow-host.md))
-2. Dispatch a **read-only** reviewer subagent pinned to a **cross-family** model slug from AGENTS.md model-routing (Claude Code: native `model` param; Cursor: in-prompt slug pin; elsewhere: generic fresh-context reviewer with host-dependent note)
+2. Dispatch a **read-only** reviewer subagent pinned to a **cross-family** model slug from AGENTS.md model-routing:
+ - **Claude Code**: native `model` param + tool-enforced read-only
+ - **Cursor**: in-prompt slug pin + tool-enforced read-only
+ - **Grok**: in-prompt / host model pin + tool-enforced read-only; single-native-family (`grok-4.5`) fails closed unless the writer is non-Grok (cross-family via bridges); receipt `mode: "host"` + actual model + `session_id: null`
+ - **Elsewhere**: generic fresh-context reviewer with host-dependent note
 3. Record actual reviewer model + `"mode": "host"` in the receipt
 4. **Every re-review is a fresh subagent** — no context reuse, no fabricated resume ids
 5. **Fail closed on missing cross-family pin:** interactive → ask user explicitly; autonomous → `NEEDS_HUMAN` (never silent same-family self-review)

--- a/plugins/flow-next/codex/skills/flow-next-spec-completion-review/workflow-host.md
+++ b/plugins/flow-next/codex/skills/flow-next-spec-completion-review/workflow-host.md
@@ -30,6 +30,7 @@ Dispatch a **fresh** read-only reviewer subagent with the resolved pin:
 |------|------------|
 | Claude Code | Native subagent `model` param; `disallowedTools: Edit, Write, Task` (or host read-only equivalent) |
 | Cursor | In-prompt slug pin on the subagent + TOOL-enforced read-only (dispatch via a `readonly: true` agent definition or Cursor's read-only subagent mode — never a mutation-capable subagent; the reviewer reads untrusted diff content, so read-only cannot be prompt-requested only) |
+| Grok | In-prompt / host model pin from AGENTS.md model-routing + TOOL-enforced read-only (never mutation-capable). Single-native-family (`grok-4.5`) — host review fails closed unless the writer is non-Grok; cross-family via bridge backends. Receipt: `mode: "host"`, actual reviewer model, `session_id: null` (same shape as Claude/Cursor) |
 | Codex | Fresh read-only reviewer subagent via the platform subagent primitive (`spawn_agent` on Codex) with the cross-family pin stated in the prompt; read-only via the platform sandbox |
 | Other | Generic fresh-context reviewer; note in the receipt that pin enforcement is host-dependent |
 

--- a/plugins/flow-next/docs/platforms.md
+++ b/plugins/flow-next/docs/platforms.md
@@ -1,6 +1,6 @@
 # Other Platforms
 
-Flow-next is a first-class citizen on Claude Code (canonical), OpenAI Codex (pre-built mirror), and Factory Droid (native cross-platform patterns). A community port exists for OpenCode. xAI **Grok Build** reads the Claude Code plugin with zero config — skills load, the `/flow-next:*` commands **run when typed**, and **multi-agent flows work** (a full `/flow-next:plan` fanned out all seven scouts, verified). Grok's UI just under-lists flow-next's commands/agents (cosmetic — they work when invoked); Ralph is fully opt-in (project hooks via ralph-init) and still to validate end-to-end on Grok (see [Grok Build](#grok-build-claude-code-compatibility) below). **Cursor** is first-class too: **recommended install is team-marketplace repo import** (admin imports the GitHub repo via the Cursor GitHub App; Default Off / On / Required modes; auto-refresh on push); local `install-cursor.sh` / `.ps1` remain the individual/fallback path. Skills, commands, multi-agent flows, native asks, and slash autocomplete verified; Ralph intentionally not built for Cursor. See [Cursor](#cursor) below.
+Flow-next is a first-class citizen on Claude Code (canonical), OpenAI Codex (pre-built mirror), and Factory Droid (native cross-platform patterns). A community port exists for OpenCode. xAI **Grok Build** reads the canonical Claude plugin format AS-IS (skills, agents, commands, MCP, instruction files). Skills load, `/flow-next:*` (and hyphenated `/flow-next-*`) slash commands run when typed, and **multi-agent flows work** (a full `/flow-next:plan` fanned out all seven scouts, verified). Setup detects Grok via **`GROK_AGENT=1`** (not Codex fallback / `$flow-next-` syntax). Copy mode + `.flow/bin/flowctl`; Ralph intentionally not built for Grok. See [Grok Build](#grok-build-claude-code-compatibility) below. **Cursor** is first-class too: **recommended install is team-marketplace repo import** (admin imports the GitHub repo via the Cursor GitHub App; Default Off / On / Required modes; auto-refresh on push); local `install-cursor.sh` / `.ps1` remain the individual/fallback path. Skills, commands, multi-agent flows, native asks, and slash autocomplete verified; Ralph intentionally not built for Cursor. See [Cursor](#cursor) below.
 
 ### Ralph hooks: per-host registration (no plugin-default)
 
@@ -12,7 +12,7 @@ The plugin **does not** ship `hooks/hooks.json`. Fresh install = zero guard proc
 | Factory Droid | `.factory/hooks.json` (primary) | Fallback: `hooks` in `.factory/settings.json` if already used |
 | Codex | `.codex/hooks.json` (project) | Shell + Stop only; no plugin auto-hooks |
 | Cursor | *(none)* | Cursor has a full agent-hook set; flow-next intentionally does not build/register Ralph on Cursor |
-| Grok Build | same as Claude (`.claude/settings.json`) | Claude-compat path |
+| Grok Build | *(none)* | flow-next intentionally does not build/register Ralph on Grok (same posture as Cursor; not a schema gap) |
 
 ## Install matrix
 
@@ -21,7 +21,7 @@ The plugin **does not** ship `hooks/hooks.json`. Fresh install = zero guard proc
 | Claude Code | `/plugin marketplace add https://github.com/gmickel/flow-next && /plugin install flow-next` | `.claude-plugin/plugin.json` | Canonical environment |
 | Factory Droid | `droid plugin marketplace add https://github.com/gmickel/flow-next && droid plugin install flow-next` (in Droid CLI) | `.claude-plugin/plugin.json` (Droid auto-translates Claude Code plugin format) | Native cross-platform patterns |
 | OpenAI Codex | `git clone https://github.com/gmickel/flow-next.git && cd flow-next && ./scripts/install-codex.sh` | `.codex-plugin/plugin.json` | Pre-built mirror under `plugins/flow-next/codex/` |
-| Grok Build (xAI) | Auto-discovered if installed in Claude Code (run `grok inspect`); or add `gmickel/flow-next` as a `[[marketplace.sources]]` entry. **Not** `grok plugin install <repo>`. | `.claude-plugin/plugin.json` (read via Claude Code compat) | **Works incl. multi-agent** (full `/flow-next:plan` scout fan-out verified). UI under-lists commands/agents (cosmetic); Ralph TBD — see below |
+| Grok Build (xAI) | Auto-discovered if installed in Claude Code (run `grok inspect`); or add `gmickel/flow-next` as a `[[marketplace.sources]]` entry. **Not** `grok plugin install <repo>`. | `.claude-plugin/plugin.json` (canonical Claude files AS-IS; no Codex mirror) | **Detected via `GROK_AGENT=1`.** Slash commands (`/flow-next:*` / `/flow-next-*`), copy mode, multi-agent verified. Ralph intentionally not built. See [Grok Build](#grok-build-claude-code-compatibility) |
 | Cursor | **Recommended:** team-marketplace repo import (admin imports `gmickel/flow-next` via Cursor GitHub App). **Fallback:** `./scripts/install-cursor.sh` / `install-cursor.ps1` → `~/.cursor/plugins/local/` | `.cursor-plugin/plugin.json` (Cursor's own namespace — does NOT read `.claude-plugin/`) | **First-class** (multi-agent, native asks, autocomplete verified). Ralph intentionally not built for Cursor — see [Cursor](#cursor) |
 | OpenCode | See [flow-next-opencode](https://github.com/gmickel/flow-next-opencode) | n/a | Community port |
 
@@ -186,29 +186,49 @@ chmod +x .flow/bin/flowctl
 
 ## Grok Build (Claude Code compatibility)
 
-[xAI Grok Build](https://x.ai/cli) (the `grok` CLI) advertises zero-config Claude Code compatibility — per [xAI docs](https://docs.x.ai/build/features/skills-plugins-marketplaces) it *"automatically reads Claude Code marketplaces, plugins, skills, MCPs, agents, hooks, and instruction files."* If flow-next is already installed in Claude Code, Grok picks it up with no extra setup.
+[xAI Grok Build](https://x.ai/cli) (the `grok` CLI) reads the **canonical Claude plugin format AS-IS** - skills, agents, commands, MCP, and instruction files. Per [xAI docs](https://docs.x.ai/build/features/skills-plugins-marketplaces) it *"automatically reads Claude Code marketplaces, plugins, skills, MCPs, agents, hooks, and instruction files."* If flow-next is already installed in Claude Code, Grok picks it up with no extra setup.
+
+**Grok is not a Codex host.** It does **not** consume the Codex mirror, does **not** use `$flow-next-*` command syntax, and must not fall through setup's `else → codex` path. Drive with `/flow-next:*` / `/flow-next-*` slash commands; after `/flow-next:setup` resolve flowctl via `.flow/bin/flowctl` (copy mode only).
+
+### Setup detection (fn-126)
+
+`/flow-next:setup` classifies the host via a positive rung, ordered after Droid / Claude / Cursor and **before** the `else → codex` fallback:
+
+| Signal | Role |
+|--------|------|
+| **`GROK_AGENT=1`** | **Only valid detection signal.** Set BY grok in its agent shell. Probe-verified 2026-07-22 (present in a real grok session; absent from a plain-shell control on the same machine/profile). |
+| `~/.grok/` directory | **Not a signal.** Install dir exists on the machine regardless of whether a grok session is running. |
+| `~/.grok/bin` on `PATH` | **Not a signal.** Profile-level; present outside grok sessions too. |
+
+**Instruction files (probe-verified):** Grok loads **both** `CLAUDE.md` and `AGENTS.md` into context (seeded-codename probe, 2026-07-22). Setup therefore writes the lifecycle docs snippet to **CLAUDE.md** by default (`/flow-next:` slash syntax, not Codex `$flow-next-`) and the model-routing scaffold to **AGENTS.md** (where host-review workflows resolve pins). A pre-existing wrong Codex `$flow-next-` marker block is consent-refreshed to the slash form (marker-scoped).
+
+**Known nesting edge (Droid → Grok) - NEEDS-HUMAN:** if a grok child inherits `DROID_PLUGIN_ROOT` from a Droid parent shell, the cascade classifies as `droid` (higher precedence). Nested Droid→Grok is **unsupported** pending a this-process-is-grok discriminator, unless a live smoke confirms `DROID_PLUGIN_ROOT` does not propagate. Claude/Cursor launched from a grok shell still classify correctly via their own higher-precedence signals. The probe disproved `CLAUDE_PLUGIN_ROOT` propagation into a grok child.
 
 ### Install (pick one)
 
-- **Already in Claude Code?** Nothing to do — run `grok inspect` and you'll see flow-next's skills loaded (Ralph guard hooks only after project-level ralph-init + trust).
+- **Already in Claude Code?** Nothing to do - run `grok inspect` and you'll see flow-next's skills loaded.
 - **Add as a marketplace source:** flow-next's repo root is a Claude Code **marketplace** (`.claude-plugin/marketplace.json`), so register `gmickel/flow-next` via `[[marketplace.sources]]` in `~/.grok/config.toml` (or the TUI **Marketplace** tab, opened with `/plugins`), then enable the `flow-next` plugin.
 - **Local / dev:** `grok --plugin-dir /path/to/flow-next/plugins/flow-next`.
 
-> **Do NOT run `grok plugin install https://github.com/gmickel/flow-next`.** That is the **single-plugin** git installer; the repo root is a **marketplace** (the plugin is nested at `plugins/flow-next/`), so it errors `no plugins found in the source (no plugin.json or convention components)` — there is no single plugin at the repo root. This is the same reason you don't `claude plugin install` a marketplace repo. Use the marketplace / auto-read path above.
+Then run **`/flow-next:setup`** in the project (slash syntax - **not** `$flow-next-setup`). Grok is always **copy mode** (no plugin-root bin PATH injection): setup stamps `.flow/bin/flowctl`, writes the slash-syntax docs snippet, offers the Grok review + model-routing menus, and does **not** copy `.codex/agents` or offer Ralph.
 
-### What works (verified, Grok 0.2.27 alpha)
+> **Do NOT run `grok plugin install https://github.com/gmickel/flow-next`.** That is the **single-plugin** git installer; the repo root is a **marketplace** (the plugin is nested at `plugins/flow-next/`), so it errors `no plugins found in the source (no plugin.json or convention components)` - there is no single plugin at the repo root. This is the same reason you don't `claude plugin install` a marketplace repo. Use the marketplace / auto-read path above.
+
+### What works (verified, Grok 0.2.27 alpha + fn-126 setup)
 
 - All 28 flow-next **skills** load (`grok inspect`: `plugin: flow-next`); discovery used the **Claude Code plugin install** directly (`Marketplaces (0)`, no Grok-side config).
-- **The `/flow-next:<name>` commands run when typed.** Typing `/flow-next:plan` fires `user_prompt_submit`, loads the `flow-next-plan` skill, and runs its workflow. Plugin-level Ralph hooks are **not** shipped; project hooks appear only after ralph-init merges them into `.claude/settings.json`.
-- **Multi-agent flows work — verified end-to-end.** A real `/flow-next:plan` run under Grok 0.2.27 **fanned out all seven scout subagents** (`repo-scout`, `practice-scout`, `docs-scout`, `spec-scout`, `docs-gap-scout`, `memory-scout`, `flow-gap-analyst`) in parallel; they spawned, completed, and the skill drove `flowctl` to create the spec + tasks and validate — a full plan, start to finish. So Grok **dispatches flow-next's custom `subagent_type`s** even though `grok inspect` doesn't list them in its agent UI. (UI listing ≠ functionality — see below.)
-- **MCP servers** resolve (e.g. RepoPrompt, linear-server); `flowctl` resolves via the bundled `.flow/bin/flowctl` copy.
+- **Slash commands.** Drive with `/flow-next:<name>` or hyphenated `/flow-next-<name>` - **not** Codex `$flow-next-` syntax. Typing `/flow-next:plan` loads the `flow-next-plan` skill and runs its workflow.
+- **Multi-agent flows work - verified end-to-end.** A real `/flow-next:plan` run under Grok 0.2.27 **fanned out all seven scout subagents** (`repo-scout`, `practice-scout`, `docs-scout`, `spec-scout`, `docs-gap-scout`, `memory-scout`, `flow-gap-analyst`) in parallel; they spawned, completed, and the skill drove `flowctl` to create the spec + tasks and validate. Grok **dispatches flow-next's custom `subagent_type`s** even when `grok inspect` does not list them in its agent UI.
+- **MCP servers** resolve (e.g. RepoPrompt, linear-server); after setup, `flowctl` resolves via **`.flow/bin/flowctl`** (copy mode).
+- **Review menu includes `host`.** Setup offers `host` alongside `rp` / `codex` / `copilot` / `cursor` / `none`. **Single-family fail-closed:** Grok's only native model family is `grok-4.5`, so native `host` review fails closed (interactive → ask; autonomous → `NEEDS_HUMAN`) unless the writer is non-Grok. Cross-family review on Grok comes through bridge backends (`codex` / `cursor` / `copilot`), not a native multi-family subagent. Host-native model-routing scaffold lands in AGENTS.md and documents the same honesty.
 
-### Caveats (cosmetic, not functional)
+### Caveats / intentional limits
 
-- **Grok's UI under-lists flow-next's commands and agents — but both work when invoked.** `grok inspect` shows only Grok's 3 builtin agents (not flow-next's 22), and the slash *autocomplete* lists only the 6 skills with **no** `user-invocable` key (`flow-next`, `flow-next-deps`, `flow-next-drive`, `flow-next-export-context`, `flow-next-rp-explorer`, `flow-next-worktree-kit`). The 22 `user-invocable: false` skills + the 23 `commands/*.md` wrappers don't show in the menu, and the custom agents don't show in `inspect` — yet **the commands run when typed in full** (e.g. `/flow-next:plan`) and **the subagents dispatch** (verified above). flow-next marks skills `user-invocable: false` because the Claude Code entry point is the command wrapper; Grok's menu keys on that flag and its `inspect` summary just doesn't surface plugin agents. **Discoverability gap, not a functional one — type the command.**
-- **Ralph autonomous mode — not yet validated.** The verified run was interactive multi-agent work; Ralph's hook-gated `Stop`/`SubagentStop` loop hasn't been exercised under Grok. Hooks load and fire; the autonomous gating specifically is untested.
+- **Command discovery (fn-124).** The pre-3.3.1 tripled-name slash-menu bug (`/flow-next:flow-next:flow-next:qa`) was fixed by **fn-124** (command-shim flatten; shipped in **3.3.1**). Grok slash-command discovery is **expected-fixed** by that change. **LIVE validation in a real grok session is a pending NEEDS-HUMAN check** - do not treat CI or prose as proof that Grok's autocomplete menu lists every command.
+- **UI listing ≠ functionality.** `grok inspect` may under-list plugin agents; commands still run when typed in full and subagents still dispatch (verified above). Type the command if autocomplete is incomplete.
+- **Ralph is intentionally not built for Grok.** Same posture as Cursor - not a hook-schema gap and not "TBD validation." Setup never offers Ralph on `PLATFORM=grok`, never registers guard hooks, and never runs ralph-init from the ceremony. Interactive plan / work / review is the supported surface.
 
-> **Status (Grok 0.2.27 alpha):** skills load; `/flow-next:*` commands **run when typed**; MCP + `flowctl` resolve; and **multi-agent subagent dispatch works** — a full `/flow-next:plan` fanned out all seven scouts end-to-end. Caveat: Grok's autocomplete + `grok inspect` under-list flow-next's commands/agents (cosmetic — they work when invoked). Ralph is opt-in (project hooks) and still to validate under Grok.
+> **Status:** verified-compat host. Detection: `GROK_AGENT=1` only. Canonical Claude files AS-IS; both CLAUDE.md and AGENTS.md loaded; `/flow-next:` slash syntax; copy mode + `.flow/bin/flowctl`; review includes `host` with single-family fail-closed; no Ralph (intentional). Multi-agent scout fan-out verified. Slash-menu discovery expected-fixed by fn-124 (3.3.1); live grok-session confirmation is NEEDS-HUMAN. Nested Droid→Grok unsupported pending propagation smoke.
 
 ## Cursor
 

--- a/plugins/flow-next/docs/platforms.md
+++ b/plugins/flow-next/docs/platforms.md
@@ -224,11 +224,12 @@ Then run **`/flow-next:setup`** in the project (slash syntax - **not** `$flow-ne
 
 ### Caveats / intentional limits
 
-- **Command discovery (fn-124).** The pre-3.3.1 tripled-name slash-menu bug (`/flow-next:flow-next:flow-next:qa`) was fixed by **fn-124** (command-shim flatten; shipped in **3.3.1**). Grok slash-command discovery is **expected-fixed** by that change. **LIVE validation in a real grok session is a pending NEEDS-HUMAN check** - do not treat CI or prose as proof that Grok's autocomplete menu lists every command.
-- **UI listing ≠ functionality.** `grok inspect` may under-list plugin agents; commands still run when typed in full and subagents still dispatch (verified above). Type the command if autocomplete is incomplete.
+- **Command discovery (fn-124) - live-verified 2026-07-22.** The pre-3.3.1 tripled-name slash-menu bug (`/flow-next:flow-next:flow-next:qa`) is **fixed** by **fn-124** (command-shim flatten; shipped in **3.3.1**) - confirmed live in a real grok session: the autocomplete shows clean single-prefix names (`/flow-next-deps`, `/flow-next-drive`), no nesting.
+- **UI listing ≠ functionality (Grok limitation).** Grok's autocomplete **under-lists**: some commands (e.g. `/flow-next-plan`, `/flow-next-work`) do not appear in the menu even though they **run correctly when typed in full** (live-verified). The commands are registered fine; grok's autocomplete surfaces only a subset. This is a Grok UI limitation, not a flow-next defect - **type the command; it works.** (Same class as historical host autocomplete quirks.)
+- **Detection signal (live-verified 2026-07-22).** `GROK_AGENT=1` confirmed present in a STANDALONE grok session (`env \| grep GROK_AGENT` → `GROK_AGENT=1`, no other vars) - not an artifact of a launched-from-another-agent probe.
 - **Ralph is intentionally not built for Grok.** Same posture as Cursor - not a hook-schema gap and not "TBD validation." Setup never offers Ralph on `PLATFORM=grok`, never registers guard hooks, and never runs ralph-init from the ceremony. Interactive plan / work / review is the supported surface.
 
-> **Status:** verified-compat host. Detection: `GROK_AGENT=1` only. Canonical Claude files AS-IS; both CLAUDE.md and AGENTS.md loaded; `/flow-next:` slash syntax; copy mode + `.flow/bin/flowctl`; review includes `host` with single-family fail-closed; no Ralph (intentional). Multi-agent scout fan-out verified. Slash-menu discovery expected-fixed by fn-124 (3.3.1); live grok-session confirmation is NEEDS-HUMAN. Nested Droid→Grok unsupported pending propagation smoke.
+> **Status:** verified-compat host. Detection: `GROK_AGENT=1` only. Canonical Claude files AS-IS; both CLAUDE.md and AGENTS.md loaded; `/flow-next:` slash syntax; copy mode + `.flow/bin/flowctl`; review includes `host` with single-family fail-closed; no Ralph (intentional). Multi-agent scout fan-out verified. `GROK_AGENT=1` + no-nesting slash menu live-verified (2026-07-22); autocomplete under-lists some commands (they run when typed - Grok UI limitation). Nested Droid→Grok unsupported pending propagation smoke.
 
 ## Cursor
 

--- a/plugins/flow-next/skills/flow-next-impl-review/SKILL.md
+++ b/plugins/flow-next/skills/flow-next-impl-review/SKILL.md
@@ -94,9 +94,13 @@ When `RP_ELIGIBLE=0`, omit the **rp** line below from any guidance you surface (
 3. Model resolved via (first match wins): `--spec cursor:<model>` flag, per-task `review`, `FLOW_REVIEW_BACKEND` spec, `FLOW_CURSOR_MODEL` env var, registry default (`gpt-5.5-high`). **No effort** — Cursor bakes effort into the model name; `cursor:<model>:<effort>` is rejected
 4. Parse verdict from command output
 
-**For host backend (fn-123 R5):**
+**For host backend (fn-123 R5 / fn-126):**
 1. **DO NOT REVIEW CODE YOURSELF** — you coordinate; a fresh-context host-native subagent reviews (see [workflow-host.md](workflow-host.md))
-2. Dispatch a **read-only** reviewer subagent pinned to a **cross-family** model slug from AGENTS.md model-routing (Claude Code: native `model` param; Cursor: in-prompt slug pin; elsewhere: generic fresh-context reviewer with host-dependent note)
+2. Dispatch a **read-only** reviewer subagent pinned to a **cross-family** model slug from AGENTS.md model-routing:
+   - **Claude Code**: native `model` param + tool-enforced read-only
+   - **Cursor**: in-prompt slug pin + tool-enforced read-only
+   - **Grok**: in-prompt / host model pin + tool-enforced read-only; single-native-family (`grok-4.5`) fails closed unless the writer is non-Grok (cross-family via bridges); receipt `mode: "host"` + actual model + `session_id: null`
+   - **Elsewhere**: generic fresh-context reviewer with host-dependent note
 3. Record actual reviewer model + `"mode": "host"` in the receipt
 4. **Every re-review is a fresh subagent** — no context reuse, no fabricated resume ids
 5. **Fail closed on missing cross-family pin:** interactive → ask user explicitly; autonomous → `NEEDS_HUMAN` (never silent same-family self-review)

--- a/plugins/flow-next/skills/flow-next-impl-review/workflow-host.md
+++ b/plugins/flow-next/skills/flow-next-impl-review/workflow-host.md
@@ -30,6 +30,7 @@ Dispatch a **fresh** read-only reviewer subagent with the resolved pin:
 |------|------------|
 | Claude Code | Native subagent `model` param (existing reviewer-subagent arrangement); `disallowedTools: Edit, Write, Task` (or host read-only equivalent) |
 | Cursor | In-prompt slug pin on the subagent + TOOL-enforced read-only (dispatch via a `readonly: true` agent definition or Cursor's read-only subagent mode — never a mutation-capable subagent; the reviewer reads untrusted diff content, so read-only cannot be prompt-requested only) |
+| Grok | In-prompt / host model pin from AGENTS.md model-routing + TOOL-enforced read-only (never mutation-capable). Single-native-family (`grok-4.5`) — host review fails closed unless the writer is non-Grok; cross-family via bridge backends. Receipt: `mode: "host"`, actual reviewer model, `session_id: null` (same shape as Claude/Cursor) |
 | Codex | Fresh read-only reviewer subagent via the platform subagent primitive (`spawn_agent` on Codex) with the cross-family pin stated in the prompt; read-only via the platform sandbox |
 | Other | Generic fresh-context reviewer; note in the receipt that pin enforcement is host-dependent |
 

--- a/plugins/flow-next/skills/flow-next-plan-review/SKILL.md
+++ b/plugins/flow-next/skills/flow-next-plan-review/SKILL.md
@@ -122,11 +122,12 @@ When `RP_ELIGIBLE=0`, omit the **rp** line below from any guidance you surface (
 3. Model resolved via (first match wins): `--spec cursor:<model>` flag, per-spec `default_review`, `FLOW_REVIEW_BACKEND` spec, `FLOW_CURSOR_MODEL` env var, registry default (`gpt-5.5-high`). **No effort** — Cursor bakes effort into the model name; `cursor:<model>:<effort>` is rejected
 4. Parse verdict from command output
 
-**For host backend (fn-123 R5):**
+**For host backend (fn-123 R5 / fn-126):**
 1. **DO NOT REVIEW THE PLAN YOURSELF** — you coordinate; a fresh-context host-native subagent reviews
 2. Dispatch a **read-only** reviewer subagent pinned to a **cross-family** model slug (family that did not write the plan) from the AGENTS.md model-routing section:
-   - **Claude Code**: native subagent `model` param (existing reviewer-subagent arrangement)
-   - **Cursor**: in-prompt slug pin on the subagent (host honors Cursor slugs)
+   - **Claude Code**: native subagent `model` param (existing reviewer-subagent arrangement); `disallowedTools: Edit, Write, Task` (or host equivalent read-only)
+   - **Cursor**: in-prompt slug pin on the subagent (host honors Cursor slugs) AND tool-enforced read-only
+   - **Grok**: in-prompt / host model pin from AGENTS.md model-routing + tool-enforced read-only (Grok is single-native-family `grok-4.5` — host review fails closed unless the writer is non-Grok; cross-family via bridge backends). Receipt semantics identical to Claude/Cursor (`mode: "host"`, actual reviewer model, `session_id: null`)
    - **Other hosts**: generic fresh-context reviewer with an explicit note that the pin is best-effort / host-dependent
 3. Reuse the existing plan-review rubrics + prior-finding convergence context (same verdict grammar as other backends)
 4. Write receipt with actual reviewer model + `"mode": "host"` (shape compatible with existing convergence/cap/pilot/land consumers)
@@ -180,6 +181,7 @@ When `BACKEND="host"`, do **not** call any `flowctl <backend> plan-review` — t
 3. **Dispatch** a fresh read-only reviewer subagent with the pin:
    - Claude Code: `Task` / subagent with `model: <cross-family-slug>`, `disallowedTools: Edit, Write, Task` (or host equivalent read-only)
    - Cursor: subagent with the slug stated in the prompt (Cursor honors in-prompt model pins) AND `readonly: true` enforcement — dispatch via a read-only agent definition (the fn-123 R4 `readonly: true` agents) or Cursor's read-only subagent mode; never a mutation-capable subagent. The reviewer analyzes untrusted diff content — read-only must be TOOL-enforced, not prompt-requested
+   - Grok: subagent / fresh-context reviewer with the AGENTS.md pin stated in the prompt AND tool-enforced read-only (never mutation-capable). Grok is single-native-family (`grok-4.5`) — if the pin is same-family as the writer, fail closed (interactive ask / autonomous NEEDS_HUMAN); cross-family review on Grok prefers bridge backends. Receipt: `mode: "host"`, actual reviewer model, `session_id: null`
    - Codex: fresh read-only reviewer via the platform subagent primitive (`spawn_agent`) with the pin stated in the prompt; read-only via the platform sandbox
    - Elsewhere: fresh-context reviewer; note in the receipt that pin enforcement is host-dependent
 4. Give the subagent the plan-review rubric ([references/plan-review-prompt.md](references/plan-review-prompt.md)), the spec content, and any prior findings for convergence. Require the same verdict tags (`SHIP` / `NEEDS_WORK` / `MAJOR_RETHINK`).

--- a/plugins/flow-next/skills/flow-next-setup/workflow.md
+++ b/plugins/flow-next/skills/flow-next-setup/workflow.md
@@ -488,7 +488,7 @@ Available questions (include only if corresponding config is unset):
 }
 ```
 
-**When `PLATFORM` is NOT `cursor`** (Claude Code / Droid / Codex — unchanged; Grok uses the dedicated menu above):
+**When `PLATFORM` is neither `cursor` nor `grok`** (Claude Code / Droid / Codex — unchanged; Cursor and Grok each use their dedicated menu above):
 ```json
 {
   "header": "Review",

--- a/plugins/flow-next/skills/flow-next-setup/workflow.md
+++ b/plugins/flow-next/skills/flow-next-setup/workflow.md
@@ -34,6 +34,8 @@ elif [ -n "${CURSOR_AGENT:-}" ] \
        *) false ;; \
      esac; then
   PLATFORM="cursor"
+elif [ -n "${GROK_AGENT:-}" ]; then
+  PLATFORM="grok"
 else
   PLATFORM="codex"
 fi
@@ -45,13 +47,17 @@ fi
 
 **Positive path discriminator — `PLUGIN_ROOT` under `~/.cursor/` (never `codex/` absence).** The manifest + env checks alone are not enough when Codex runs from the **checked-in plugin source** inside a Cursor shell (Codex marketplace points at `./plugins/flow-next`, which carries `.cursor-plugin/`, `.codex-plugin/`, and the `codex/` mirror) — there the Cursor manifest is present in the workspace tree, so env+manifest would misfire. The positive signal is that a **real Cursor install** resolves `PLUGIN_ROOT` under `~/.cursor/` — local `install-cursor.sh`/`.ps1` → `~/.cursor/plugins/local/flow-next/`; team-marketplace repo-import → Cursor's marketplace plugin cache under `~/.cursor/` (and that cache **may contain `codex/`** because the whole plugin source is imported; explicit component paths in `.cursor-plugin/plugin.json` keep Cursor from loading the mirror as skills). A genuine Codex install resolves under `$CODEX_HOME` (default `~/.codex`); the shared source tree resolves to a workspace path. Neither is under `~/.cursor/`, so both correctly fall through to `codex` even with inherited `CURSOR_AGENT`. **Do not** key detection on the `codex/` directory being absent — that misclassifies marketplace repo-imports as Codex.
 
-**Matrix (detection fixtures):** (1) marketplace whole-repo import under `~/.cursor/` + may have `codex/` → `cursor`; (2) local `install-cursor` under `~/.cursor/plugins/local/` (no `codex/`) → `cursor`; (3) Codex under `$CODEX_HOME` / `~/.codex` with inherited `CURSOR_AGENT` → `codex`; (4) Claude (`CLAUDE_PLUGIN_ROOT`) / Droid (`DROID_PLUGIN_ROOT`) still win first — precedence unchanged.
+**Grok ordering matters (fn-126).** Grok Build (xAI's `grok` CLI) reads the canonical Claude plugin format AS-IS and drives with `/flow-next-*` / `/flow-next:` slash commands — not the Codex `$flow-next-` mirror. Without a positive signal it fell through to `else → codex` and setup wrote Codex-shaped `$flow-next-` snippets into AGENTS.md (dogfood 2026-07-22). **Probe-verified signal:** `GROK_AGENT=1` is set BY grok in its agent shell (absent from a plain-shell control on the same machine). **Rejected non-signals:** `~/.grok/` exists on the machine regardless (install dir), and `~/.grok/bin` on `PATH` is profile-level — neither distinguishes a grok session. The `GROK_AGENT` branch MUST come after Droid / Claude / Cursor (so a real Claude/Cursor/Droid host that merely inherited `GROK_AGENT` from a parent grok shell still classifies by its own higher-precedence signal) and BEFORE the `else → codex` fallback.
+
+**Known nesting edge (Droid → Grok) — NEEDS-HUMAN.** The probe disproved `CLAUDE_PLUGIN_ROOT` propagation into a grok child, so Claude-from-parent does not misfire. It did **not** disprove `DROID_PLUGIN_ROOT` propagation: if a grok child inherits `DROID_PLUGIN_ROOT` from a Droid parent shell, the cascade classifies as `droid` (higher precedence). Treat nested Droid→Grok as **unsupported pending a this-process-is-grok discriminator** unless a NEEDS-HUMAN smoke confirms `DROID_PLUGIN_ROOT` does not propagate. Claude/Cursor-from-grok remain correct via higher-precedence signals.
+
+**Matrix (detection fixtures):** (1) marketplace whole-repo import under `~/.cursor/` + may have `codex/` → `cursor`; (2) local `install-cursor` under `~/.cursor/plugins/local/` (no `codex/`) → `cursor`; (3) Codex under `$CODEX_HOME` / `~/.codex` with inherited `CURSOR_AGENT` → `codex`; (4) Claude (`CLAUDE_PLUGIN_ROOT`) / Droid (`DROID_PLUGIN_ROOT`) still win first — precedence unchanged; (5) standalone `GROK_AGENT=1` (no higher signal) → `grok`; (6) `GROK_AGENT=1` + `CLAUDE_PLUGIN_ROOT` / `CURSOR_AGENT`(+cursor install) / `DROID_PLUGIN_ROOT` → higher host wins; (7) plain shell (no host signal) → `codex`.
 
 Store `PLATFORM` for use in later steps. This determines:
 - Which manifest to read for version (`plugin.json`)
 - Which docs file to prefer (CLAUDE.md vs AGENTS.md)
 - Whether to copy Codex agents to project (hooks are **not** copied here — Ralph is opt-in via the Ralph question + `/flow-next:ralph-init`)
-- Which command-name syntax the docs snippet uses (`/flow-next:plan` for Claude Code / Droid / **Cursor**; `$flow-next-plan` for Codex)
+- Which command-name syntax the docs snippet uses (`/flow-next:plan` for Claude Code / Droid / **Cursor** / **Grok**; `$flow-next-plan` for Codex)
 
 ## Step 1: Initialize .flow/
 
@@ -77,6 +83,7 @@ Also read plugin version from the platform-specific manifest:
 - Claude Code: `${PLUGIN_ROOT}/.claude-plugin/plugin.json`
 - Factory Droid: `${PLUGIN_ROOT}/.claude-plugin/plugin.json` (Droid's interop layer reads the Claude Code manifest directly for Claude-first plugins like flow-next)
 - Cursor: `${PLUGIN_ROOT}/.cursor-plugin/plugin.json`
+- Grok: `${PLUGIN_ROOT}/.claude-plugin/plugin.json` (Grok reads the canonical Claude plugin format AS-IS — no separate Grok manifest)
 
 Check whichever matches `PLATFORM`. Fall back to `.claude-plugin/plugin.json` if the platform-specific file doesn't exist.
 
@@ -96,7 +103,7 @@ Two install modes exist. **Copy mode** (the only mode before fn-121, and the onl
 CURRENT_MODE=$(jq -r '.setup_mode // empty' .flow/meta.json 2>/dev/null)
 ```
 
-**If `PLATFORM` is not `claude-code`:** plugin mode is Claude-Code-only (Cursor exposes no plugin-root env vars and no bin PATH injection; Codex resolves `$HOME/.codex/scripts/flowctl`; Droid's bin support is unverified) — never OFFER it on these hosts. But never silently CONVERT either (PR #227 review): when `CURRENT_MODE` is `plugin` (a Claude-Code-managed repo visited from this host), ask via `AskUserQuestion` (sync-codex.sh carries an equivalent guard in the mirror): `Keep plugin mode` — skip Step 3, Step 4's copies, and the Step 7c stamp entirely (set `MODE=plugin-kept`; config/ceremony steps still run, and the Docs step may target AGENTS.md only — CLAUDE.md's FLOW-NEXT block is the Claude-Code-managed rail and is NEVER touched in kept mode, PR #227 review: writing the copy-mode snippet there would destroy the sentinel while the plugin stamp stands) — or `Convert to copy mode` — proceed as copy (writes the snapshots; Step 7c stamps copy). Recommend per host (PR #227 review): on Codex/Droid recommend Keep (Codex skills self-resolve flowctl from `$HOME/.codex/scripts/`; Droid reads the plugin root envs) — on Cursor recommend CONVERT and say why: Cursor exposes no plugin-root env vars, so with no `.flow/bin` the skill preambles cannot resolve flowctl and flow-next skills will not function on this host until the repo has copies. When `CURRENT_MODE` is anything else, set `MODE=copy` silently and continue to Step 3.
+**If `PLATFORM` is not `claude-code`:** plugin mode is Claude-Code-only (Cursor exposes no plugin-root env vars and no bin PATH injection; Grok likewise has no plugin-root bin PATH injection; Codex resolves `$HOME/.codex/scripts/flowctl`; Droid's bin support is unverified) — never OFFER it on these hosts. But never silently CONVERT either (PR #227 review): when `CURRENT_MODE` is `plugin` (a Claude-Code-managed repo visited from this host), ask via `AskUserQuestion` (sync-codex.sh carries an equivalent guard in the mirror): `Keep plugin mode` — skip Step 3, Step 4's copies, and the Step 7c stamp entirely (set `MODE=plugin-kept`; config/ceremony steps still run, and the Docs step may target AGENTS.md only — CLAUDE.md's FLOW-NEXT block is the Claude-Code-managed rail and is NEVER touched in kept mode, PR #227 review: writing the copy-mode snippet there would destroy the sentinel while the plugin stamp stands) — or `Convert to copy mode` — proceed as copy (writes the snapshots; Step 7c stamps copy). Recommend per host (PR #227 review): on Codex/Droid recommend Keep (Codex skills self-resolve flowctl from `$HOME/.codex/scripts/`; Droid reads the plugin root envs) — on Cursor **and Grok** recommend CONVERT and say why: neither exposes plugin-root env vars / bin PATH injection, so with no `.flow/bin` the skill preambles cannot resolve flowctl and flow-next skills will not function on this host until the repo has copies. When `CURRENT_MODE` is anything else, set `MODE=copy` silently and continue to Step 3.
 
 **If `PLATFORM=claude-code` and `CURRENT_MODE` is empty (first mode decision):** ask via `AskUserQuestion` (sync-codex.sh rewrites this to a plain-text numbered prompt for the Codex mirror — unreachable in practice, since this branch requires `PLATFORM=claude-code`):
 
@@ -238,7 +245,7 @@ Then handle `.flow/usage.md` — preserve any repo-customized variant:
 
 ## Step 4b: Codex-specific project setup (PLATFORM=codex only)
 
-**Skip this step entirely if PLATFORM is not `codex`.** (Claude Code / Droid / Cursor all skip it — Cursor drives the workflow with `/flow-next:*` slash commands and resolves `flowctl` via `.flow/bin/flowctl`, not project-scoped `.codex/` agents.)
+**Skip this step entirely if PLATFORM is not `codex`.** (Claude Code / Droid / Cursor / Grok all skip it — Cursor and Grok drive the workflow with `/flow-next:*` slash commands and resolve `flowctl` via `.flow/bin/flowctl`, not project-scoped `.codex/` agents. Grok never copies `.codex/agents`.)
 
 On Codex, agents live in project-scoped `.codex/` directories (not in the plugin cache). Copy them. **Do not copy or enable Ralph hooks here** — hooks are opt-in via the Ralph question (Step 6d, always asked) and `/flow-next:ralph-init` registration prose.
 
@@ -287,11 +294,12 @@ HAVE_CURSOR=$(which cursor-agent >/dev/null 2>&1 && echo 1 || echo 0)
 HAVE_GROK=$(which grok >/dev/null 2>&1 && echo 1 || echo 0)
 
 # fn-97: at least one bridge CLI on PATH gates the Model Routing question in 6d
-# on non-Cursor hosts (with zero bridges every wiring route in the scaffold
+# on non-host-native hosts (with zero bridges every wiring route in the scaffold
 # would be an inert install-note comment, so the question is not offered —
 # install a bridge CLI and re-run /flow-next:setup to get it).
-# fn-123 R6: PLATFORM=cursor is the exception — host-native AGENTS.md pins need
-# no external bridge CLI, so Model Routing is still offered when ROUTING_ASK=1.
+# fn-123 R6 / fn-126: PLATFORM=cursor or PLATFORM=grok is the exception —
+# host-native AGENTS.md pins need no external bridge CLI, so Model Routing is
+# still offered when ROUTING_ASK=1.
 BRIDGE_DETECTED=0
 if [[ "$HAVE_CODEX" == "1" || "$HAVE_CURSOR" == "1" || "$HAVE_GROK" == "1" ]]; then
   BRIDGE_DETECTED=1
@@ -320,13 +328,13 @@ CURRENT_GITHUB_SCOUT=$("${PLUGIN_ROOT}/scripts/flowctl" config get scouts.github
 CURRENT_HTML_ARTIFACTS=$("${PLUGIN_ROOT}/scripts/flowctl" config get artifacts.html.enabled --raw --json 2>/dev/null | jq -r 'if .value == null then "" else (.value | tostring) end')
 
 # Optional model-routing scaffold ceremony (Step 6d question + Step 7 processing)
-# is offered ONLY in an interactive setup. On non-Cursor hosts also require a
-# bridge CLI (BRIDGE_DETECTED=1, fn-97). On PLATFORM=cursor offer when interactive
-# regardless of bridges (fn-123 R6 host-native pins). Under ANY non-interactive /
-# autonomous marker, the question is skipped SILENTLY — setup must never block a
-# headless driver. Scan the WHOLE autonomy-marker family (Ralph / receipt-path /
-# autonomous / mode token), not a fixed pair — the same family every lifecycle
-# skill honors.
+# is offered ONLY in an interactive setup. On non-host-native hosts also require a
+# bridge CLI (BRIDGE_DETECTED=1, fn-97). On PLATFORM=cursor or PLATFORM=grok offer
+# when interactive regardless of bridges (fn-123 R6 / fn-126 host-native pins).
+# Under ANY non-interactive / autonomous marker, the question is skipped SILENTLY
+# — setup must never block a headless driver. Scan the WHOLE autonomy-marker
+# family (Ralph / receipt-path / autonomous / mode token), not a fixed pair —
+# the same family every lifecycle skill honors.
 ROUTING_ASK=1
 if [[ "${FLOW_RALPH:-}" == "1" || -n "${REVIEW_RECEIPT_PATH:-}" \
       || "${FLOW_AUTONOMOUS:-}" == "1" || "${ARGUMENTS:-}" == *mode:autonomous* ]]; then
@@ -341,7 +349,7 @@ Store detection results for use in questions. When showing options, indicate cur
 Choose the correct template based on platform AND mode:
 - **Codex** (`PLATFORM=codex`): read [templates/agents-md-snippet.md](templates/agents-md-snippet.md) — uses `$flow-next-plan` syntax
 - **Claude Code in plugin mode** (`MODE=plugin`): read [templates/claude-md-snippet-plugin.md](templates/claude-md-snippet-plugin.md) — bare `flowctl` (plugin-bin PATH), `flowctl usage` pull directives, internal `<!-- flow-next:snippet:vN -->` sentinel. CLAUDE.md is the REQUIRED target (the rail's guarantee is CLAUDE.md's every-turn presence); AGENTS.md is an optional secondary.
-- **Claude Code (copy mode) / Droid / Cursor**: read [templates/claude-md-snippet.md](templates/claude-md-snippet.md) — uses `/flow-next:plan` syntax (Cursor runs the same slash commands; on Cursor the snippet lands in AGENTS.md, which Cursor reads)
+- **Claude Code (copy mode) / Droid / Cursor / Grok**: read [templates/claude-md-snippet.md](templates/claude-md-snippet.md) — uses `/flow-next:plan` slash syntax (Cursor runs the same slash commands; on Cursor the snippet lands in AGENTS.md. Grok drives with `/flow-next-` slash commands and reads BOTH CLAUDE.md and AGENTS.md — lifecycle snippet targets CLAUDE.md by default; a pre-existing wrong Codex `$flow-next-` marker block is consent-refreshed to the slash form, marker-scoped)
 
 For each of CLAUDE.md and AGENTS.md:
 1. Check if file exists
@@ -373,7 +381,7 @@ Only include lines for config values that are set. If no config is set, skip thi
 
 Build the questions array dynamically. **Only include questions for config values that are NOT already set** — existing config is preserved, never overwritten. To change an already-set value, the user runs `flowctl config set <key> <value>` directly (the commands are surfaced in 6c's current-config notice).
 
-Skipped questions = config values already persisted from a prior run. Asking again would either no-op (same answer) or silently flip a deliberate user choice — both are wrong. The grouped single-prompt design (a single `AskUserQuestion` call below, with one questions array containing only the unset entries) means a re-run with all config set produces zero config questions and asks only the always-include Docs + Ralph (except `PLATFORM=cursor`) + Star questions (plus the interactive-only Model Routing scaffold question, when `ROUTING_ASK=1` and the platform/bridge gate passes).
+Skipped questions = config values already persisted from a prior run. Asking again would either no-op (same answer) or silently flip a deliberate user choice — both are wrong. The grouped single-prompt design (a single `AskUserQuestion` call below, with one questions array containing only the unset entries) means a re-run with all config set produces zero config questions and asks only the always-include Docs + Ralph (except `PLATFORM=cursor` / `PLATFORM=grok`) + Star questions (plus the interactive-only Model Routing scaffold question, when `ROUTING_ASK=1` and the platform/bridge gate passes).
 
 Available questions (include only if corresponding config is unset):
 
@@ -463,7 +471,24 @@ Available questions (include only if corresponding config is unset):
 }
 ```
 
-**When `PLATFORM` is NOT `cursor`** (Claude Code / Droid / Codex — unchanged):
+**When `PLATFORM=grok`** (fn-126) — offer `host` with the fail-closed cross-family caveat (Grok is single-native-family `grok-4.5`) plus every external backend; when `HAVE_CODEX=1` mark Codex Recommended (true cross-family vs a Grok writer):
+```json
+{
+  "header": "Review",
+  "question": "Which review backend? Plans and implementations get reviewed before they land. Grok's only native model family is grok-4.5 — host-native review fails closed unless the writer is non-Grok; cross-family review comes via bridge backends (codex/cursor/copilot). Guide: https://flow-next.dev/review/workflow/",
+  "options": [
+    {"label": "Host", "description": "Fresh-context host-native subagent; pin from AGENTS.md model-routing (setup scaffolds). Fail-closed: Grok is single-native-family (grok-4.5) — native host review refuses same-family self-review (interactive → ask; autonomous → NEEDS_HUMAN) unless the writer is non-Grok. Cross-family via bridges."},
+    {"label": "Codex CLI", "description": "OpenAI's codex CLI, reviews on its top reasoning tier (GPT family). Cross-platform, simple setup. <detected if HAVE_CODEX=1, (not detected) if HAVE_CODEX=0>"},
+    {"label": "Copilot CLI", "description": "Routes to Claude- or GPT-family reviewers via your GitHub Copilot plan. Requires gh copilot auth. <detected if HAVE_COPILOT=1, (not detected) if HAVE_COPILOT=0>"},
+    {"label": "Cursor CLI", "description": "Runs cursor-agent with a multi-family model menu (pick the family that did not write the diff). Billed to your Cursor subscription. <detected if HAVE_CURSOR=1, (not detected) if HAVE_CURSOR=0>"},
+    {"label": "RepoPrompt", "description": "macOS only. Auto-discovers git diffs + context, reviews scoped to actual changes, far fewer tokens than full-repo approaches. <detected if HAVE_RP=1, (not detected) if HAVE_RP=0>"},
+    {"label": "None", "description": "Skip AI reviews for now. Set later with flowctl config set review.backend <name>, or per-run via --review"}
+  ],
+  "multiSelect": false
+}
+```
+
+**When `PLATFORM` is NOT `cursor`** (Claude Code / Droid / Codex — unchanged; Grok uses the dedicated menu above):
 ```json
 {
   "header": "Review",
@@ -479,17 +504,18 @@ Available questions (include only if corresponding config is unset):
 }
 ```
 
-When `HAVE_CODEX=1` AND `PLATFORM` is NOT `codex` AND `PLATFORM` is NOT `cursor`, append ` (Recommended - cross-family default)` to the `Codex CLI` label: the recommended multi-model pipeline reviews cross-family FROM THE WRITER, and on a Claude Code / Droid host codex review is a different family than the session writer - so this question carries the ceremony's `review.backend codex` offer while the key is unset (fn-97). On `PLATFORM=cursor` do NOT add the Codex Recommended label — `Host (Recommended)` already leads. On a Codex host (`PLATFORM=codex`) do NOT add the label: the writer is GPT-family (the session model, or the optional terra worker pin), so codex review would be SAME-family - prefer a detected non-GPT backend there (copilot / cursor with a Claude-family model) and leave the options unannotated when none is detected. When `review.backend` is ALREADY set to something else, this question is skipped (existing config is never silently overwritten) - the offer instead rides the Model Routing scaffold as an explicit opt-in switch, Step 7's step 8 below.
+When `HAVE_CODEX=1` AND `PLATFORM` is NOT `codex` AND `PLATFORM` is NOT `cursor`, append ` (Recommended - cross-family default)` to the `Codex CLI` label: the recommended multi-model pipeline reviews cross-family FROM THE WRITER, and on a Claude Code / Droid / Grok host codex review is a different family than the session writer - so this question carries the ceremony's `review.backend codex` offer while the key is unset (fn-97). On `PLATFORM=cursor` do NOT add the Codex Recommended label — `Host (Recommended)` already leads. On a Codex host (`PLATFORM=codex`) do NOT add the label: the writer is GPT-family (the session model, or the optional terra worker pin), so codex review would be SAME-family - prefer a detected non-GPT backend there (copilot / cursor with a Claude-family model) and leave the options unannotated when none is detected. When `review.backend` is ALREADY set to something else, this question is skipped (existing config is never silently overwritten) - the offer instead rides the Model Routing scaffold as an explicit opt-in switch, Step 7's step 8 below.
 
 Stored value is a bare backend name by default (`host` / `codex` / `copilot` / `cursor` / `rp` / `none`). Power users can also write a full spec like `codex:gpt-5.4:high`, `copilot:claude-opus-4.5:xhigh`, or `cursor:gpt-5.5-high` (cursor takes a model only — no `:effort`) via `flowctl config set review.backend <spec>` after setup — the review commands accept both forms. Backend `host` is bare only (no `host:<model>` — pins live in the AGENTS.md model-routing section).
 
-**Model Routing question** — include when `ROUTING_ASK=1` AND (`BRIDGE_DETECTED=1` OR `PLATFORM=cursor`):
-- **Non-Cursor:** require `ROUTING_ASK=1` AND `BRIDGE_DETECTED=1` — interactive setup with at least one bridge CLI (`codex` / `cursor-agent` / `grok`) detected per 6a; skipped silently under any non-interactive/autonomous marker, and skipped without a detected bridge CLI — the scaffold's wiring routes would all be inert install notes (fn-97).
+**Model Routing question** — include when `ROUTING_ASK=1` AND (`BRIDGE_DETECTED=1` OR `PLATFORM=cursor` OR `PLATFORM=grok`):
+- **Non-host-native** (not cursor, not grok): require `ROUTING_ASK=1` AND `BRIDGE_DETECTED=1` — interactive setup with at least one bridge CLI (`codex` / `cursor-agent` / `grok`) detected per 6a; skipped silently under any non-interactive/autonomous marker, and skipped without a detected bridge CLI — the scaffold's wiring routes would all be inert install notes (fn-97).
 - **Cursor (`PLATFORM=cursor`):** offer when `ROUTING_ASK=1` even with zero bridge CLIs — host-native AGENTS.md pins use Cursor subagent model slugs, not external bridges (fn-123 R6).
+- **Grok (`PLATFORM=grok`):** offer when `ROUTING_ASK=1` even with zero bridge CLIs — host-native AGENTS.md pins enumerate Grok's available models at setup (fn-126); single-native-family so host-review pin is TODO/fail-closed unless a cross-family bridge is also available.
 
 Offers the recommended multi-model pipeline scaffold (composed + written in Step 7). The frozen option set is `Scaffold` / `Scaffold + enable codex delegation` / `Skip`; **include the `Scaffold + enable codex delegation` option ONLY when `HAVE_CODEX=1`** (drop that one object entirely when `HAVE_CODEX=0` — never show a delegation route to a missing binary).
 
-**Non-Cursor question body** (bridge-wired scores table):
+**Non-host-native question body** (bridge-wired scores table; Claude Code / Droid / Codex):
 ```json
 {
   "header": "Model Routing",
@@ -510,6 +536,20 @@ Offers the recommended multi-model pipeline scaffold (composed + written in Step
   "question": "Scaffold host-native model routing into AGENTS.md? Enumerates real Cursor model slugs available on this host, then pins a cheap slug for read-only scouts and a cross-family slug for host review (everything else inherits the session model). Date-stamped; re-run setup to refresh volatile ids. Shown in FULL before writing. Background: https://flow-next.dev/orchestration/",
   "options": [
     {"label": "Scaffold", "description": "Write the Cursor host-native model-routing section into AGENTS.md (or the Docs target). Host agent enumerates slugs and picks the pins — never Python."},
+    {"label": "Scaffold + enable codex delegation", "description": "Also set work.delegate=codex so /flow-next:work can offload bulk implementation to the codex CLI. First-use consent is still required — this never pre-approves it. INCLUDE THIS OPTION ONLY WHEN HAVE_CODEX=1."},
+    {"label": "Skip", "description": "Don't scaffold a routing section (default). Re-run /flow-next:setup later to add it."}
+  ],
+  "multiSelect": false
+}
+```
+
+**Grok question body** (`PLATFORM=grok` — host-native model pins; no bridge CLI required; single-native-family caveat):
+```json
+{
+  "header": "Model Routing",
+  "question": "Scaffold host-native model routing into AGENTS.md? Enumerates Grok's available models at setup (typically grok-4.5 only — single native family), pins a scout slug, and documents that host review fails closed for same-family writers unless a cross-family bridge pin is available. Date-stamped; re-run setup to refresh. Shown in FULL before writing. Background: https://flow-next.dev/orchestration/",
+  "options": [
+    {"label": "Scaffold", "description": "Write the Grok host-native model-routing section into AGENTS.md (host-review reads this; lifecycle docs may live in CLAUDE.md — Grok loads both). Host agent enumerates models and picks the pins — never Python."},
     {"label": "Scaffold + enable codex delegation", "description": "Also set work.delegate=codex so /flow-next:work can offload bulk implementation to the codex CLI. First-use consent is still required — this never pre-approves it. INCLUDE THIS OPTION ONLY WHEN HAVE_CODEX=1."},
     {"label": "Skip", "description": "Don't scaffold a routing section (default). Re-run /flow-next:setup later to add it."}
   ],
@@ -579,7 +619,22 @@ For **Cursor** (`PLATFORM=cursor`) — Cursor reads AGENTS.md, so recommend it (
 }
 ```
 
-**Ralph question** — **skip entirely when `PLATFORM=cursor`** (fn-123: no Ralph support on Cursor; never offer, never register hooks, never run `/flow-next:ralph-init` from this ceremony). On Cursor set `RALPH_OUTCOME="off (unsupported on Cursor)"` and do not include the question. On every other platform: always include (fresh setup AND re-run). Ralph is fully opt-in: default install ships zero hooks. Detect whether the project already has a Ralph surface (`scripts/ralph/` present, or any settings file with a hook command containing `scripts/ralph/hooks/ralph-guard`) and adjust the question wording (enable vs keep). **Default is No.**
+For **Grok** (`PLATFORM=grok`) — Grok reads BOTH CLAUDE.md and AGENTS.md; lifecycle snippet defaults to CLAUDE.md (canonical Claude-format target, `/flow-next:` slash syntax — NOT the Codex `$flow-next-` one). A pre-existing wrong Codex `$flow-next-` marker block is consent-refreshed to the slash form (marker-scoped; text outside markers untouched). Model-routing block still targets AGENTS.md (where host-review workflows read it):
+```json
+{
+  "header": "Docs",
+  "question": "Update project documentation with Flow-Next instructions? Adds a marker-bounded section teaching any agent that opens this repo how to track work via flowctl; your text outside the markers is never touched. Grok loads both CLAUDE.md and AGENTS.md.",
+  "options": [
+    {"label": "CLAUDE.md only (Recommended)", "description": "Add flow-next section to CLAUDE.md (canonical Grok lifecycle target; /flow-next: slash syntax)"},
+    {"label": "AGENTS.md only", "description": "Add flow-next section to AGENTS.md"},
+    {"label": "Both", "description": "Add flow-next section to both files (recommended when you also want the model-routing block's sibling lifecycle snippet nearby)"},
+    {"label": "Skip", "description": "Don't update documentation"}
+  ],
+  "multiSelect": false
+}
+```
+
+**Ralph question** — **skip entirely when `PLATFORM=cursor` or `PLATFORM=grok`** (fn-123 / fn-126: no Ralph support on Cursor or Grok; never offer, never register hooks, never run `/flow-next:ralph-init` from this ceremony). On Cursor set `RALPH_OUTCOME="off (unsupported on Cursor)"`; on Grok set `RALPH_OUTCOME="off (unsupported on Grok)"`; do not include the question. On every other platform: always include (fresh setup AND re-run). Ralph is fully opt-in: default install ships zero hooks. Detect whether the project already has a Ralph surface (`scripts/ralph/` present, or any settings file with a hook command containing `scripts/ralph/hooks/ralph-guard`) and adjust the question wording (enable vs keep). **Default is No.**
 
 ```json
 {
@@ -807,9 +862,9 @@ esac
 
 Use the correct template based on **target file** and **platform**:
 - AGENTS.md on **Codex**: use [templates/agents-md-snippet.md](templates/agents-md-snippet.md) (uses `$flow-next-plan` syntax)
-- AGENTS.md on **Claude Code (copy mode) / Droid / Cursor**: use [templates/claude-md-snippet.md](templates/claude-md-snippet.md) (uses `/flow-next:plan` syntax — Cursor runs the slash commands, so its AGENTS.md must carry the `/flow-next:` snippet, NOT the Codex `$flow-next-` one)
+- AGENTS.md on **Claude Code (copy mode) / Droid / Cursor / Grok**: use [templates/claude-md-snippet.md](templates/claude-md-snippet.md) (uses `/flow-next:plan` slash syntax — Cursor and Grok run the slash commands, so their AGENTS.md must carry the `/flow-next:` snippet, NOT the Codex `$flow-next-` one; a wrong Codex `$` block is consent-refreshed marker-scoped)
 - CLAUDE.md on **Claude Code in plugin mode** (`MODE=plugin`): use [templates/claude-md-snippet-plugin.md](templates/claude-md-snippet-plugin.md) — the slim rail with the `<!-- flow-next:snippet:v1 -->` sentinel that `flowctl setup-mode set plugin` (Step 7c) verifies; writing the regular snippet here would make the plugin stamp refuse. AGENTS.md as an optional plugin-mode secondary gets the same plugin template.
-- CLAUDE.md (any platform, copy mode): use [templates/claude-md-snippet.md](templates/claude-md-snippet.md)
+- CLAUDE.md (any platform, copy mode — including Grok's default lifecycle target): use [templates/claude-md-snippet.md](templates/claude-md-snippet.md)
 
 **Resolve the target file set:** an explicit Docs-question answer is authoritative - if the user is asked and selects specific files (or declines one), honor exactly that; never touch a file the user just deselected. The one addition is a backfill for the SKIPPED case: when the Docs question is omitted entirely because the block is already current (per the Note above), still run `apply` on each already-marker-bearing file. Rationale (R8): a current-but-hashless block (written by a pre-hash plugin version) would otherwise never reach `apply`, so its pristine hash never gets backfilled and the NEXT template change wrongly prompts "Overwrite customized?". `apply` on a current block is cheap and idempotent - it returns `unchanged` and records the missing hash. So: resolve targets = files chosen by the Docs question when it was asked; OR, when the Docs question was skipped, the files already carrying the `<!-- BEGIN FLOW-NEXT -->` marker. Run the helper once per resolved file.
 
@@ -837,7 +892,7 @@ For each resolved file (CLAUDE.md and/or AGENTS.md) - the block mechanics (marke
 
 The marker-block boundaries are load-bearing: pre-existing prose outside `<!-- BEGIN FLOW-NEXT -->` … `<!-- END FLOW-NEXT -->` is **never** modified by this step, and only the flowctl helper performs writes. Only the bytes between (and including) those markers are candidates for replacement.
 
-**Model Routing scaffold** (only if the Model Routing question was asked — i.e. `ROUTING_ASK=1` AND (`BRIDGE_DETECTED=1` OR `PLATFORM=cursor`); when the question was never shown, this step is a silent no-op — record `not offered` for the summary and skip to Star). Keep the non-Cursor gate string load-bearing for bridge hosts: non-Cursor still requires `ROUTING_ASK=1` AND `BRIDGE_DETECTED=1`.
+**Model Routing scaffold** (only if the Model Routing question was asked — i.e. `ROUTING_ASK=1` AND (`BRIDGE_DETECTED=1` OR `PLATFORM=cursor` OR `PLATFORM=grok`); when the question was never shown, this step is a silent no-op — record `not offered` for the summary and skip to Star). Keep the non-host-native gate string load-bearing for bridge hosts: non-cursor/non-grok still requires `ROUTING_ASK=1` AND `BRIDGE_DETECTED=1`.
 
 Run this **after** the Docs block above and **before** Star. It may touch the **same** file the Docs block just wrote this run — always **re-read the target from disk here**; never reuse an in-memory copy and never interleave the two writes. Set `ROUTING_OUTCOME=""` for the Step 8 summary and update it at each terminal branch below. Every "done with the block pipeline" terminal below still falls through to **step 7 (delegation)** — the delegation opt-in is independent of whether the block was written — then on to Star.
 
@@ -889,14 +944,59 @@ _Scaffolded by `/flow-next:setup` on Cursor (<YYYY-MM-DD>). Model ids are volati
 
 **C4. Target + write** — the model-routing block ALWAYS targets AGENTS.md on Cursor, regardless of the Docs answer or where existing markers live (the host-review workflows resolve the cross-family pin from AGENTS.md model-routing, and Cursor reads AGENTS.md — a block scaffolded only into CLAUDE.md would leave `review.backend host` failing closed despite a completed scaffold). When the Docs choice also selected CLAUDE.md, write the block to BOTH files (AGENTS.md is the load-bearing copy). Apply the shim guard. Then the same marker/byte-compare/read-back/write discipline as steps 4–6 (identical, Keep mine / Overwrite / skip; never silent write). On write, print: `Model-routing section written to <file> — Cursor host-native pins; re-run /flow-next:setup to refresh volatile ids.` Set `ROUTING_OUTCOME` accordingly. Then run **step 7 (delegation)** if the answer included codex delegation, skip step 8's codex review-backend switch entirely on `PLATFORM=cursor` regardless of `CURRENT_BACKEND` (Host is the Cursor recommended default and the Codex-switch offer contradicts the Host-first / cursor-CLI-is-circular policy; if the user wants a different backend they pick it in the review-backend question, never via this offer), and continue to Ralph/Star.
 
-##### Non-Cursor bridge path (Claude Code / Droid / Codex — unchanged)
+##### Grok host-native path (`PLATFORM=grok` only — fn-126)
 
-For non-Cursor platforms, run the block pipeline (step 1 once, then steps 2–6 **per resolved target file** — see the per-file loop below), then always run step 7 once:
+When `PLATFORM=grok`, do **not** use the bridge-probe template transform below. Compose a host-native AGENTS.md block from enumerated Grok models. **The HOST AGENT picks the pins — never Python / never flowctl ranking.** Grok is **single-native-family** (`grok-4.5` is the only native family per `grok models` / equivalent) — native host review fails closed for a Grok writer unless a cross-family bridge pin is available; document that honesty in the block.
+
+**G1. Enumerate available Grok models** (in order; first success wins):
+1. Host agent catalogs its own available models (session model list / host knowledge — typically `grok-4.5` only).
+2. Fallback: if `HAVE_GROK=1`, run `grok models` (or the host's equivalent model-list command; foreground, short timeout; capture up to ~50 lines).
+3. If both fail, still scaffold listing `grok-4.5` with a note that ids could not be live-enumerated — user edits later; re-run setup to refresh.
+
+**G2. HOST AGENT picks pins** from the enumerated set (judgment, not a fixed table):
+- `SCOUT_PIN` — cheapest / fastest suitable slug for **read-only scouts** (on single-family Grok this is typically `grok-4.5`).
+- `REVIEW_PIN` — strongest acceptable slug from a **different family than the session/writer** for **host review** (`review.backend host`). **On single-family Grok this pin is almost always unavailable natively** — leave `REVIEW_PIN` as an explicit TODO (or a bridge-model note) and state that host review fails closed (interactive → ask; autonomous → NEEDS_HUMAN) unless the writer is non-Grok or a bridge backend is used for review. Never invent a fake cross-family native slug.
+
+**G3. Compose the block** (verbatim structure; substitute today's ISO date, the enumerated list, and the pins). Markers and provenance are load-bearing:
+
+```markdown
+<!-- flow-next:model-routing:start -->
+## Picking models for flow-next workflows and subagents
+
+_Scaffolded by `/flow-next:setup` on Grok (<YYYY-MM-DD>). Grok is single-native-family (grok-4.5); model ids may change — re-run setup to refresh. Edit freely; this section is yours now._
+
+### Available models (enumerated at setup)
+
+- <bullet list of enumerated Grok models — typically just grok-4.5>
+
+### Dispatch pins (host agent picked)
+
+| role | pin | rule |
+|------|-----|------|
+| read-only scouts | `<SCOUT_PIN>` | cheap / fast |
+| host review | `<REVIEW_PIN or TODO>` | cross-family vs the writer — fails closed on same-family Grok |
+| everything else | inherit | session model |
+
+### Routing rules
+
+- Read-only scouts (repo-scout, context-scout, and any read-only Explore-class subagent): pin `<SCOUT_PIN>` (cheap).
+- Host review (`review.backend host`): pin `<REVIEW_PIN>` only when it is a **different family than the writer**. Grok's only native family is grok — native host review **fails closed** for a Grok writer (interactive → ask for a bridge/replacement pin; autonomous → NEEDS_HUMAN). Cross-family review on Grok comes through bridge backends (`codex` / `cursor` / `copilot`), not a native multi-family subagent.
+- Implementation, plan, judgment, and all other work: **inherit** the session model unless the user pins otherwise.
+- Reviews prefer a different family than the writer — uncorrelated blind spots.
+- Graceful degrade: unavailable slug → fall back to the session model; never block. **EXCEPTION — host review:** the `REVIEW_PIN` never degrades to the session model (that would silently turn the required cross-family review into same-family self-review). If the pin is unavailable, host review fails closed. Re-run `/flow-next:setup` to refresh the pin.
+<!-- flow-next:model-routing:end -->
+```
+
+**G4. Target + write** — the model-routing block ALWAYS targets **AGENTS.md** on Grok (where host-review workflows resolve the cross-family pin), even though the lifecycle docs snippet defaults to **CLAUDE.md** — Grok loads BOTH instruction files (probe-verified 2026-07-22), so the pin resolves either way; AGENTS.md is the load-bearing copy for host-review consistency with Cursor. When the Docs choice also selected CLAUDE.md (or Both), write the routing block to AGENTS.md always; optionally also to CLAUDE.md when Docs selected it. Apply the shim guard. Then the same marker/byte-compare/read-back/write discipline as steps 4–6 (identical, Keep mine / Overwrite / skip; never silent write). On write, print: `Model-routing section written to <file> — Grok host-native pins (single-family fail-closed for host review); re-run /flow-next:setup to refresh.` Set `ROUTING_OUTCOME` accordingly. Then run **step 7 (delegation)** if the answer included codex delegation. On `PLATFORM=grok`, step 8's codex review-backend switch MAY still run when `HAVE_CODEX=1` and `CURRENT_BACKEND` is non-empty and not already codex (unlike Cursor — on Grok, Codex is the real cross-family default when available). Continue to Ralph/Star.
+
+##### Non-host-native bridge path (Claude Code / Droid / Codex — unchanged)
+
+For platforms that are neither cursor nor grok, run the block pipeline (step 1 once, then steps 2–6 **per resolved target file** — see the per-file loop below), then always run step 7 once:
 
 **1. Resolve target file(s)** via this deterministic ladder (independent of whether the Docs question fired — evaluate in order, first match wins):
    a. **Docs answered this run** → mirror that choice: `CLAUDE.md only` → CLAUDE.md; `AGENTS.md only` → AGENTS.md; `Both` → the same block to **both** files; `Skip` → fall through to (b).
    b. **Docs skipped or already-current** → the file(s) that already carry the `<!-- BEGIN FLOW-NEXT -->` docs marker (marker in both → both).
-   c. **Neither** → the platform-default mapping (the Step 6b buckets): Codex → AGENTS.md; Claude Code / Droid → CLAUDE.md; Cursor → AGENTS.md.
+   c. **Neither** → the platform-default mapping (the Step 6b buckets): Codex → AGENTS.md; Claude Code / Droid → CLAUDE.md; Cursor → AGENTS.md. (Grok never reaches this ladder — it uses the host-native path above, which always targets AGENTS.md for the routing block.)
 
    **Shim guard** (apply to each resolved target before writing): read the file and take its non-empty content lines. If there is exactly **one** non-empty content line and it matches either `@<path>.md` **or** `See[:] <path>.md` (case-insensitive, `<path>` repo-relative), the target is a **shim** — do **not** write into it. Instead follow the pointer: if `<path>.md` exists in-repo, retarget to it (and re-apply the shim guard to that file); if it does not exist, print `Model-routing scaffold: <file> is a shim pointing at a missing <path>.md — skipping` and drop this target. Any other content = a normal file, proceed. Never turn a shim into a mixed file. If every resolved target drops out (all shims to missing files), `ROUTING_OUTCOME="skipped (shim)"`; done with the block pipeline (proceed to step 7).
 
@@ -910,7 +1010,7 @@ For non-Cursor platforms, run the block pipeline (step 1 once, then steps 2–6 
 
    Result invariant (R10): after the transform the composed block contains **no** `<!-- probe:` sentinel and **no active (non-comment) line that invokes a CLI whose probe failed** — every failed-probe route is fully enclosed in an HTML comment with an install note. All three probes (codex, cursor, grok) failing → every probe-gated wiring route is a commented-out note (the scores table + the native routes + always-on escalation/graceful-degrade rules still stand); you MAY note in the read-back that with none of the CLIs installed, `Skip` is reasonable — but still honor the user's choice.
 
-**3. Substitute the invocation syntax per target file** — keyed on the target file's snippet family from the Docs mapping above, NOT on platform alone: rewrite every `/flow-next:<cmd>` → `$flow-next-<cmd>` (this covers the provenance line's `/flow-next:setup` **and** the `delegate:codex` work route's `/flow-next:work`) **only** when the target is AGENTS.md on **Codex** (the `agents-md-snippet.md` family); keep `/flow-next:` verbatim for CLAUDE.md on **every** platform and for AGENTS.md on **Claude Code / Droid / Cursor** (the `claude-md-snippet.md` family — Cursor runs the slash commands). When step 1 resolved **both** files on Codex, compose one copy per file: AGENTS.md gets `$flow-next-`, CLAUDE.md keeps `/flow-next:`.
+**3. Substitute the invocation syntax per target file** — keyed on the target file's snippet family from the Docs mapping above, NOT on platform alone: rewrite every `/flow-next:<cmd>` → `$flow-next-<cmd>` (this covers the provenance line's `/flow-next:setup` **and** the `delegate:codex` work route's `/flow-next:work`) **only** when the target is AGENTS.md on **Codex** (the `agents-md-snippet.md` family); keep `/flow-next:` verbatim for CLAUDE.md on **every** platform and for AGENTS.md on **Claude Code / Droid / Cursor / Grok** (the `claude-md-snippet.md` family — Cursor and Grok run the slash commands). When step 1 resolved **both** files on Codex, compose one copy per file: AGENTS.md gets `$flow-next-`, CLAUDE.md keeps `/flow-next:`.
 
 **4. Inspect marker + byte-compare FIRST — before any read-back.** Read the resolved target from disk:
    - **Marker present** (`<!-- flow-next:model-routing:start -->` … `<!-- flow-next:model-routing:end -->`): extract that block inclusive and **byte-compare** it against the block composed in 2–3 **for this target file** (today's probe state + this file's invocation syntax — this is the *current composed canonical*):
@@ -948,7 +1048,7 @@ For non-Cursor platforms, run the block pipeline (step 1 once, then steps 2–6 
 
 `Keep current` → no write, done. `Switch to codex` → run `"${PLUGIN_ROOT}/scripts/flowctl" config set review.backend codex --json`, then read the persisted value back (same read-back pattern as step 7); if it did not persist as `codex`, print `Warning: review.backend did not persist as codex — set it manually with flowctl config set review.backend codex`. This step never runs non-interactively (the whole scaffold pipeline is gated on `ROUTING_ASK=1`) and never fires when the user skipped the scaffold — declining the scaffold declines its pipeline too.
 
-**Ralph** (processed when the Ralph question was asked — i.e. `PLATFORM` is NOT `cursor`. On `PLATFORM=cursor`: never offer, never register, never run ralph-init; print `Ralph: off (unsupported on Cursor)` and skip this whole block — fn-123):
+**Ralph** (processed when the Ralph question was asked — i.e. `PLATFORM` is NOT `cursor` and NOT `grok`. On `PLATFORM=cursor`: never offer, never register, never run ralph-init; print `Ralph: off (unsupported on Cursor)` and skip this whole block — fn-123. On `PLATFORM=grok`: same posture — print `Ralph: off (unsupported on Grok)` and skip this whole block — fn-126):
 
 - **Yes, enable or keep:**
   1. Tell the user Ralph is opt-in and that the next step is `/flow-next:ralph-init` (or `$flow-next-ralph-init` on Codex).
@@ -988,7 +1088,7 @@ Include `Setup mode: <MODE_OUTCOME>` in the Step 8 summary.
 ```
 Flow-Next setup complete!
 
-Platform: <claude-code|codex|droid|cursor>
+Platform: <claude-code|codex|droid|cursor|grok>
 
 Installed:
 - .flow/bin/flowctl (v<VERSION>)
@@ -1005,6 +1105,17 @@ Cursor host notes:
 - Copy mode only (.flow/bin/flowctl) — Cursor exposes no plugin-root env vars / bin PATH injection
 - Review default: host (host-native cross-family subagent pins in AGENTS.md model-routing)
 - Ralph: unsupported on Cursor (not offered; not registered)
+```
+
+**If PLATFORM=grok, also show:**
+```
+Grok host notes:
+- Copy mode only (.flow/bin/flowctl) — Grok exposes no plugin-root bin PATH injection
+- Docs: /flow-next: slash snippet (CLAUDE.md default lifecycle target; Grok also reads AGENTS.md)
+- Model-routing block: AGENTS.md (host-review pin target)
+- Review: host offered (single-native-family fail-closed for Grok writers) + rp/codex/copilot/cursor/none
+- No .codex/agents copy; Ralph: unsupported on Grok (not offered; not registered)
+- Detection: GROK_AGENT=1 (not ~/.grok or PATH)
 ```
 
 **If PLATFORM=codex, also show:**
@@ -1041,7 +1152,7 @@ Model-pin ceremony (fn-115.2): <MODELS_CEREMONY — "written" | "stamped" | "ski
 
 Notes:
 - Re-run /flow-next:setup after plugin updates to refresh scripts
-- Ralph: answered in the setup ceremony (default off; skipped entirely on Cursor — unsupported). To enable later on supported hosts: /flow-next:ralph-init (merges project hooks; plugin ships none)
+- Ralph: answered in the setup ceremony (default off; skipped entirely on Cursor and Grok — unsupported). To enable later on supported hosts: /flow-next:ralph-init (merges project hooks; plugin ships none)
 - Use Linear / GitHub Issues / GitLab / Jira for project management? Run /flow-next:tracker-sync to configure the (opt-in) two-way tracker bridge — it runs a discovery ceremony (detects Linear MCP / LINEAR_API_KEY / gh auth / glab auth or GITLAB_TOKEN / JIRA_BASE_URL + credential, asks, writes config), then syncs specs ⇄ issues; on Linear it additionally makes your PRs reviewable as Linear Diffs. Skips cleanly if you don't use a tracker; adds nothing to the base install until enabled.
 - Uninstall (run manually): rm -rf .flow/bin .flow/templates .flow/usage.md and remove the <!-- BEGIN/END FLOW-NEXT --> and <!-- flow-next:model-routing:start/end --> blocks from docs — or run /flow-next:uninstall for full cleanup (also strips Ralph guard hook entries from project settings)
 - This setup is optional - plugin works without it

--- a/plugins/flow-next/skills/flow-next-spec-completion-review/SKILL.md
+++ b/plugins/flow-next/skills/flow-next-spec-completion-review/SKILL.md
@@ -93,9 +93,13 @@ When `RP_ELIGIBLE=0`, omit the **rp** line below from any guidance you surface (
 3. Model resolved via (first match wins): `--spec cursor:<model>` flag, per-spec `default_review`, `FLOW_REVIEW_BACKEND` spec, `FLOW_CURSOR_MODEL` env var, registry default (`gpt-5.5-high`). **No effort** — Cursor bakes effort into the model name; `cursor:<model>:<effort>` is rejected
 4. Parse verdict from command output
 
-**For host backend (fn-123 R5):**
+**For host backend (fn-123 R5 / fn-126):**
 1. **DO NOT REVIEW COMPLETION YOURSELF** — you coordinate; a fresh-context host-native subagent reviews (see [workflow-host.md](workflow-host.md))
-2. Dispatch a **read-only** reviewer subagent pinned to a **cross-family** model slug from AGENTS.md model-routing (Claude Code: native `model` param; Cursor: in-prompt slug pin; elsewhere: generic fresh-context reviewer with host-dependent note)
+2. Dispatch a **read-only** reviewer subagent pinned to a **cross-family** model slug from AGENTS.md model-routing:
+   - **Claude Code**: native `model` param + tool-enforced read-only
+   - **Cursor**: in-prompt slug pin + tool-enforced read-only
+   - **Grok**: in-prompt / host model pin + tool-enforced read-only; single-native-family (`grok-4.5`) fails closed unless the writer is non-Grok (cross-family via bridges); receipt `mode: "host"` + actual model + `session_id: null`
+   - **Elsewhere**: generic fresh-context reviewer with host-dependent note
 3. Record actual reviewer model + `"mode": "host"` in the receipt
 4. **Every re-review is a fresh subagent** — no context reuse, no fabricated resume ids
 5. **Fail closed on missing cross-family pin:** interactive → ask user explicitly; autonomous → `NEEDS_HUMAN` (never silent same-family self-review)

--- a/plugins/flow-next/skills/flow-next-spec-completion-review/workflow-host.md
+++ b/plugins/flow-next/skills/flow-next-spec-completion-review/workflow-host.md
@@ -30,6 +30,7 @@ Dispatch a **fresh** read-only reviewer subagent with the resolved pin:
 |------|------------|
 | Claude Code | Native subagent `model` param; `disallowedTools: Edit, Write, Task` (or host read-only equivalent) |
 | Cursor | In-prompt slug pin on the subagent + TOOL-enforced read-only (dispatch via a `readonly: true` agent definition or Cursor's read-only subagent mode — never a mutation-capable subagent; the reviewer reads untrusted diff content, so read-only cannot be prompt-requested only) |
+| Grok | In-prompt / host model pin from AGENTS.md model-routing + TOOL-enforced read-only (never mutation-capable). Single-native-family (`grok-4.5`) — host review fails closed unless the writer is non-Grok; cross-family via bridge backends. Receipt: `mode: "host"`, actual reviewer model, `session_id: null` (same shape as Claude/Cursor) |
 | Codex | Fresh read-only reviewer subagent via the platform subagent primitive (`spawn_agent` on Codex) with the cross-family pin stated in the prompt; read-only via the platform sandbox |
 | Other | Generic fresh-context reviewer; note in the receipt that pin enforcement is host-dependent |
 

--- a/plugins/flow-next/tests/test_setup_cursor_host.py
+++ b/plugins/flow-next/tests/test_setup_cursor_host.py
@@ -109,7 +109,7 @@ class TestHostLeadsReviewMenu(unittest.TestCase):
         # the non-cursor review branch), all backends appear.
         host_idx = self.text.index('"label": "Host (Recommended)"')
         non_cursor_idx = self.text.index(
-            "**When `PLATFORM` is NOT `cursor`**", host_idx
+            "**When `PLATFORM` is neither `cursor` nor `grok`**", host_idx
         )
         cursor_menu = self.text[host_idx:non_cursor_idx]
         for label in (
@@ -243,8 +243,8 @@ class TestCursorCopyModeUnchanged(unittest.TestCase):
 
     def test_non_cursor_review_menu_retained(self) -> None:
         # Claude/Droid/Codex menu still ships without Host-first requirement.
-        self.assertIn("**When `PLATFORM` is NOT `cursor`**", self.text)
-        non = self.text.split("**When `PLATFORM` is NOT `cursor`**", 1)[1]
+        self.assertIn("**When `PLATFORM` is neither `cursor` nor `grok`**", self.text)
+        non = self.text.split("**When `PLATFORM` is neither `cursor` nor `grok`**", 1)[1]
         # First review-options block after that header should still lead with Codex CLI
         # (not Host) for the non-cursor path.
         self.assertIn('"label": "Codex CLI"', non[:2000])

--- a/plugins/flow-next/tests/test_setup_grok_host.py
+++ b/plugins/flow-next/tests/test_setup_grok_host.py
@@ -261,5 +261,33 @@ class TestMirrorUnconditionalCodex(unittest.TestCase):
             self.assertEqual(_run_detection(self.bash, env), "codex")
 
 
+class TestGrokProfileContract(unittest.TestCase):
+    """fn-126 R2 (codex impl-review P1): lock the FULL Grok profile in the
+    canonical setup workflow (not just detection), via exact-substring checks
+    against known markers — so half-configured Grok support fails the test."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.wf = _read(CANONICAL_WF)
+
+    def test_generic_review_menu_excludes_grok(self) -> None:
+        # Catch-all review menu must exclude cursor AND grok, else grok
+        # double-matches the dedicated grok menu and may emit a host-less menu.
+        self.assertNotIn("**When `PLATFORM` is NOT `cursor`**", self.wf)
+        self.assertIn("neither `cursor` nor `grok`", self.wf)
+
+    def test_dedicated_grok_review_menu(self) -> None:
+        self.assertIn("When `PLATFORM=grok`", self.wf)
+
+    def test_grok_skips_codex_agents_copy(self) -> None:
+        self.assertIn("Grok never copies `.codex/agents`", self.wf)
+
+    def test_grok_no_ralph_convert_recommended(self) -> None:
+        self.assertIn("on Cursor **and Grok** recommend CONVERT", self.wf)
+
+    def test_grok_snippet_target_claude_md(self) -> None:
+        self.assertIn("lifecycle snippet targets CLAUDE.md", self.wf)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/plugins/flow-next/tests/test_setup_grok_host.py
+++ b/plugins/flow-next/tests/test_setup_grok_host.py
@@ -1,0 +1,265 @@
+"""fn-126 R4 — executable Step-0 platform detection + Codex mirror guard.
+
+Locks:
+
+  (a) Canonical detection bash (extracted from flow-next-setup/workflow.md)
+      classifies standalone GROK_AGENT=1 as grok; higher-precedence host
+      signals win when present alongside GROK_AGENT; plain shell → codex;
+      droid/claude/cursor/codex unregressed.
+  (b) Codex mirror Step-0 is unconditional PLATFORM=codex — even with
+      GROK_AGENT=1 and every other host signal set, the mirror returns codex.
+
+Run:
+    cd plugins/flow-next/tests && python3 -m unittest test_setup_grok_host -q
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+HERE = Path(__file__).resolve()
+PLUGIN = HERE.parent.parent
+CANONICAL_WF = PLUGIN / "skills" / "flow-next-setup" / "workflow.md"
+MIRROR_WF = PLUGIN / "codex" / "skills" / "flow-next-setup" / "workflow.md"
+
+# Host signals the detection cascade keys on — scrub so the ambient agent shell
+# cannot poison fixture classification (this test often runs inside Claude/Grok).
+HOST_ENV_KEYS = (
+    "DROID_PLUGIN_ROOT",
+    "CLAUDE_PLUGIN_ROOT",
+    "CURSOR_AGENT",
+    "GROK_AGENT",
+    "CLAUDECODE",
+    "CURSOR_TRACE_ID",
+    "CODEX_HOME",
+)
+
+_BASH = shutil.which("bash")
+
+_STEP0_HEADING = re.compile(
+    r"(?m)^## Step 0: Resolve plugin path and detect platform\s*$"
+)
+_FIRST_BASH_FENCE = re.compile(r"(?ms)^```bash\n(.*?)(?:^```\s*$)", re.MULTILINE)
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8").replace("\r\n", "\n").replace("\r", "\n")
+
+
+def _extract_step0_detection_bash(text: str, *, source: str) -> str:
+    """Extract the Step-0 platform-detection bash fence.
+
+    Anchor: Step-0 heading → first ```bash fence under it. Exactly one match.
+    """
+    heads = list(_STEP0_HEADING.finditer(text))
+    if len(heads) != 1:
+        raise AssertionError(
+            f"{source}: expected exactly one Step-0 heading, found {len(heads)}"
+        )
+    after = text[heads[0].end() :]
+    # Stop at the next ## heading so we only look inside Step 0.
+    next_h2 = re.search(r"(?m)^## ", after)
+    step0 = after[: next_h2.start()] if next_h2 else after
+    fences = list(_FIRST_BASH_FENCE.finditer(step0))
+    if len(fences) != 1:
+        raise AssertionError(
+            f"{source}: expected exactly one ```bash fence under Step 0, "
+            f"found {len(fences)}"
+        )
+    return fences[0].group(1)
+
+
+def _clean_env(home: str, plugin_root: str, **extra: str) -> dict[str, str]:
+    """Minimal env: scrub host signals, pin HOME/PLUGIN_ROOT, keep PATH."""
+    env = {
+        k: v
+        for k, v in os.environ.items()
+        if k not in HOST_ENV_KEYS
+    }
+    env["HOME"] = home
+    env["PLUGIN_ROOT"] = plugin_root
+    # Drop any residual host keys, then apply fixture overrides.
+    for k in HOST_ENV_KEYS:
+        env.pop(k, None)
+    env.update(extra)
+    return env
+
+
+def _run_detection(bash_body: str, env: dict[str, str]) -> str:
+    script = f"set -eu\n{bash_body}\nprintf '%s\\n' \"$PLATFORM\"\n"
+    proc = subprocess.run(
+        [_BASH, "-c", script],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+    if proc.returncode != 0:
+        raise AssertionError(
+            f"detection bash failed (rc={proc.returncode}):\n"
+            f"stdout={proc.stdout!r}\nstderr={proc.stderr!r}"
+        )
+    return proc.stdout.strip()
+
+
+def _build_cursor_install(home: Path) -> Path:
+    """Temp Cursor install tree: ~/.cursor/plugins/local/flow-next/ + manifest."""
+    root = home / ".cursor" / "plugins" / "local" / "flow-next"
+    manifest = root / ".cursor-plugin" / "plugin.json"
+    manifest.parent.mkdir(parents=True, exist_ok=True)
+    manifest.write_text('{"name":"flow-next","version":"0.0.0"}\n', encoding="utf-8")
+    return root
+
+
+@unittest.skipUnless(_BASH, "bash required to execute the Step-0 detection fence")
+class TestCanonicalDetectionExecutable(unittest.TestCase):
+    """R4: run the ACTUAL canonical Step-0 bash under controlled fixtures."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        if not CANONICAL_WF.is_file():
+            raise AssertionError(f"missing {CANONICAL_WF}")
+        cls.bash = _extract_step0_detection_bash(
+            _read(CANONICAL_WF), source="canonical workflow"
+        )
+        # Sanity: the extracted body is the multi-host cascade, not unconditional.
+        if "GROK_AGENT" not in cls.bash:
+            raise AssertionError(
+                "canonical Step-0 bash missing GROK_AGENT rung — extraction wrong?"
+            )
+        if 'PLATFORM="codex"' not in cls.bash:
+            raise AssertionError("canonical Step-0 bash missing codex fallback")
+
+    def _run(self, plugin_root: str | None = None, **host_env: str) -> str:
+        with tempfile.TemporaryDirectory() as td:
+            home = Path(td)
+            # Default plugin root: neutral path (not under ~/.cursor).
+            pr = plugin_root or str(home / "plugin-src" / "flow-next")
+            Path(pr).mkdir(parents=True, exist_ok=True)
+            env = _clean_env(str(home), pr, **host_env)
+            return _run_detection(self.bash, env)
+
+    def test_exactly_one_step0_bash_fence(self) -> None:
+        # Extraction already asserts; re-run for an explicit unit-test name.
+        body = _extract_step0_detection_bash(
+            _read(CANONICAL_WF), source="canonical workflow"
+        )
+        self.assertIn("GROK_AGENT", body)
+        self.assertIn("DROID_PLUGIN_ROOT", body)
+        self.assertIn("CLAUDE_PLUGIN_ROOT", body)
+        self.assertIn("CURSOR_AGENT", body)
+
+    def test_grok_agent_alone_is_grok(self) -> None:
+        self.assertEqual(self._run(GROK_AGENT="1"), "grok")
+
+    def test_plain_shell_is_codex(self) -> None:
+        self.assertEqual(self._run(), "codex")
+
+    def test_droid_wins_over_grok(self) -> None:
+        self.assertEqual(
+            self._run(DROID_PLUGIN_ROOT="/tmp/droid-plugin", GROK_AGENT="1"),
+            "droid",
+        )
+
+    def test_claude_wins_over_grok(self) -> None:
+        self.assertEqual(
+            self._run(CLAUDE_PLUGIN_ROOT="/tmp/claude-plugin", GROK_AGENT="1"),
+            "claude-code",
+        )
+
+    def test_cursor_wins_over_grok(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            home = Path(td)
+            cursor_root = _build_cursor_install(home)
+            env = _clean_env(
+                str(home),
+                str(cursor_root),
+                CURSOR_AGENT="1",
+                GROK_AGENT="1",
+            )
+            self.assertEqual(_run_detection(self.bash, env), "cursor")
+
+    def test_droid_alone(self) -> None:
+        self.assertEqual(self._run(DROID_PLUGIN_ROOT="/tmp/droid-plugin"), "droid")
+
+    def test_claude_alone(self) -> None:
+        self.assertEqual(
+            self._run(CLAUDE_PLUGIN_ROOT="/tmp/claude-plugin"), "claude-code"
+        )
+
+    def test_cursor_alone(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            home = Path(td)
+            cursor_root = _build_cursor_install(home)
+            env = _clean_env(str(home), str(cursor_root), CURSOR_AGENT="1")
+            self.assertEqual(_run_detection(self.bash, env), "cursor")
+
+    def test_cursor_agent_without_install_tree_falls_to_codex(self) -> None:
+        # Inherited CURSOR_AGENT + non-cursor PLUGIN_ROOT → codex (not cursor).
+        self.assertEqual(self._run(CURSOR_AGENT="1"), "codex")
+
+    def test_cursor_agent_without_install_plus_grok_is_grok(self) -> None:
+        # No cursor path match → fall through; GROK_AGENT then wins over else.
+        self.assertEqual(self._run(CURSOR_AGENT="1", GROK_AGENT="1"), "grok")
+
+
+@unittest.skipUnless(_BASH, "bash required to execute the mirror Step-0 detection fence")
+class TestMirrorUnconditionalCodex(unittest.TestCase):
+    """R4: Codex mirror Step-0 is unconditional PLATFORM=codex."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        if not MIRROR_WF.is_file():
+            raise AssertionError(
+                f"missing {MIRROR_WF} — run ./scripts/sync-codex.sh first"
+            )
+        cls.bash = _extract_step0_detection_bash(
+            _read(MIRROR_WF), source="codex mirror workflow"
+        )
+
+    def test_mirror_bash_has_no_host_detection_branches(self) -> None:
+        for signal in (
+            "GROK_AGENT",
+            "CURSOR_AGENT",
+            "DROID_PLUGIN_ROOT",
+            "CLAUDE_PLUGIN_ROOT",
+        ):
+            self.assertNotIn(
+                signal,
+                self.bash,
+                f"mirror Step-0 bash must not branch on {signal}",
+            )
+        self.assertIn('PLATFORM="codex"', self.bash)
+
+    def test_mirror_returns_codex_with_every_host_signal(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            home = Path(td)
+            cursor_root = _build_cursor_install(home)
+            env = _clean_env(
+                str(home),
+                str(cursor_root),
+                GROK_AGENT="1",
+                CURSOR_AGENT="1",
+                CLAUDE_PLUGIN_ROOT="/tmp/claude-plugin",
+                DROID_PLUGIN_ROOT="/tmp/droid-plugin",
+            )
+            self.assertEqual(_run_detection(self.bash, env), "codex")
+
+    def test_mirror_returns_codex_plain(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            home = Path(td)
+            pr = home / "plugin"
+            pr.mkdir()
+            env = _clean_env(str(home), str(pr))
+            self.assertEqual(_run_detection(self.bash, env), "codex")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/sync-codex.sh
+++ b/scripts/sync-codex.sh
@@ -447,9 +447,35 @@ fi
 # the mirrored pre-check's "Refresh now" path reads it, and excluding it would
 # strand a plugin-mode repo's snippet refresh when visited from Codex. Data, not
 # doctrine: the file alone offers nothing. Validation below guards regression.
+#
+# fn-126 R4: the Codex mirror is consumed ONLY by Codex. Replace the multi-host
+# Step-0 detection cascade with unconditional PLATFORM="codex" (canonical hosts
+# never read this mirror; a GROK_AGENT / CURSOR_AGENT inheritance must not
+# reclassify a Codex session). Hard-fail guard below enforces no host-detection
+# branches in the mirror Step-0 bash fence.
 setup_wf="$CODEX_DIR/skills/flow-next-setup/workflow.md"
 if [ -f "$setup_wf" ]; then
   awk '
+    # fn-126 R4: first ```bash under Step 0 Platform detection → unconditional codex
+    /^## Step 0: Resolve plugin path and detect platform/ {in_step0=1}
+    in_step0 && /^## / && !/^## Step 0:/ {in_step0=0; det_done=0}
+    in_step0 && !det_done && /^```bash$/ {
+      print "```bash"
+      print "# Codex mirror: this workflow is consumed only by Codex."
+      print "# Host detection is irrelevant — always PLATFORM=codex"
+      print "# (canonical Claude-format hosts never read this mirror)."
+      print "PLATFORM=\"codex\""
+      skip_det=1
+      det_done=1
+      next
+    }
+    skip_det && /^```$/ {
+      print
+      skip_det=0
+      next
+    }
+    skip_det {next}
+
     /^## Step 2b: Setup mode/ {
       print "## Existing-mode guard (before Step 3)";
       print "";
@@ -1874,6 +1900,40 @@ if grep -q '^## Step 3: Create .flow/bin/' "$CODEX_DIR/skills/flow-next-setup/wo
   echo -e "  ${GREEN}✓${NC} Copy-mode setup path retained in codex mirror (Step 3 + copy stamp)"
 else
   echo -e "  ${RED}✗${NC} Copy-mode setup path missing from codex mirror (Step 3 heading or copy stamp gone)"
+  errors=$((errors + 1))
+fi
+
+# fn-126 R4: mirror Step-0 detection bash must be unconditional PLATFORM=codex
+# (no multi-host cascade — Codex always reads this mirror as PLATFORM=codex).
+# Scope: the first ```bash fence under the Step 0 heading only (prose may still
+# mention host signals for documentation; the executable detection block must not).
+setup_mirror_wf="$CODEX_DIR/skills/flow-next-setup/workflow.md"
+if [ -f "$setup_mirror_wf" ]; then
+  det_block=$(awk '
+    /^## Step 0: Resolve plugin path and detect platform/ {in_s0=1; next}
+    in_s0 && /^## / {exit}
+    in_s0 && /^```bash$/ {grab=1; next}
+    grab && /^```$/ {exit}
+    grab {print}
+  ' "$setup_mirror_wf")
+  det_bad=0
+  for sig in GROK_AGENT CURSOR_AGENT DROID_PLUGIN_ROOT CLAUDE_PLUGIN_ROOT; do
+    if printf '%s\n' "$det_block" | grep -q "$sig"; then
+      echo -e "  ${RED}✗${NC} codex mirror setup Step-0 detection bash still branches on $sig (fn-126 R4 — must be unconditional PLATFORM=codex)"
+      det_bad=1
+    fi
+  done
+  if ! printf '%s\n' "$det_block" | grep -q 'PLATFORM="codex"'; then
+    echo -e "  ${RED}✗${NC} codex mirror setup Step-0 detection bash missing unconditional PLATFORM=\"codex\" (fn-126 R4)"
+    det_bad=1
+  fi
+  if [ "$det_bad" = "0" ]; then
+    echo -e "  ${GREEN}✓${NC} Codex mirror setup Step-0 is unconditional PLATFORM=codex (no host-detection branches)"
+  else
+    errors=$((errors + 1))
+  fi
+else
+  echo -e "  ${RED}✗${NC} codex mirror setup workflow missing — cannot validate Step-0 (fn-126 R4)"
   errors=$((errors + 1))
 fi
 

--- a/scripts/sync-codex.sh
+++ b/scripts/sync-codex.sh
@@ -1917,14 +1917,13 @@ if [ -f "$setup_mirror_wf" ]; then
     grab {print}
   ' "$setup_mirror_wf")
   det_bad=0
-  for sig in GROK_AGENT CURSOR_AGENT DROID_PLUGIN_ROOT CLAUDE_PLUGIN_ROOT; do
-    if printf '%s\n' "$det_block" | grep -q "$sig"; then
-      echo -e "  ${RED}✗${NC} codex mirror setup Step-0 detection bash still branches on $sig (fn-126 R4 — must be unconditional PLATFORM=codex)"
-      det_bad=1
-    fi
-  done
-  if ! printf '%s\n' "$det_block" | grep -q 'PLATFORM="codex"'; then
-    echo -e "  ${RED}✗${NC} codex mirror setup Step-0 detection bash missing unconditional PLATFORM=\"codex\" (fn-126 R4)"
+  # Fail-CLOSED (codex impl-review): the executable content must be EXACTLY the
+  # single `PLATFORM="codex"` assignment. Strip comment/blank lines, then require
+  # the remainder to equal that one line — so ANY future branch (new signal,
+  # if/case, extra assignment) fails, not just the four named signals.
+  det_exec=$(printf '%s\n' "$det_block" | sed 's/#.*$//' | grep -vE '^[[:space:]]*$' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+  if [ "$det_exec" != 'PLATFORM="codex"' ]; then
+    echo -e "  ${RED}✗${NC} codex mirror setup Step-0 executable content is not exactly 'PLATFORM=\"codex\"' (fn-126 R4 — must be unconditional; got: $(printf '%s' "$det_exec" | tr '\n' '|'))"
     det_bad=1
   fi
   if [ "$det_bad" = "0" ]; then


### PR DESCRIPTION
## TL;DR

Makes **Grok Build a properly-detected first-class host** (fn-126). Grok was silently falling through the setup platform cascade to the `else → codex` fallback, so `/flow-next:setup` wrote Codex-shaped `$flow-next-` snippets even though Grok drives with `/flow-next-` slash commands and reads the canonical Claude files. This adds a positive `GROK_AGENT` detection rung + the full Grok host profile, an executable detection test, and a hardened Codex-mirror guard.

Implemented by grok-4.5 (high) via the grok CLI; plan reviewed cross-family by Fable and gpt-5.6-sol, implementation reviewed by gpt-5.6-sol — all findings folded in. Two live smokes run in a real Grok session (results below).

## R-ID coverage

| R-ID | Requirement | Task | Commit |
|------|-------------|------|--------|
| R1 | `GROK_AGENT` positive detection rung (after Droid/Claude/Cursor, before codex) | .1 | 33b71791 |
| R2 | Grok host profile (slash syntax, CLAUDE.md docs + AGENTS.md routing, copy mode, no `.codex/agents`, no Ralph) + full-profile contract tests | .1/fix | 33b71791 / dcf94fb3 |
| R3 | Grok review menu (`host` + externals) + host-native routing scaffold extended to grok; Grok row in the 3 review skills | .1/fix | 33b71791 / dcf94fb3 |
| R4 | Executable detection test + unconditional-codex mirror + fail-closed guard | .2/fix | a7596038 / dcf94fb3 |
| R5 | Docs walk (platforms.md, CHANGELOG, flow-next.dev) + smoke results | .3 | 8872b744 / a8af8528 |

## Critical changes

- **`plugins/flow-next/skills/flow-next-setup/workflow.md`** — new `elif [ -n "${GROK_AGENT:-}" ]; then PLATFORM="grok"` rung (ordered after Droid/Claude/Cursor, before `else→codex`) with an evidence-backed rationale; full Grok profile wired through every PLATFORM consumer (plugin-mode CONVERT list, `.codex/agents` skip, review menu, host-native routing scaffold, no-Ralph, docs-target split). Generic review menu now excludes **both** cursor and grok (codex P1 — it was `NOT cursor`, double-matching grok → host-less menu).
- **`plugins/flow-next/tests/test_setup_grok_host.py`** (new) — EXECUTES the extracted Step-0 bash under fake envs (GROK_AGENT→grok; precedence cases; plain→codex) + a full-profile contract matrix + a mirror-determinism fixture.
- **`scripts/sync-codex.sh`** — flattens the Codex mirror's Step-0 to unconditional `PLATFORM="codex"` (the mirror is consumed only by Codex), enforced by a **fail-closed** guard (exact-match, rejects any future branch/signal — codex P2).
- **3 review skills** (plan/impl/completion) — explicit Grok row in the host-review dispatch table, matching Cursor/Claude (read-only + receipt semantics).
- Docs: `platforms.md` Grok section, CHANGELOG `## [Unreleased]`, flow-next.dev (committed separately in that repo).

## Evidence / decisions

- **`GROK_AGENT=1` is the detection signal** — probe found it set by grok in its shell, absent in a plain-shell control; `~/.grok/` dir and `~/.grok/bin`-on-PATH are NOT signals (present on the machine regardless).
- **Grok reads BOTH `CLAUDE.md` and `AGENTS.md`** — seeded-codename probe (this dissolved an earlier "routing-target conflict" finding that had been built on an unverified assumption). Lifecycle snippet → CLAUDE.md; model-routing block → AGENTS.md (where host-review reads it); Grok sees both.
- **Grok is single-native-family (`grok-4.5`)** — so native `host` review fails closed unless the writer is non-Grok (mirrors Claude Code); cross-family via bridge backends.

## Live smoke results (real Grok session, 2026-07-22)

- ✅ **Detection** — `env \| grep GROK_AGENT` in a STANDALONE grok session → `GROK_AGENT=1`. Signal confirmed live.
- ✅ **No nesting** — autocomplete shows clean single-prefix `/flow-next-*` (the fn-124 tripled-name fix holds in Grok).
- ⚠️ **Autocomplete under-lists** — some commands (`/flow-next-plan`, `/flow-next-work`) don't appear in grok's menu though they **run correctly when typed**. Registered fine; Grok's UI surfaces a subset. Documented as a Grok UI limitation, not fixed here.

## Open items (NEEDS-HUMAN)

- **Nested Droid → Grok precedence** — if a grok child inherits `DROID_PLUGIN_ROOT`, it classifies as `droid`. Documented unsupported pending a smoke confirming `DROID_PLUGIN_ROOT` does not propagate (the probe only disproved `CLAUDE_PLUGIN_ROOT` propagation).
- **Vault Platforms note** — release-time downstream, deferred to the fn-126 release walk (per maintainer downstream discipline).

## Verification

- Full suite: `python3 scripts/run_tests_parallel.py` — 2168 tests, 0 failures.
- `test_setup_grok_host` executes the real Step-0 bash; sync-codex twice-idempotent (tree-hash confirmed); mirror guard fail-closed.
- Reviews: Fable (plan) + gpt-5.6-sol (plan) + gpt-5.6-sol (impl) — all findings folded; one Fable/sol finding dissolved on the both-files probe evidence.

**Version note:** no bump — CHANGELOG staged under `## [Unreleased]` per batched-release policy. A patch release is in flight on main; this branch will be **rebased onto it before merge** (CHANGELOG Unreleased is the expected conflict point).

---
*fn-126 · Grok host fidelity · grok-4.5 implemented / Fable+sol reviewed*
