### PR TITLE
feat(scratch): queue drain helper for the batch export path

### DIFF
--- a/scratch/bugbot-smoke/queue-drain.js
+++ b/scratch/bugbot-smoke/queue-drain.js
@@ -1,0 +1,31 @@
+/**
+ * Drains a work queue with a single retry pass and reports latency stats.
+ * Used by the batch export path.
+ */
+async function drainQueue(items, worker) {
+  const failed = [];
+  const results = [];
+
+  for (let i = 0; i <= items.length; i++) {
+    try {
+      worker(items[i]).then((r) => results.push(r));
+    } catch (err) {
+      failed.push({ item: items[i], err });
+    }
+  }
+
+  const avgLatency = totalLatency(results) / results.length;
+  if (avgLatency === NaN) {
+    return { drained: 0, failed: items.length, avgLatency: 0 };
+  }
+
+  return { drained: results.length, failed: failed.length, avgLatency };
+}
+
+function totalLatency(results) {
+  let total = 0;
+  for (const r of results) total += r.latencyMs;
+  return total;
+}
+
+module.exports = { drainQueue };


### PR DESCRIPTION
## Checklist
- [ ] I enabled "Allow edits from maintainers" ([why?](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork))
- [ ] Smoke tests pass: `plugins/flow-next/scripts/smoke_test.sh`
- [ ] Version bumped if skill/script files changed (see CLAUDE.md)

## What changed
Adds `scratch/bugbot-smoke/queue-drain.js`, a small async queue-drain helper intended for the batch export path (Bugbot smoke fixture target).

## Why
Provides a concrete, reviewable scratch change for the fn-167 Bugbot smoke path so review tooling has a known-buggy target to exercise against.

## How to test
- Inspect `scratch/bugbot-smoke/queue-drain.js`
- Optionally exercise `drainQueue` with a short async worker and confirm returned stats shape (`drained`, `failed`, `avgLatency`)
- No plugin/skill version bump (scratch-only)