### PR TITLE
feat(interview): scope marker owns project-added spec sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to the flow-next.
 
 ## Unreleased
 
+### Changed
+
+- **Project-added spec sections are now first-class to the interview passes.**
+  `flowctl scope write-policy` enumerates the seven canonical sections only, so
+  a section a project added via its own repo-root `SPEC.md` scaffold appeared in
+  neither its `writable` nor its `preserved` list. The interview prose asked the
+  agent to think in terms of that closed list, which left custom sections with
+  no stated protection and no route to ever being filled. Ownership now comes
+  from the section's own scope-owner marker in the spec body, with a three-way
+  rule: a marker naming this pass's scope makes the section **writable** (filled
+  and refined like a canonical section), a marker naming the other scope
+  preserves it byte-for-byte, and no marker (or an unparseable one) preserves it
+  byte-for-byte and says so in the read-back. `scope: both` is writable under
+  any pass. Absence from the write-policy lists is explicitly never permission
+  to drop a section. Scope-owner markers, previously strippable as authoring
+  guidance, must now be **kept on project-added sections** because for those the
+  marker is the only ownership signal a later pass has. Prose only - no
+  `flowctl` change, no new command surface, no version bump.
+
 ### Documentation
 
 - **Customizing the spec scaffold is now properly documented.** The repo-root

--- a/plugins/flow-next/codex/references/spec-template-discovery.md
+++ b/plugins/flow-next/codex/references/spec-template-discovery.md
@@ -49,3 +49,11 @@ Edge Cases & Constraints, Acceptance Criteria, Boundaries,
 Decision Context) with scope-owner HTML-comment annotations. Frontmatter +
 HTML-comment scope-owner markers may be stripped from the final spec body —
 they're authoring guidance, not user-visible spec content.
+
+Exception: **keep the scope-owner marker on any section the project added** to
+its own tier-1/2 scaffold (a section outside the canonical 7). `flowctl scope
+write-policy` enumerates canonical sections only, so for a project-added
+section that marker is the sole ownership signal a later scope-aware pass has
+- stripping it silently downgrades the section to preserve-only, and it will
+never be filled. Canonical-section markers are safe to strip because the
+write-policy carries their ownership.

--- a/plugins/flow-next/codex/skills/flow-next-interview/SKILL.md
+++ b/plugins/flow-next/codex/skills/flow-next-interview/SKILL.md
@@ -65,7 +65,7 @@ SCOPE_DEFAULTED=$(printf '%s' "$RESOLVED_JSON" | jq -r '.defaulted // false')
 ARGUMENTS=$(printf '%s' "$RESOLVED_JSON" | jq -r '.remaining_args | join(" ")')
 ```
 
-The section-write policy for the resolved scope is computed by `flowctl scope write-policy`, called BEFORE any markdown edit. It returns which sections the pass MAY write and which it MUST preserve byte-for-byte (per the fn-44 spec Edge Cases merge contract):
+The section-write policy for the resolved scope is computed by `flowctl scope write-policy`, called BEFORE any markdown edit. It returns which sections the pass MAY write and which it MUST preserve byte-for-byte (per the fn-44 spec Edge Cases merge contract). It enumerates **canonical sections only** - a section the project added via its own repo-root `SPEC.md` scaffold appears in neither list, and its absence is never permission to drop it; ownership comes from the section's own scope-owner marker (see the project-added-section rule in [`references/write-back.md`](references/write-back.md)):
 
 ```bash
 # Build the current-sections JSON from the existing spec (T2 wires this).

--- a/plugins/flow-next/codex/skills/flow-next-interview/references/write-back.md
+++ b/plugins/flow-next/codex/skills/flow-next-interview/references/write-back.md
@@ -23,6 +23,14 @@ The canonical spec section structure lives in [`plugins/flow-next/templates/spec
 
 Section-write rules from the scope-aware pass behavior (above) MUST be honored — the write-policy result from `flowctl scope write-policy` is the source of truth for which sections this scope writes vs preserves. The `## Decision Context` substructure / FLAT-vs-substructured promotion logic is in the write-policy; do not invent inline.
 
+**Project-added sections.** `write-policy` enumerates the canonical sections only, so a spec may contain sections this project added via its own repo-root `SPEC.md` scaffold (a risk register, user stories, a rollout runbook). Never treat a section's absence from the write-policy lists as permission to drop it. Decide ownership from the section's own scope-owner marker in the body, and default to caution:
+
+- marker names **your** scope (e.g. `<!-- scope: business -->` under a `--scope=business` pass) → **writable**: fill and refine it exactly as you would a canonical section of that scope.
+- marker names the **other** scope → **preserve byte-for-byte**, same as any other-scope canonical section.
+- **no marker, or a marker you cannot parse** → **preserve byte-for-byte**, and mention in the read-back that it was left untouched so the user can add a marker if they wanted it filled.
+
+`scope: both` on a project-added section is writable under any pass. A project-added section carrying an empty body is still preserved unless it is writable under this scope - an empty section you do not own is the user's placeholder, not litter.
+
 ### For NEW IDEA (text input, no Flow ID)
 
 Create spec with interview output. **DO NOT create tasks** — that's `/flow-next:plan`'s job.
@@ -124,16 +132,17 @@ $FLOWCTL tasks --spec <id> --json
 
 **If no tasks:** Update spec, then suggest `/flow-next:plan`.
 
-The canonical section layout for the spec body is in [`plugins/flow-next/templates/spec.md`](../../templates/spec.md). Read the existing spec, refine sections under your scope per the write-policy (preserving sections owned by the other scope byte-for-byte), and append/update the auxiliary interview-audit sections. The R21 drift guard forbids re-embedding the canonical section sequence in this skill — read the existing body, do not regenerate from a template.
+The canonical section layout for the spec body is in [`plugins/flow-next/templates/spec.md`](../../templates/spec.md). Read the existing spec, refine sections under your scope per the write-policy (preserving sections owned by the other scope byte-for-byte, and project-added sections per the ownership rule above), and append/update the auxiliary interview-audit sections. The R21 drift guard forbids re-embedding the canonical section sequence in this skill - read the existing body, do not regenerate from a template.
 
 **Reuse the spec body already fetched at Detect Input Type** (`$FLOWCTL cat <id>` ran there) — do NOT re-fetch here. Re-fetch only if the interview mutated the spec on disk since that read (e.g. an earlier partial write-back in this run).
 
-Refine canonical sections under your scope's writable list (per write-policy) while preserving sections owned by the other scope byte-for-byte, append the auxiliary interview-audit sections (only those that fired), and Write the merged body ONCE to a literal unique path (e.g. `${TMPDIR:-/tmp}/flow-interview-spec-<id>-<suffix>.md`) via the **Write tool** — per the single-emission write pattern above. The body:
+Refine canonical sections under your scope's writable list (per write-policy) while preserving sections owned by the other scope byte-for-byte, apply the project-added-section ownership rule above, append the auxiliary interview-audit sections (only those that fired), and Write the merged body ONCE to a literal unique path (e.g. `${TMPDIR:-/tmp}/flow-interview-spec-<id>-<suffix>.md`) via the **Write tool** - per the single-emission write pattern above. The body:
 
 ```markdown
-<merged body: canonical sections from the Detect-Input-Type read, with this
- scope's writable sections refined from interview answers, other-scope sections
- preserved byte-for-byte per the write-policy>
+<merged body: EVERY section present in the Detect-Input-Type read, in its
+ original order, with this scope's writable sections refined from interview
+ answers, other-scope sections preserved byte-for-byte per the write-policy,
+ and project-added sections written or preserved per their scope-owner marker>
 
 ## Resolved via Codebase
 (optional — written by the technical pass when codebase-investigation resolved items)

--- a/plugins/flow-next/docs/spec-template.md
+++ b/plugins/flow-next/docs/spec-template.md
@@ -65,11 +65,23 @@ Keep R-ID bullets in the canonical form - `- **R1:** <criterion>` - with optiona
 
 The other three canonical sections (`Architecture & Data Models`, `API Contracts`, `Edge Cases & Constraints`) are technical-scope write targets. Removing them is survivable, but the technical interview pass will have fewer places to put what it learns.
 
-### Known limitation - custom sections and the interview passes
+### Custom sections and the interview passes - use the scope marker
 
-`flowctl scope write-policy` returns a `writable` list and a `preserved` list, and **both enumerate only the seven canonical sections**. A section you added appears in neither, so the write-policy contract does not explicitly instruct an interview pass to preserve it byte-for-byte the way it protects the other scope's canonical sections.
+`flowctl scope write-policy` enumerates the seven canonical sections only, so a section you added appears in neither its `writable` nor its `preserved` list. Ownership of a project-added section therefore comes from **the section's own scope-owner marker in the spec body**, and the interview passes apply a three-way rule:
 
-In practice a pass reads the existing body and refines in place, so custom sections normally survive. But the guarantee is contractual for canonical sections and incidental for yours. If you add a section carrying content you cannot afford to lose, keep it under version control (you committed `SPEC.md`, so `git diff` on the spec after a pass is the check) rather than relying on the pass to protect it.
+| Marker on your section | What an interview pass does |
+|---|---|
+| names the pass's own scope (`<!-- scope: business -->` under `--scope=business`) | **writes it** - fills and refines it like a canonical section of that scope |
+| names the other scope | preserves it byte-for-byte |
+| `<!-- scope: both -->` | writable under any pass |
+| absent or unparseable | preserves it byte-for-byte, and says so in the read-back |
+
+So the marker is the difference between a section that gets filled and a section that stays frozen. Add one if you want the interview to do the work; leave it off if the section is yours to hand-write.
+
+Two consequences worth knowing:
+
+- A marked section is **rewritable**. If you hand-write user stories and mark them `scope: business`, the next business pass will refine them. That is the point, but it means hand-authored content under a marker you own is not sacred - drop the marker to freeze it.
+- Scope-owner markers are ordinarily authoring guidance and may be stripped from a finished spec body. For project-added sections they must be **kept**, because they are the only ownership signal a later pass has. See [`../references/spec-template-discovery.md`](../references/spec-template-discovery.md).
 
 `capture` and `plan` seed from the template directly and have no such caveat.
 

--- a/plugins/flow-next/references/spec-template-discovery.md
+++ b/plugins/flow-next/references/spec-template-discovery.md
@@ -49,3 +49,11 @@ Edge Cases & Constraints, Acceptance Criteria, Boundaries,
 Decision Context) with scope-owner HTML-comment annotations. Frontmatter +
 HTML-comment scope-owner markers may be stripped from the final spec body —
 they're authoring guidance, not user-visible spec content.
+
+Exception: **keep the scope-owner marker on any section the project added** to
+its own tier-1/2 scaffold (a section outside the canonical 7). `flowctl scope
+write-policy` enumerates canonical sections only, so for a project-added
+section that marker is the sole ownership signal a later scope-aware pass has
+- stripping it silently downgrades the section to preserve-only, and it will
+never be filled. Canonical-section markers are safe to strip because the
+write-policy carries their ownership.

--- a/plugins/flow-next/skills/flow-next-interview/SKILL.md
+++ b/plugins/flow-next/skills/flow-next-interview/SKILL.md
@@ -65,7 +65,7 @@ SCOPE_DEFAULTED=$(printf '%s' "$RESOLVED_JSON" | jq -r '.defaulted // false')
 ARGUMENTS=$(printf '%s' "$RESOLVED_JSON" | jq -r '.remaining_args | join(" ")')
 ```
 
-The section-write policy for the resolved scope is computed by `flowctl scope write-policy`, called BEFORE any markdown edit. It returns which sections the pass MAY write and which it MUST preserve byte-for-byte (per the fn-44 spec Edge Cases merge contract):
+The section-write policy for the resolved scope is computed by `flowctl scope write-policy`, called BEFORE any markdown edit. It returns which sections the pass MAY write and which it MUST preserve byte-for-byte (per the fn-44 spec Edge Cases merge contract). It enumerates **canonical sections only** - a section the project added via its own repo-root `SPEC.md` scaffold appears in neither list, and its absence is never permission to drop it; ownership comes from the section's own scope-owner marker (see the project-added-section rule in [`references/write-back.md`](references/write-back.md)):
 
 ```bash
 # Build the current-sections JSON from the existing spec (T2 wires this).

--- a/plugins/flow-next/skills/flow-next-interview/references/write-back.md
+++ b/plugins/flow-next/skills/flow-next-interview/references/write-back.md
@@ -21,6 +21,14 @@ The canonical spec section structure lives in [`plugins/flow-next/templates/spec
 
 Section-write rules from the scope-aware pass behavior (above) MUST be honored — the write-policy result from `flowctl scope write-policy` is the source of truth for which sections this scope writes vs preserves. The `## Decision Context` substructure / FLAT-vs-substructured promotion logic is in the write-policy; do not invent inline.
 
+**Project-added sections.** `write-policy` enumerates the canonical sections only, so a spec may contain sections this project added via its own repo-root `SPEC.md` scaffold (a risk register, user stories, a rollout runbook). Never treat a section's absence from the write-policy lists as permission to drop it. Decide ownership from the section's own scope-owner marker in the body, and default to caution:
+
+- marker names **your** scope (e.g. `<!-- scope: business -->` under a `--scope=business` pass) → **writable**: fill and refine it exactly as you would a canonical section of that scope.
+- marker names the **other** scope → **preserve byte-for-byte**, same as any other-scope canonical section.
+- **no marker, or a marker you cannot parse** → **preserve byte-for-byte**, and mention in the read-back that it was left untouched so the user can add a marker if they wanted it filled.
+
+`scope: both` on a project-added section is writable under any pass. A project-added section carrying an empty body is still preserved unless it is writable under this scope - an empty section you do not own is the user's placeholder, not litter.
+
 ### For NEW IDEA (text input, no Flow ID)
 
 Create spec with interview output. **DO NOT create tasks** — that's `/flow-next:plan`'s job.
@@ -122,16 +130,17 @@ $FLOWCTL tasks --spec <id> --json
 
 **If no tasks:** Update spec, then suggest `/flow-next:plan`.
 
-The canonical section layout for the spec body is in [`plugins/flow-next/templates/spec.md`](../../templates/spec.md). Read the existing spec, refine sections under your scope per the write-policy (preserving sections owned by the other scope byte-for-byte), and append/update the auxiliary interview-audit sections. The R21 drift guard forbids re-embedding the canonical section sequence in this skill — read the existing body, do not regenerate from a template.
+The canonical section layout for the spec body is in [`plugins/flow-next/templates/spec.md`](../../templates/spec.md). Read the existing spec, refine sections under your scope per the write-policy (preserving sections owned by the other scope byte-for-byte, and project-added sections per the ownership rule above), and append/update the auxiliary interview-audit sections. The R21 drift guard forbids re-embedding the canonical section sequence in this skill - read the existing body, do not regenerate from a template.
 
 **Reuse the spec body already fetched at Detect Input Type** (`$FLOWCTL cat <id>` ran there) — do NOT re-fetch here. Re-fetch only if the interview mutated the spec on disk since that read (e.g. an earlier partial write-back in this run).
 
-Refine canonical sections under your scope's writable list (per write-policy) while preserving sections owned by the other scope byte-for-byte, append the auxiliary interview-audit sections (only those that fired), and Write the merged body ONCE to a literal unique path (e.g. `${TMPDIR:-/tmp}/flow-interview-spec-<id>-<suffix>.md`) via the **Write tool** — per the single-emission write pattern above. The body:
+Refine canonical sections under your scope's writable list (per write-policy) while preserving sections owned by the other scope byte-for-byte, apply the project-added-section ownership rule above, append the auxiliary interview-audit sections (only those that fired), and Write the merged body ONCE to a literal unique path (e.g. `${TMPDIR:-/tmp}/flow-interview-spec-<id>-<suffix>.md`) via the **Write tool** - per the single-emission write pattern above. The body:
 
 ```markdown
-<merged body: canonical sections from the Detect-Input-Type read, with this
- scope's writable sections refined from interview answers, other-scope sections
- preserved byte-for-byte per the write-policy>
+<merged body: EVERY section present in the Detect-Input-Type read, in its
+ original order, with this scope's writable sections refined from interview
+ answers, other-scope sections preserved byte-for-byte per the write-policy,
+ and project-added sections written or preserved per their scope-owner marker>
 
 ## Resolved via Codebase
 (optional — written by the technical pass when codebase-investigation resolved items)


### PR DESCRIPTION
## Summary

A project can already override the spec scaffold with a repo-root `SPEC.md`, but `flowctl scope write-policy` enumerates the **seven canonical sections only**. A section the project added landed in neither the `writable` nor the `preserved` list, and the interview prose asked the agent to reason in terms of that closed list. Two consequences: the custom section had no stated protection, and no route to ever being *filled*.

Ownership now comes from the section's own scope-owner marker in the spec body.

## What changed

Prose only. No `flowctl` change, no new command surface.

| Marker on a project-added section | Interview pass behaviour |
|---|---|
| names this pass's scope | **writable** - filled and refined like a canonical section |
| names the other scope | preserved byte-for-byte |
| `scope: both` | writable under any pass |
| absent or unparseable | preserved byte-for-byte, reported in the read-back |

Plus: absence from the write-policy lists is now explicitly **never** permission to drop a section, and scope-owner markers (previously strippable as authoring guidance) must be **kept on project-added sections**, since for those the marker is the only ownership signal a later pass has.

Files:

- `skills/flow-next-interview/references/write-back.md` - the rule, applied at all 3 sites that previously said "sections owned by the other scope" (the rule statement, the refine path, the merged-body contract)
- `skills/flow-next-interview/SKILL.md` - notes write-policy is canonical-only and points at the rule
- `references/spec-template-discovery.md` - stripping exception for project-added sections
- `docs/spec-template.md` - guide section rewritten from "known limitation" to the marker rule
- Codex mirror regenerated (`sync-codex.sh` x2, idempotent)

## Why prose and not a flowctl contract change

`write-policy` is advisory JSON; the preserving is done by the agent following the prose. Changing only flowctl would return a more accurate list and change no behaviour. Putting ownership in the spec body as data the agent reads keeps `write-policy` deterministic plumbing and avoids teaching it every section name a project might invent. A flowctl-side version (compute `preserved` = present minus writable) remains possible later if the guarantee needs to be enforceable rather than instructed.

## Behaviour change worth flagging

A marked section is **rewritable**. Hand-authored content under a marker you own will be refined by the next pass of that scope. That is intended, and the docs say so - drop the marker to freeze a section.

## Verification

- `uvx ruff@0.16.0 check .` clean
- `python3 scripts/run_tests_parallel.py` - **3286 tests, 0 failures, 0 errors**
- `./scripts/sync-codex.sh` run twice, idempotent, mirror matches canonical
- No cross-model review, per instruction - these are prose changes

## Version

No bump. Behaviour change is staged under `## Unreleased`; version/release is decided separately per the batched-release rule.

## Downstream

Already pushed to main in their own repos: flow-next.dev (`1c068f7`, `pnpm build` green) and the Obsidian vault notes. The AI x SDLC guide links to the site section and needed no edit.