### PR TITLE
fix(flowctl): review-attempt finalize is a single atomic sidecar write

### DIFF
--- a/.flow/bin/flowctl.py
+++ b/.flow/bin/flowctl.py
@@ -29426,6 +29426,7 @@ def _finish_backend_exec(
             output=output,
             failure_class=failure_class,
             task_id=task_id,
+            reviewed_head_sha=reviewed_head_sha,
             review_type=review_type,
             use_json=args.json,
         )

--- a/.flow/bin/flowctl.py
+++ b/.flow/bin/flowctl.py
@@ -29065,6 +29065,7 @@ def _dispatch_backend_review(
     review_kind: Optional[str],
     review_type: str,
     task_id: Optional[str] = None,
+    reviewed_head_sha: Optional[str] = None,
 ) -> tuple[str, Optional[str], int, str]:
     """Run a backend and refund if dispatch itself terminates before a result."""
     try:
@@ -29086,6 +29087,7 @@ def _dispatch_backend_review(
                 output="backend dispatch terminated before returning output",
                 failure_class="dispatch_error",
                 task_id=task_id,
+                reviewed_head_sha=reviewed_head_sha,
                 review_type=review_type,
                 use_json=args.json,
             )
@@ -29112,6 +29114,7 @@ def _dispatch_backend_review(
                 output=detail,
                 failure_class="dispatch_exception",
                 task_id=task_id,
+                reviewed_head_sha=reviewed_head_sha,
                 review_type=review_type,
                 use_json=args.json,
             )
@@ -29259,6 +29262,7 @@ def _backend_impl_review(args: argparse.Namespace, backend: str) -> None:
         review_kind=None if standalone else "impl",
         review_type="impl",
         task_id=None if standalone else task_id,
+        reviewed_head_sha=reviewed_head_sha,
     )
 
     resolved_spec, effective_model, effective_effort = _bind_receipt_model_effort(
@@ -29583,6 +29587,7 @@ def _backend_plan_review(args: argparse.Namespace, backend: str) -> None:
         spec_id=epic_id,
         review_kind="plan",
         review_type="plan",
+        reviewed_head_sha=reviewed_head_sha,
     )
 
     resolved_spec, effective_model, effective_effort = _bind_receipt_model_effort(
@@ -29767,6 +29772,7 @@ def _backend_completion_review(args: argparse.Namespace, backend: str) -> None:
         spec_id=epic_id,
         review_kind="plan",
         review_type="completion",
+        reviewed_head_sha=reviewed_head_sha,
     )
 
     resolved_spec, effective_model, effective_effort = _bind_receipt_model_effort(

--- a/.flow/bin/flowctl.py
+++ b/.flow/bin/flowctl.py
@@ -9193,6 +9193,28 @@ def _review_attempt_summary(
     }
 
 
+def _review_head_sha() -> Optional[str]:
+    """Best-effort HEAD sha for review-attempt provenance (issue #279).
+
+    Never raises: detached HEAD still resolves; a broken/absent git, an
+    unborn branch, or a timeout returns None.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True, encoding="utf-8",
+            cwd=str(get_repo_root()),
+            timeout=10,
+        )
+        if result.returncode != 0:
+            return None
+        sha = (result.stdout or "").strip()
+        return sha or None
+    except Exception:
+        return None
+
+
 def record_review_attempt(
     spec_id: str,
     review_kind: str,
@@ -9204,6 +9226,8 @@ def record_review_attempt(
     task_id: Optional[str] = None,
     review_type: Optional[str] = None,
     use_json: bool = False,
+    finalize_status_kind: Optional[str] = None,
+    reset_rounds_on_ship: bool = False,
 ) -> dict:
     """Finalize one pre-dispatch reservation and persist its outcome.
 
@@ -9211,14 +9235,21 @@ def record_review_attempt(
     transport-failure count. A no-verdict attempt refunds exactly one reserved
     round, increments the separate transport-failure count, and remains
     auditable in ``review_attempts`` on the spec sidecar.
+    When ``finalize_status_kind`` is set, the denormalized
+    ``<kind>_review_status`` / ``<kind>_reviewed_at`` fields (and, with
+    ``reset_rounds_on_ship``, the SHIP round-counter reset) are folded into
+    the same single atomic sidecar write (issue #279).
     """
     flow_dir = get_flow_dir()
     spec_json_path = find_spec_json_path(flow_dir, spec_id)
     if not spec_json_path.exists():
-        return {
+        result = {
             "recorded": False,
             "outcome": "verdict" if verdict else "transport_failure",
         }
+        if finalize_status_kind is not None:
+            result["status_written"] = None
+        return result
 
     spec_data = normalize_epic(
         load_json_or_exit(spec_json_path, f"Spec {spec_id}", use_json=use_json)
@@ -9274,12 +9305,32 @@ def record_review_attempt(
             (output or "").encode("utf-8", errors="replace")
         ).hexdigest(),
         "round_consumed": not refunded,
+        "head_sha": _review_head_sha(),
     }
     attempts = spec_data.get("review_attempts")
     if not isinstance(attempts, list):
         attempts = []
         spec_data["review_attempts"] = attempts
     attempts.append(row)
+    # issue #279: fold the denormalized status write and the SHIP cap reset
+    # into THIS sidecar mutation so the attempt ledger, <kind>_review_status,
+    # and the round counter land in ONE atomic_write_json - no interrupt
+    # window where the ledger and the read model diverge.
+    status_written: Optional[str] = None
+    if finalize_status_kind in ("plan", "completion"):
+        status = {
+            "SHIP": "ship",
+            "NEEDS_WORK": "needs_work",
+            "MAJOR_RETHINK": "needs_work",
+        }.get(verdict or "")
+        if status:
+            spec_data[f"{finalize_status_kind}_review_status"] = status
+            spec_data[f"{finalize_status_kind}_reviewed_at"] = now_iso()
+            status_written = status
+    if reset_rounds_on_ship and verdict == "SHIP":
+        # Same counter mutation reset_review_cap performs; pending is
+        # deliberately left alone (fn-134.7 / R22).
+        _write_review_rounds(spec_data, review_kind, task_id, 0)
     spec_data["updated_at"] = now_iso()
     atomic_write_json(spec_json_path, spec_data)
 
@@ -9303,6 +9354,8 @@ def record_review_attempt(
             ),
         }
     )
+    if finalize_status_kind is not None:
+        summary["status_written"] = status_written
     return summary
 
 
@@ -29217,10 +29270,8 @@ def _backend_impl_review(args: argparse.Namespace, backend: str) -> None:
         review_kind=None if standalone else "impl",
         review_type="impl",
         task_id=None if standalone else task_id,
+        reset_rounds_on_ship=not standalone,
     )
-
-    if verdict == "SHIP" and not standalone:
-        reset_review_cap(spec_id_from_task(task_id), "impl", task_id=task_id)
 
     review_id = task_id if task_id else "branch"
     review_text = reg["extract_review"](output)
@@ -29316,6 +29367,9 @@ def _finish_backend_exec(
     review_kind: Optional[str] = None,
     review_type: Optional[str] = None,
     task_id: Optional[str] = None,
+    finalize_status_kind: Optional[str] = None,
+    reset_rounds_on_ship: bool = False,
+    attempt_out: Optional[dict] = None,
 ) -> str:
     """Shared post-exec gates and verdict-aware round finalization.
 
@@ -29326,7 +29380,7 @@ def _finish_backend_exec(
     verdict = parse_codex_verdict(output)
     if verdict:
         if spec_id and review_kind:
-            record_review_attempt(
+            summary = record_review_attempt(
                 spec_id,
                 review_kind,
                 backend=backend,
@@ -29335,7 +29389,11 @@ def _finish_backend_exec(
                 task_id=task_id,
                 review_type=review_type,
                 use_json=args.json,
+                finalize_status_kind=finalize_status_kind,
+                reset_rounds_on_ship=reset_rounds_on_ship,
             )
+            if attempt_out is not None:
+                attempt_out.update(summary)
         return verdict
 
     sandbox_failure = (
@@ -29525,20 +29583,21 @@ def _backend_plan_review(args: argparse.Namespace, backend: str) -> None:
         prior_receipt_model=prior_receipt_model,
         prior_receipt_effort=prior_receipt_effort,
     )
+    attempt_summary: dict = {}
     verdict = _finish_backend_exec(
         backend=backend, reg=reg, args=args, receipt_path=receipt_path,
         output=output, stderr=stderr, exit_code=exit_code,
         spec_id=epic_id,
         review_kind="plan",
         review_type="plan",
+        finalize_status_kind="plan",
+        reset_rounds_on_ship=True,
+        attempt_out=attempt_summary,
     )
 
-    if verdict == "SHIP":
-        reset_review_cap(epic_id, "plan")
-
-    written_status = _self_write_review_status(
-        epic_id, "plan", verdict, use_json=args.json
-    )
+    # issue #279: attempt row, plan_review_status, and the SHIP cap reset all
+    # landed in ONE atomic sidecar write inside record_review_attempt.
+    written_status = attempt_summary.get("status_written")
 
     review_text = reg["extract_review"](output)
 
@@ -29713,10 +29772,8 @@ def _backend_completion_review(args: argparse.Namespace, backend: str) -> None:
         spec_id=epic_id,
         review_kind="plan",
         review_type="completion",
+        reset_rounds_on_ship=True,
     )
-
-    if verdict == "SHIP":
-        reset_review_cap(epic_id, "plan")
 
     # Preserve session_id for continuity (avoid clobbering on resumed sessions).
     session_id_to_write = returned_session_id or session_id

--- a/.flow/bin/flowctl.py
+++ b/.flow/bin/flowctl.py
@@ -9228,6 +9228,7 @@ def record_review_attempt(
     use_json: bool = False,
     finalize_status_kind: Optional[str] = None,
     reset_rounds_on_ship: bool = False,
+    reviewed_head_sha: Optional[str] = None,
 ) -> dict:
     """Finalize one pre-dispatch reservation and persist its outcome.
 
@@ -9305,7 +9306,9 @@ def record_review_attempt(
             (output or "").encode("utf-8", errors="replace")
         ).hexdigest(),
         "round_consumed": not refunded,
-        "head_sha": _review_head_sha(),
+        # The sha the review OBSERVED (pre-dispatch snapshot) when the caller
+        # has it; finalize-time HEAD is only the fallback (rp/refund paths).
+        "head_sha": reviewed_head_sha or _review_head_sha(),
     }
     attempts = spec_data.get("review_attempts")
     if not isinstance(attempts, list):
@@ -29271,6 +29274,7 @@ def _backend_impl_review(args: argparse.Namespace, backend: str) -> None:
         review_type="impl",
         task_id=None if standalone else task_id,
         reset_rounds_on_ship=not standalone,
+        reviewed_head_sha=reviewed_head_sha,
     )
 
     review_id = task_id if task_id else "branch"
@@ -29370,6 +29374,7 @@ def _finish_backend_exec(
     finalize_status_kind: Optional[str] = None,
     reset_rounds_on_ship: bool = False,
     attempt_out: Optional[dict] = None,
+    reviewed_head_sha: Optional[str] = None,
 ) -> str:
     """Shared post-exec gates and verdict-aware round finalization.
 
@@ -29391,6 +29396,7 @@ def _finish_backend_exec(
                 use_json=args.json,
                 finalize_status_kind=finalize_status_kind,
                 reset_rounds_on_ship=reset_rounds_on_ship,
+                reviewed_head_sha=reviewed_head_sha,
             )
             if attempt_out is not None:
                 attempt_out.update(summary)
@@ -29593,6 +29599,7 @@ def _backend_plan_review(args: argparse.Namespace, backend: str) -> None:
         finalize_status_kind="plan",
         reset_rounds_on_ship=True,
         attempt_out=attempt_summary,
+        reviewed_head_sha=reviewed_head_sha,
     )
 
     # issue #279: attempt row, plan_review_status, and the SHIP cap reset all
@@ -29773,6 +29780,7 @@ def _backend_completion_review(args: argparse.Namespace, backend: str) -> None:
         review_kind="plan",
         review_type="completion",
         reset_rounds_on_ship=True,
+        reviewed_head_sha=reviewed_head_sha,
     )
 
     # Preserve session_id for continuity (avoid clobbering on resumed sessions).

--- a/.flow/bin/flowctl_tracker/MANIFEST.json
+++ b/.flow/bin/flowctl_tracker/MANIFEST.json
@@ -2,7 +2,7 @@
   "files": [
     {
       "path": "flowctl.py",
-      "sha256": "16fbb10684562aecbdef85a32e72d41045bc2a2d5a4ee9b6725f33a3ec86745a"
+      "sha256": "fd29320ae2b3bcc6cd586cea1c1a089bb3c8db74a2dfc1337af6754ce4de9006"
     },
     {
       "path": "flowctl_tracker/__init__.py",

--- a/.flow/bin/flowctl_tracker/MANIFEST.json
+++ b/.flow/bin/flowctl_tracker/MANIFEST.json
@@ -2,7 +2,7 @@
   "files": [
     {
       "path": "flowctl.py",
-      "sha256": "97f9876633fdef9007b0a8168d099443415f88932a1208ccfee0bc17aa3940c9"
+      "sha256": "2fbd8d363920446917e860ec3e542d14bef449b629ad5310cc4834fe3df4af05"
     },
     {
       "path": "flowctl_tracker/__init__.py",

--- a/.flow/bin/flowctl_tracker/MANIFEST.json
+++ b/.flow/bin/flowctl_tracker/MANIFEST.json
@@ -2,7 +2,7 @@
   "files": [
     {
       "path": "flowctl.py",
-      "sha256": "fd29320ae2b3bcc6cd586cea1c1a089bb3c8db74a2dfc1337af6754ce4de9006"
+      "sha256": "663cb56876ff0f00bf2c042fec2cabf5bacd6716c87413dde8ec776ab5c0f580"
     },
     {
       "path": "flowctl_tracker/__init__.py",

--- a/.flow/bin/flowctl_tracker/MANIFEST.json
+++ b/.flow/bin/flowctl_tracker/MANIFEST.json
@@ -2,7 +2,7 @@
   "files": [
     {
       "path": "flowctl.py",
-      "sha256": "2fbd8d363920446917e860ec3e542d14bef449b629ad5310cc4834fe3df4af05"
+      "sha256": "16fbb10684562aecbdef85a32e72d41045bc2a2d5a4ee9b6725f33a3ec86745a"
     },
     {
       "path": "flowctl_tracker/__init__.py",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 All notable changes to the flow-next.
 
+## Unreleased
+
+An interrupted review can no longer leave your spec telling two different
+stories. Previously, if a plan review died between its internal writes (a
+crash, a Ctrl-C, an OOM), the attempt ledger could carry the new verdict
+while `plan_review_status` still showed the old one - and the next pipeline
+stage would trust the stale status. Now the in-process plan-review path
+commits the attempt row, the status field, and the SHIP round-counter reset
+as one atomic write, so the sidecar is always internally consistent.
+
+### Fixed
+
+- **Review sidecar write transaction (#279).** `record_review_attempt` can
+  now fold the denormalized `<kind>_review_status` write and the SHIP
+  round-counter reset into its single atomic sidecar write. The in-process
+  plan-review path uses both; impl and completion reviews fold the SHIP cap
+  reset (completion keeps its separate status write - receipt persistence
+  before terminal status is a recovery contract). Transport failures never
+  touch status. Each attempt row also gains a best-effort `head_sha` so the
+  ledger records which commit a verdict reviewed. Authority rule documented
+  in `docs/architecture.md`: `review_attempts[]` is the ledger,
+  `*_review_status` is a read model, ledger wins on divergence. Reported by
+  @sn-furali (#279) with a precise read of the write paths - thank you.
+
 ## [flow-next 3.12.0] - 2026-07-31
 
 Your editor can now validate and autocomplete `.flow/config.json`. Flow-next

--- a/plugins/flow-next/docs/architecture.md
+++ b/plugins/flow-next/docs/architecture.md
@@ -94,6 +94,35 @@ New fields:
 - Spec JSON `tracker` block (tracker-sync, defaulted/optional): `tracker.id` (tracker UUID - durable dedupe key), `identifier` (display key `WOR-17`), `url`, `lastSyncedAt` (advances only on a real reconcile), `baseHashFlow` / `baseHashTracker` (echo-fence content hashes), `mergeBaseFlow` / `mergeBaseTracker` (paired body snapshots - the 3-way merge base, written atomically as a unit). Full schema: [`tracker-sync.md`](tracker-sync.md).
 - Task JSON: `priority`. The parent reference field is `spec`.
 
+### Review bookkeeping: authority and write-ordering
+
+The spec sidecar carries two views of review state. `review_attempts[]` is the
+authoritative ledger - one row per finalized reservation, with backend,
+outcome, verdict, output hash, and (best-effort) the `head_sha` the review
+observed. `plan_review_status` / `completion_review_status` (plus their
+`*_reviewed_at` stamps) are a denormalized read model derived from that
+ledger; when the two ever diverge, the ledger wins.
+
+Write-ordering differs by path, on purpose:
+
+- **In-process plan review** (`flowctl codex|copilot|cursor plan-review`)
+  finalizes the attempt row, writes `plan_review_status`, and performs the
+  SHIP round-counter reset as ONE atomic sidecar write inside
+  `record_review_attempt` - there is no interrupt window where the ledger
+  carries a verdict the status field has not seen.
+- **In-process completion review** deliberately stays two writes: the receipt
+  (and its recovery payload) must persist BEFORE the terminal
+  `completion_review_status` lands. That ordering is a recovery contract - if
+  the process dies between the writes, status stays non-terminal and the
+  skill restores from the recovery payload instead of dispatching another
+  round. The SHIP cap reset is folded into the attempt write; the status
+  write stays separate, with the ledger authoritative on divergence.
+- **Host/rp paths** (`flowctl review-rounds record`,
+  `set-plan-review-status`, `set-completion-review-status`) are separate CLI
+  invocations by design - the host agent sequences them - and the same
+  authority rule applies: the ledger row is the record of what happened; the
+  status field is the projection.
+
 ## ID format
 
 - **Spec**: `fn-N-slug` where `slug` is derived from the spec title (e.g., `fn-1-add-oauth`, `fn-2-fix-login-bug`)

--- a/plugins/flow-next/docs/architecture.md
+++ b/plugins/flow-next/docs/architecture.md
@@ -99,7 +99,8 @@ New fields:
 The spec sidecar carries two views of review state. `review_attempts[]` is the
 authoritative ledger - one row per finalized reservation, with backend,
 outcome, verdict, output hash, and (best-effort) the `head_sha` the review
-observed. `plan_review_status` / `completion_review_status` (plus their
+observed (the pre-dispatch snapshot on the in-process backend paths;
+finalize-time HEAD is the fallback where no snapshot exists, e.g. rp). `plan_review_status` / `completion_review_status` (plus their
 `*_reviewed_at` stamps) are a denormalized read model derived from that
 ledger; when the two ever diverge, the ledger wins.
 

--- a/plugins/flow-next/scripts/flowctl.py
+++ b/plugins/flow-next/scripts/flowctl.py
@@ -29426,6 +29426,7 @@ def _finish_backend_exec(
             output=output,
             failure_class=failure_class,
             task_id=task_id,
+            reviewed_head_sha=reviewed_head_sha,
             review_type=review_type,
             use_json=args.json,
         )

--- a/plugins/flow-next/scripts/flowctl.py
+++ b/plugins/flow-next/scripts/flowctl.py
@@ -29065,6 +29065,7 @@ def _dispatch_backend_review(
     review_kind: Optional[str],
     review_type: str,
     task_id: Optional[str] = None,
+    reviewed_head_sha: Optional[str] = None,
 ) -> tuple[str, Optional[str], int, str]:
     """Run a backend and refund if dispatch itself terminates before a result."""
     try:
@@ -29086,6 +29087,7 @@ def _dispatch_backend_review(
                 output="backend dispatch terminated before returning output",
                 failure_class="dispatch_error",
                 task_id=task_id,
+                reviewed_head_sha=reviewed_head_sha,
                 review_type=review_type,
                 use_json=args.json,
             )
@@ -29112,6 +29114,7 @@ def _dispatch_backend_review(
                 output=detail,
                 failure_class="dispatch_exception",
                 task_id=task_id,
+                reviewed_head_sha=reviewed_head_sha,
                 review_type=review_type,
                 use_json=args.json,
             )
@@ -29259,6 +29262,7 @@ def _backend_impl_review(args: argparse.Namespace, backend: str) -> None:
         review_kind=None if standalone else "impl",
         review_type="impl",
         task_id=None if standalone else task_id,
+        reviewed_head_sha=reviewed_head_sha,
     )
 
     resolved_spec, effective_model, effective_effort = _bind_receipt_model_effort(
@@ -29583,6 +29587,7 @@ def _backend_plan_review(args: argparse.Namespace, backend: str) -> None:
         spec_id=epic_id,
         review_kind="plan",
         review_type="plan",
+        reviewed_head_sha=reviewed_head_sha,
     )
 
     resolved_spec, effective_model, effective_effort = _bind_receipt_model_effort(
@@ -29767,6 +29772,7 @@ def _backend_completion_review(args: argparse.Namespace, backend: str) -> None:
         spec_id=epic_id,
         review_kind="plan",
         review_type="completion",
+        reviewed_head_sha=reviewed_head_sha,
     )
 
     resolved_spec, effective_model, effective_effort = _bind_receipt_model_effort(

--- a/plugins/flow-next/scripts/flowctl.py
+++ b/plugins/flow-next/scripts/flowctl.py
@@ -9193,6 +9193,28 @@ def _review_attempt_summary(
     }
 
 
+def _review_head_sha() -> Optional[str]:
+    """Best-effort HEAD sha for review-attempt provenance (issue #279).
+
+    Never raises: detached HEAD still resolves; a broken/absent git, an
+    unborn branch, or a timeout returns None.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True, encoding="utf-8",
+            cwd=str(get_repo_root()),
+            timeout=10,
+        )
+        if result.returncode != 0:
+            return None
+        sha = (result.stdout or "").strip()
+        return sha or None
+    except Exception:
+        return None
+
+
 def record_review_attempt(
     spec_id: str,
     review_kind: str,
@@ -9204,6 +9226,8 @@ def record_review_attempt(
     task_id: Optional[str] = None,
     review_type: Optional[str] = None,
     use_json: bool = False,
+    finalize_status_kind: Optional[str] = None,
+    reset_rounds_on_ship: bool = False,
 ) -> dict:
     """Finalize one pre-dispatch reservation and persist its outcome.
 
@@ -9211,14 +9235,21 @@ def record_review_attempt(
     transport-failure count. A no-verdict attempt refunds exactly one reserved
     round, increments the separate transport-failure count, and remains
     auditable in ``review_attempts`` on the spec sidecar.
+    When ``finalize_status_kind`` is set, the denormalized
+    ``<kind>_review_status`` / ``<kind>_reviewed_at`` fields (and, with
+    ``reset_rounds_on_ship``, the SHIP round-counter reset) are folded into
+    the same single atomic sidecar write (issue #279).
     """
     flow_dir = get_flow_dir()
     spec_json_path = find_spec_json_path(flow_dir, spec_id)
     if not spec_json_path.exists():
-        return {
+        result = {
             "recorded": False,
             "outcome": "verdict" if verdict else "transport_failure",
         }
+        if finalize_status_kind is not None:
+            result["status_written"] = None
+        return result
 
     spec_data = normalize_epic(
         load_json_or_exit(spec_json_path, f"Spec {spec_id}", use_json=use_json)
@@ -9274,12 +9305,32 @@ def record_review_attempt(
             (output or "").encode("utf-8", errors="replace")
         ).hexdigest(),
         "round_consumed": not refunded,
+        "head_sha": _review_head_sha(),
     }
     attempts = spec_data.get("review_attempts")
     if not isinstance(attempts, list):
         attempts = []
         spec_data["review_attempts"] = attempts
     attempts.append(row)
+    # issue #279: fold the denormalized status write and the SHIP cap reset
+    # into THIS sidecar mutation so the attempt ledger, <kind>_review_status,
+    # and the round counter land in ONE atomic_write_json - no interrupt
+    # window where the ledger and the read model diverge.
+    status_written: Optional[str] = None
+    if finalize_status_kind in ("plan", "completion"):
+        status = {
+            "SHIP": "ship",
+            "NEEDS_WORK": "needs_work",
+            "MAJOR_RETHINK": "needs_work",
+        }.get(verdict or "")
+        if status:
+            spec_data[f"{finalize_status_kind}_review_status"] = status
+            spec_data[f"{finalize_status_kind}_reviewed_at"] = now_iso()
+            status_written = status
+    if reset_rounds_on_ship and verdict == "SHIP":
+        # Same counter mutation reset_review_cap performs; pending is
+        # deliberately left alone (fn-134.7 / R22).
+        _write_review_rounds(spec_data, review_kind, task_id, 0)
     spec_data["updated_at"] = now_iso()
     atomic_write_json(spec_json_path, spec_data)
 
@@ -9303,6 +9354,8 @@ def record_review_attempt(
             ),
         }
     )
+    if finalize_status_kind is not None:
+        summary["status_written"] = status_written
     return summary
 
 
@@ -29217,10 +29270,8 @@ def _backend_impl_review(args: argparse.Namespace, backend: str) -> None:
         review_kind=None if standalone else "impl",
         review_type="impl",
         task_id=None if standalone else task_id,
+        reset_rounds_on_ship=not standalone,
     )
-
-    if verdict == "SHIP" and not standalone:
-        reset_review_cap(spec_id_from_task(task_id), "impl", task_id=task_id)
 
     review_id = task_id if task_id else "branch"
     review_text = reg["extract_review"](output)
@@ -29316,6 +29367,9 @@ def _finish_backend_exec(
     review_kind: Optional[str] = None,
     review_type: Optional[str] = None,
     task_id: Optional[str] = None,
+    finalize_status_kind: Optional[str] = None,
+    reset_rounds_on_ship: bool = False,
+    attempt_out: Optional[dict] = None,
 ) -> str:
     """Shared post-exec gates and verdict-aware round finalization.
 
@@ -29326,7 +29380,7 @@ def _finish_backend_exec(
     verdict = parse_codex_verdict(output)
     if verdict:
         if spec_id and review_kind:
-            record_review_attempt(
+            summary = record_review_attempt(
                 spec_id,
                 review_kind,
                 backend=backend,
@@ -29335,7 +29389,11 @@ def _finish_backend_exec(
                 task_id=task_id,
                 review_type=review_type,
                 use_json=args.json,
+                finalize_status_kind=finalize_status_kind,
+                reset_rounds_on_ship=reset_rounds_on_ship,
             )
+            if attempt_out is not None:
+                attempt_out.update(summary)
         return verdict
 
     sandbox_failure = (
@@ -29525,20 +29583,21 @@ def _backend_plan_review(args: argparse.Namespace, backend: str) -> None:
         prior_receipt_model=prior_receipt_model,
         prior_receipt_effort=prior_receipt_effort,
     )
+    attempt_summary: dict = {}
     verdict = _finish_backend_exec(
         backend=backend, reg=reg, args=args, receipt_path=receipt_path,
         output=output, stderr=stderr, exit_code=exit_code,
         spec_id=epic_id,
         review_kind="plan",
         review_type="plan",
+        finalize_status_kind="plan",
+        reset_rounds_on_ship=True,
+        attempt_out=attempt_summary,
     )
 
-    if verdict == "SHIP":
-        reset_review_cap(epic_id, "plan")
-
-    written_status = _self_write_review_status(
-        epic_id, "plan", verdict, use_json=args.json
-    )
+    # issue #279: attempt row, plan_review_status, and the SHIP cap reset all
+    # landed in ONE atomic sidecar write inside record_review_attempt.
+    written_status = attempt_summary.get("status_written")
 
     review_text = reg["extract_review"](output)
 
@@ -29713,10 +29772,8 @@ def _backend_completion_review(args: argparse.Namespace, backend: str) -> None:
         spec_id=epic_id,
         review_kind="plan",
         review_type="completion",
+        reset_rounds_on_ship=True,
     )
-
-    if verdict == "SHIP":
-        reset_review_cap(epic_id, "plan")
 
     # Preserve session_id for continuity (avoid clobbering on resumed sessions).
     session_id_to_write = returned_session_id or session_id

--- a/plugins/flow-next/scripts/flowctl.py
+++ b/plugins/flow-next/scripts/flowctl.py
@@ -9228,6 +9228,7 @@ def record_review_attempt(
     use_json: bool = False,
     finalize_status_kind: Optional[str] = None,
     reset_rounds_on_ship: bool = False,
+    reviewed_head_sha: Optional[str] = None,
 ) -> dict:
     """Finalize one pre-dispatch reservation and persist its outcome.
 
@@ -9305,7 +9306,9 @@ def record_review_attempt(
             (output or "").encode("utf-8", errors="replace")
         ).hexdigest(),
         "round_consumed": not refunded,
-        "head_sha": _review_head_sha(),
+        # The sha the review OBSERVED (pre-dispatch snapshot) when the caller
+        # has it; finalize-time HEAD is only the fallback (rp/refund paths).
+        "head_sha": reviewed_head_sha or _review_head_sha(),
     }
     attempts = spec_data.get("review_attempts")
     if not isinstance(attempts, list):
@@ -29271,6 +29274,7 @@ def _backend_impl_review(args: argparse.Namespace, backend: str) -> None:
         review_type="impl",
         task_id=None if standalone else task_id,
         reset_rounds_on_ship=not standalone,
+        reviewed_head_sha=reviewed_head_sha,
     )
 
     review_id = task_id if task_id else "branch"
@@ -29370,6 +29374,7 @@ def _finish_backend_exec(
     finalize_status_kind: Optional[str] = None,
     reset_rounds_on_ship: bool = False,
     attempt_out: Optional[dict] = None,
+    reviewed_head_sha: Optional[str] = None,
 ) -> str:
     """Shared post-exec gates and verdict-aware round finalization.
 
@@ -29391,6 +29396,7 @@ def _finish_backend_exec(
                 use_json=args.json,
                 finalize_status_kind=finalize_status_kind,
                 reset_rounds_on_ship=reset_rounds_on_ship,
+                reviewed_head_sha=reviewed_head_sha,
             )
             if attempt_out is not None:
                 attempt_out.update(summary)
@@ -29593,6 +29599,7 @@ def _backend_plan_review(args: argparse.Namespace, backend: str) -> None:
         finalize_status_kind="plan",
         reset_rounds_on_ship=True,
         attempt_out=attempt_summary,
+        reviewed_head_sha=reviewed_head_sha,
     )
 
     # issue #279: attempt row, plan_review_status, and the SHIP cap reset all
@@ -29773,6 +29780,7 @@ def _backend_completion_review(args: argparse.Namespace, backend: str) -> None:
         review_kind="plan",
         review_type="completion",
         reset_rounds_on_ship=True,
+        reviewed_head_sha=reviewed_head_sha,
     )
 
     # Preserve session_id for continuity (avoid clobbering on resumed sessions).

--- a/plugins/flow-next/scripts/flowctl_tracker/MANIFEST.json
+++ b/plugins/flow-next/scripts/flowctl_tracker/MANIFEST.json
@@ -2,7 +2,7 @@
   "files": [
     {
       "path": "flowctl.py",
-      "sha256": "16fbb10684562aecbdef85a32e72d41045bc2a2d5a4ee9b6725f33a3ec86745a"
+      "sha256": "fd29320ae2b3bcc6cd586cea1c1a089bb3c8db74a2dfc1337af6754ce4de9006"
     },
     {
       "path": "flowctl_tracker/__init__.py",

--- a/plugins/flow-next/scripts/flowctl_tracker/MANIFEST.json
+++ b/plugins/flow-next/scripts/flowctl_tracker/MANIFEST.json
@@ -2,7 +2,7 @@
   "files": [
     {
       "path": "flowctl.py",
-      "sha256": "97f9876633fdef9007b0a8168d099443415f88932a1208ccfee0bc17aa3940c9"
+      "sha256": "2fbd8d363920446917e860ec3e542d14bef449b629ad5310cc4834fe3df4af05"
     },
     {
       "path": "flowctl_tracker/__init__.py",

--- a/plugins/flow-next/scripts/flowctl_tracker/MANIFEST.json
+++ b/plugins/flow-next/scripts/flowctl_tracker/MANIFEST.json
@@ -2,7 +2,7 @@
   "files": [
     {
       "path": "flowctl.py",
-      "sha256": "fd29320ae2b3bcc6cd586cea1c1a089bb3c8db74a2dfc1337af6754ce4de9006"
+      "sha256": "663cb56876ff0f00bf2c042fec2cabf5bacd6716c87413dde8ec776ab5c0f580"
     },
     {
       "path": "flowctl_tracker/__init__.py",

--- a/plugins/flow-next/scripts/flowctl_tracker/MANIFEST.json
+++ b/plugins/flow-next/scripts/flowctl_tracker/MANIFEST.json
@@ -2,7 +2,7 @@
   "files": [
     {
       "path": "flowctl.py",
-      "sha256": "2fbd8d363920446917e860ec3e542d14bef449b629ad5310cc4834fe3df4af05"
+      "sha256": "16fbb10684562aecbdef85a32e72d41045bc2a2d5a4ee9b6725f33a3ec86745a"
     },
     {
       "path": "flowctl_tracker/__init__.py",

--- a/plugins/flow-next/tests/test_review_convergence_cap.py
+++ b/plugins/flow-next/tests/test_review_convergence_cap.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import contextlib
 import importlib.util
+import inspect
 import io
 import json
 import os
@@ -627,6 +628,233 @@ class TestDeterministicCap(unittest.TestCase):
         row = self._spec_data()["review_attempts"][-1]
         self.assertEqual(row["failure_class"], "dispatch_exception")
         self.assertFalse(row["round_consumed"])
+
+
+# ------------- issue #279: combined finalize write transaction -------------
+
+
+class TestCombinedFinalizeWrite(unittest.TestCase):
+    """issue #279: attempt ledger, denormalized status, and the SHIP cap
+    reset must land in ONE atomic sidecar write on the in-process paths."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self._tmp.name)
+        _init_flow_repo(self.root)
+        self.spec_id = "fn-1-demo"
+        self._cwd = os.getcwd()
+        os.chdir(self.root)
+        self._old_env = os.environ.pop("MAX_REVIEW_ITERATIONS", None)
+
+    def tearDown(self):
+        os.chdir(self._cwd)
+        if self._old_env is not None:
+            os.environ["MAX_REVIEW_ITERATIONS"] = self._old_env
+        self._tmp.cleanup()
+
+    def _spec_data(self) -> dict:
+        return json.loads(
+            (self.root / ".flow" / "specs" / f"{self.spec_id}.json").read_text()
+        )
+
+    def _reserve(self, kind: str = "plan") -> None:
+        flowctl.enforce_and_increment_review_cap(self.spec_id, kind)
+
+    def test_ship_finalize_is_one_atomic_write(self):
+        """SHIP with finalize + reset: attempt row appended, plan status set,
+        rounds zeroed - all via exactly one atomic_write_json call."""
+        self._reserve()
+        real = flowctl.atomic_write_json
+        with mock.patch.object(
+            flowctl, "atomic_write_json", side_effect=real
+        ) as aw:
+            result = flowctl.record_review_attempt(
+                self.spec_id,
+                "plan",
+                backend="codex",
+                output="<verdict>SHIP</verdict>",
+                verdict="SHIP",
+                review_type="plan",
+                finalize_status_kind="plan",
+                reset_rounds_on_ship=True,
+            )
+        self.assertEqual(aw.call_count, 1)
+        self.assertEqual(result["status_written"], "ship")
+        data = self._spec_data()
+        self.assertEqual(data["plan_review_status"], "ship")
+        self.assertIn("plan_reviewed_at", data)
+        self.assertEqual(int(data.get("plan_review_rounds", 0) or 0), 0)
+        self.assertEqual(len(data["review_attempts"]), 1)
+        self.assertTrue(data["review_attempts"][0]["round_consumed"])
+
+    def test_major_rethink_maps_needs_work_and_keeps_round(self):
+        """MAJOR_RETHINK maps to needs_work exactly like
+        _self_write_review_status, and the consumed round is NOT reset."""
+        self._reserve()
+        result = flowctl.record_review_attempt(
+            self.spec_id,
+            "plan",
+            backend="codex",
+            output="<verdict>MAJOR_RETHINK</verdict>",
+            verdict="MAJOR_RETHINK",
+            review_type="plan",
+            finalize_status_kind="plan",
+            reset_rounds_on_ship=True,
+        )
+        self.assertEqual(result["status_written"], "needs_work")
+        data = self._spec_data()
+        self.assertEqual(data["plan_review_status"], "needs_work")
+        self.assertEqual(int(data.get("plan_review_rounds", 0) or 0), 1)
+
+    def test_transport_failure_with_finalize_does_not_touch_status(self):
+        """verdict=None (transport) + finalize_status_kind set: no status
+        write, no reviewed_at, no SHIP reset - only the refund + ledger row."""
+        self._reserve()
+        result = flowctl.record_review_attempt(
+            self.spec_id,
+            "plan",
+            backend="codex",
+            output="",
+            failure_class="empty_output",
+            review_type="plan",
+            finalize_status_kind="plan",
+            reset_rounds_on_ship=True,
+        )
+        self.assertEqual(result["outcome"], "transport_failure")
+        self.assertIsNone(result["status_written"])
+        data = self._spec_data()
+        # normalize_epic defaults survive untouched - no terminal status.
+        self.assertEqual(data["plan_review_status"], "unknown")
+        self.assertIsNone(data["plan_reviewed_at"])
+        self.assertFalse(data["review_attempts"][-1]["round_consumed"])
+
+    def test_summary_shape_unchanged_without_finalize(self):
+        """Callers that never opt in (rp review-rounds record) keep the old
+        summary shape - no status_written key, no status side effects."""
+        self._reserve()
+        result = flowctl.record_review_attempt(
+            self.spec_id,
+            "plan",
+            backend="rp",
+            output="<verdict>SHIP</verdict>",
+            verdict="SHIP",
+            review_type="plan",
+        )
+        self.assertNotIn("status_written", result)
+        self.assertEqual(self._spec_data()["plan_review_status"], "unknown")
+
+    def test_finish_backend_exec_combined_plan_path(self):
+        """_finish_backend_exec threads finalize + reset through and surfaces
+        the record summary via attempt_out."""
+        self._reserve()
+        attempt_out: dict = {}
+        real = flowctl.atomic_write_json
+        with mock.patch.object(
+            flowctl, "atomic_write_json", side_effect=real
+        ) as aw:
+            verdict = flowctl._finish_backend_exec(
+                backend="codex",
+                reg={
+                    "has_sandbox": False,
+                    "cli_label": "codex exec",
+                    "no_verdict_label": "Codex",
+                },
+                args=mock.Mock(json=False),
+                receipt_path=None,
+                output="<verdict>SHIP</verdict>",
+                stderr="",
+                exit_code=0,
+                spec_id=self.spec_id,
+                review_kind="plan",
+                review_type="plan",
+                finalize_status_kind="plan",
+                reset_rounds_on_ship=True,
+                attempt_out=attempt_out,
+            )
+        self.assertEqual(verdict, "SHIP")
+        self.assertEqual(aw.call_count, 1)
+        self.assertEqual(attempt_out["status_written"], "ship")
+        data = self._spec_data()
+        self.assertEqual(data["plan_review_status"], "ship")
+        self.assertEqual(int(data.get("plan_review_rounds", 0) or 0), 0)
+
+    def test_head_sha_recorded_in_git_repo(self):
+        subprocess.run(["git", "init", "-q"], cwd=self.root, check=True)
+        subprocess.run(
+            [
+                "git", "-c", "user.email=t@t", "-c", "user.name=t",
+                "commit", "--allow-empty", "-q", "-m", "x",
+            ],
+            cwd=self.root,
+            check=True,
+        )
+        head = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=self.root,
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+        self._reserve()
+        flowctl.record_review_attempt(
+            self.spec_id,
+            "plan",
+            backend="codex",
+            output="<verdict>NEEDS_WORK</verdict>",
+            verdict="NEEDS_WORK",
+            review_type="plan",
+        )
+        row = self._spec_data()["review_attempts"][-1]
+        self.assertEqual(row["head_sha"], head)
+
+    def test_head_sha_none_outside_git(self):
+        self._reserve()
+        flowctl.record_review_attempt(
+            self.spec_id,
+            "plan",
+            backend="codex",
+            output="<verdict>NEEDS_WORK</verdict>",
+            verdict="NEEDS_WORK",
+            review_type="plan",
+        )
+        row = self._spec_data()["review_attempts"][-1]
+        self.assertIn("head_sha", row)
+        self.assertIsNone(row["head_sha"])
+
+    def test_head_sha_helper_never_raises(self):
+        with mock.patch.object(
+            flowctl.subprocess, "run", side_effect=OSError("no git")
+        ):
+            self.assertIsNone(flowctl._review_head_sha())
+
+    def test_completion_path_keeps_separate_status_write(self):
+        """Completion deliberately stays two writes: receipt persistence
+        BEFORE terminal status (recovery invariant). The standalone status
+        writer must survive and keep MAJOR_RETHINK -> needs_work."""
+        written = flowctl._self_write_review_status(
+            self.spec_id, "completion", "MAJOR_RETHINK"
+        )
+        self.assertEqual(written, "needs_work")
+        self.assertEqual(
+            self._spec_data()["completion_review_status"], "needs_work"
+        )
+        src = inspect.getsource(flowctl._backend_completion_review)
+        self.assertIn("_self_write_review_status", src)
+        self.assertNotIn("finalize_status_kind", src)
+        self.assertIn("reset_rounds_on_ship=True", src)
+        self.assertNotIn("reset_review_cap", src)
+
+    def test_plan_and_impl_paths_fold_writes(self):
+        """The in-process plan path folds status + cap reset; the impl path
+        folds the cap reset; neither makes a second sidecar write."""
+        plan_src = inspect.getsource(flowctl._backend_plan_review)
+        self.assertIn('finalize_status_kind="plan"', plan_src)
+        self.assertIn("reset_rounds_on_ship=True", plan_src)
+        self.assertNotIn("reset_review_cap", plan_src)
+        self.assertNotIn("_self_write_review_status", plan_src)
+        impl_src = inspect.getsource(flowctl._backend_impl_review)
+        self.assertIn("reset_rounds_on_ship=not standalone", impl_src)
+        self.assertNotIn("reset_review_cap", impl_src)
 
 
 class TestReviewRoundsCLI(unittest.TestCase):

--- a/plugins/flow-next/tests/test_review_convergence_cap.py
+++ b/plugins/flow-next/tests/test_review_convergence_cap.py
@@ -1326,5 +1326,24 @@ class TestRpRecorderFailureFences(unittest.TestCase):
         self.assertIn("VERDICT=SHIP", result.stdout)
 
 
+class TestReviewedHeadShaBinding(TestCombinedFinalizeWrite):
+    """The attempt row records the sha the review OBSERVED when supplied
+    (pre-dispatch snapshot beats finalize-time HEAD)."""
+
+    def test_reviewed_head_sha_wins_over_finalize_time_head(self) -> None:
+        self._reserve()
+        flowctl.record_review_attempt(
+            self.spec_id,
+            "plan",
+            backend="codex",
+            output="<verdict>SHIP</verdict>",
+            verdict="SHIP",
+            reviewed_head_sha="a" * 40,
+        )
+        self.assertEqual(
+            self._spec_data()["review_attempts"][-1]["head_sha"], "a" * 40
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/plugins/flow-next/tests/test_review_prompt_constraints.py
+++ b/plugins/flow-next/tests/test_review_prompt_constraints.py
@@ -180,6 +180,9 @@ class ReviewPromptConstraintTest(unittest.TestCase):
                 ("subprocess.run", "get_copilot_version"): 1,
                 ("subprocess.run", "get_cursor_version"): 1,
                 ("subprocess.run", "get_actor"): 2,
+                # issue #279: best-effort HEAD-sha provenance on review-attempt
+                # rows - a deterministic git read, not an execution bridge.
+                ("subprocess.run", "_review_head_sha"): 1,
                 ("subprocess.run", "_spec_alloc_git"): 1,
                 ("subprocess.run", "_export_run_git"): 1,
                 ("subprocess.run", "_export_read_base_blobs"): 1,


### PR DESCRIPTION
Fixes #279.

`review_attempts[]` (the durable ledger) and `*_review_status` (the denormalized cheap check) were written by two separate atomic writes with no transaction spanning them - a crash between the pair left the ledger carrying the new verdict while the status field silently kept the old one. Reported by @sn-furali with a precise read of the write paths.

## What changed

- **In-process plan and impl finalize is now ONE atomic sidecar write** - `record_review_attempt()` gained `finalize_status_kind` / `reset_rounds_on_ship`, so the attempt row, `plan_review_status`/`plan_reviewed_at`, and the SHIP round-counter reset land in a single `atomic_write_json`; the separate `reset_review_cap` + `_self_write_review_status` calls on those paths are gone.
- **Completion deliberately stays two writes** - its receipt-persistence-before-terminal-status ordering is a documented recovery invariant; only the SHIP cap reset is folded into the attempt write. The authority contract is now written down in `architecture.md`: the attempts ledger is authoritative, the status fields are a derived read model, ledger wins on divergence (this also covers the host/rp paths, which are separate CLI invocations by design).
- **Every attempt row binds to what the review observed** - a `head_sha` field carrying the pre-dispatch snapshot sha on the in-process paths (finalize-time HEAD as the fallback for rp/refund paths) - the issue's suggestion 3, matching the fn-136 head-bound receipt convention.
- Behavior on every non-opted path is bit-for-bit unchanged (transport failures never touch status; `MAJOR_RETHINK` maps to `needs_work` identically; rp `review-rounds record` JSON shape unchanged).

## Verification

- 11 new tests in `test_review_convergence_cap.py`: the one-write invariant pinned by a mocked `atomic_write_json` call count (direct + through `_finish_backend_exec`), status-mapping parity, transport-no-touch, snapshot-beats-fallback binding, completion ordering preserved.
- Two full in-host fable-5 review rounds before this PR (round 1 SHIP with a P2 - snapshot binding - fixed; round 2 SHIP with a one-line P3 - no-verdict branch - fixed); reviewer independently traced all three call-site scopes, verified dual-copy shas, and ran the suites.
- Full parallel suite green (168 files, 3590 tests, 0 failures) + `uvx ruff@0.16.0 check .` clean; dual copies + tracker MANIFEST regenerated; no prompt-text changes.

## Version note

No version bump - staged under `## Unreleased` per the batched-release policy, with reporter credit.

---
*Manual make-pr-shaped body (specless fix PR) for issue #279.*
