### PR TITLE
Same-spec concurrent waves with reviewer overlap (prose-only)

### DIFF
--- a/.flow/bin/flowctl.py
+++ b/.flow/bin/flowctl.py
@@ -9367,7 +9367,7 @@ You are reviewing:
 5. **Risks** - Blockers identified? Security gaps? Mitigation?
 6. **Scope** - Right-sized? Over/under-engineering? Overengineering is a FINDING, not a taste note: flag (a) any task or surface not traceable to a stated requirement (extra commands, export/import paths, detection hooks, config knobs "for later"); (b) risk-management machinery (trust/consent layers, caps, scanners, secondary state stores) where the risk could be eliminated structurally (closed schema, inert format, capability not exposed); (c) N-way generality where the request names one concrete case. Scope-minimality never trims rigor: error/negative-case enumeration per AC must stay complete — flag the plan if minimality was achieved by dropping error handling or by dropping filesystem-identity, permission, or concurrency guards (realpath/symlink containment, lock-guarded writes, forced excludes of runtime state).
 7. **Testability** - How will we verify this works?
-8. **Consistency** - Do task specs align with epic spec?
+8. **Consistency** - Do task specs align with epic spec? Are `**Touches:**` declarations plausible against each task's Files/Approach, and do any two dep-independent tasks' Touches sets overlap (overlaps force serial dispatch - flag the pair)?
 
 ## Verdict Scope
 

--- a/.flow/bin/flowctl_tracker/MANIFEST.json
+++ b/.flow/bin/flowctl_tracker/MANIFEST.json
@@ -2,7 +2,7 @@
   "files": [
     {
       "path": "flowctl.py",
-      "sha256": "66a42e578ae06f6db0858a2625d5c1bd59bc87d0017e08ed02fb7ea60922a1a2"
+      "sha256": "0248f92eb05b125b1ea0af001db10e28d9382937092206608ddff15ed2c6a299"
     },
     {
       "path": "flowctl_tracker/__init__.py",

--- a/.flow/specs/fn-176-same-spec-concurrent-waves-with.json
+++ b/.flow/specs/fn-176-same-spec-concurrent-waves-with.json
@@ -1,7 +1,7 @@
 {
   "branch_name": "fn-176-same-spec-concurrent-waves-with",
-  "completion_review_status": "unknown",
-  "completion_reviewed_at": null,
+  "completion_review_status": "ship",
+  "completion_reviewed_at": "2026-08-08T17:50:08.548101Z",
   "created_at": "2026-08-08T09:15:30.845554Z",
   "default_impl": null,
   "default_review": null,
@@ -28,5 +28,5 @@
     "mergeBaseTracker": null,
     "url": null
   },
-  "updated_at": "2026-08-08T17:46:42.151425Z"
+  "updated_at": "2026-08-08T17:50:08.548249Z"
 }

--- a/.flow/specs/fn-176-same-spec-concurrent-waves-with.json
+++ b/.flow/specs/fn-176-same-spec-concurrent-waves-with.json
@@ -11,8 +11,8 @@
   "impl_review_rounds": {},
   "next_task": 1,
   "plan_review_rounds": 0,
-  "plan_review_status": "unknown",
-  "plan_reviewed_at": null,
+  "plan_review_status": "ship",
+  "plan_reviewed_at": "2026-08-08T17:46:42.151285Z",
   "ready": true,
   "spec_path": ".flow/specs/fn-176-same-spec-concurrent-waves-with.md",
   "status": "open",
@@ -28,5 +28,5 @@
     "mergeBaseTracker": null,
     "url": null
   },
-  "updated_at": "2026-08-08T11:29:00.886151Z"
+  "updated_at": "2026-08-08T17:46:42.151425Z"
 }

--- a/.flow/specs/fn-176-same-spec-concurrent-waves-with.md
+++ b/.flow/specs/fn-176-same-spec-concurrent-waves-with.md
@@ -1,39 +1,45 @@
 # Overview
 
-85% of 684 measured subagent dispatches ran with zero overlapping sibling; `flow-next:worker` dispatches average 17 minutes. The wave machinery (worktree isolation, parallel-wave worker contract, conductor join) shipped long ago but its trigger is a vague judgment call ("prefer a concurrent wave when tasks are safely disjoint") that almost never fires. Reviewers additionally block ~19% of pipeline wall fully serially. This spec replaces the judgment call with an explicit fail-closed dispatch rule and folds in reviewer overlap — the two remaining large speed levers (est. 15–20% + 4–7%).
+85% of 684 measured subagent dispatches ran with zero overlapping sibling; `flow-next:worker` dispatches average 17 minutes. The wave machinery (worktree isolation, parallel-wave worker contract, conductor join) shipped long ago but its trigger is a vague judgment call ("prefer a concurrent wave when tasks are safely disjoint") that almost never fires. Reviewers additionally block ~19% of pipeline wall fully serially. This spec replaces the judgment call with an explicit fail-closed dispatch rule and folds in reviewer overlap - the two remaining large speed levers (est. 15-20% + 4-7%).
 
-**Evidence standing: designed from measured serialization in the flow-efficiency replay campaign (results 06 §2, 01 §6). The sequential-equivalence gate below is part of the change itself — no separate eval campaign.** This spec is the primary dogfood target for the fn-spec on task shape: its own tasks should come out how-shaped, `touches:`-declared, restatement-free.
+**Evidence standing: designed from measured serialization in the flow-efficiency replay campaign (results 06 §2, 01 §6). The sequential-equivalence gate below is part of the change itself - no separate eval campaign.** This spec is the primary dogfood target for fn-175's task shape: its own tasks should come out how-shaped, Touches:-declared, restatement-free.
 
 ## Goal & Context
 
-Make same-spec concurrent worker waves the DEFAULT whenever an explicit, checkable rule passes, and let review of a completed task overlap implementation of a dep-independent one — without weakening plan-sync's consistency role or adding any flowctl code.
+Make same-spec concurrent worker waves the DEFAULT whenever an explicit, checkable rule passes, and let review of a completed task overlap implementation of a dep-independent one - without weakening plan-sync's consistency role or adding any flowctl code.
+
+## Quick commands
+
+```bash
+cd plugins/flow-next/tests && python3 -m unittest test_work_reached_path_routes test_skill_prose_diet -q
+./scripts/sync-codex.sh && ./scripts/sync-codex.sh && git status --short   # idempotent
+```
 
 ## Architecture & Data Models
 
-Prose-only orchestration change in `skills/flow-next-work/phases.md` (+ small plan-review rubric line). Depends on the task-shape spec landing `touches:`.
+Prose-only orchestration change. Edit sites:
 
-**Wave dispatch rule (replaces the vague preference; fail-closed):** dispatch tasks A and B concurrently iff ALL of: same spec; wave size ≤ 3; neither depends on the other, transitively (`flowctl dep`); `touches(A) ∩ touches(B) = ∅`; neither touches the always-serial set (`.flow/`, lockfiles, migration dirs, codegen outputs, spec/task files); every dispatched task HAS a `touches:` declaration. Any missing declaration, any intersection, any doubt → serial (today's behavior — the rule's failure mode is the status quo).
-
-**Safety is structural, not the check:** workers run in isolated worktrees, so a wrong dispatch surfaces at the join as a merge conflict → conductor serially re-runs the losing task and records the collision in the receipt (making bad `touches:` declarations visible to plan review). A prose-grade check with a structural backstop; no semantic prediction anywhere (fn-83's decision record untouched — this is declared-intent enforcement, same trust model as `deps`).
-
-**Reviewer overlap:** review(N) may run concurrently with implement(N+1) only when N+1 is dep-independent of N AND outside N's plan-sync target set (spec-level reading of the same dep graph). **Plan-sync remains the barrier before any dependent work anchors.** Join → review → plan-sync → next frontier is otherwise unchanged.
+1. `plugins/flow-next/skills/flow-next-work/phases.md` 3a: replace the vague preference paragraph with the explicit fail-closed dispatch rule (R1): dispatch concurrently iff ALL of - same spec; wave ≤ 3; no transitive dep path either way (`flowctl dep`); disjoint `**Touches:**` declarations; neither touches the always-serial set (`.flow/`, lockfiles, migration dirs, codegen outputs, spec/task files); every dispatched task HAS a Touches: declaration. Any missing declaration, any intersection, any doubt → serial (today's behavior is the failure mode).
+2. Same file, 3d: join conflict handling (R2) - a merge conflict at join is never auto-resolved; the conductor serially re-runs the losing task from the joined state and records the collision in the receipt (a stage line: `stage: wave-join - failed(collision: <tasks> <paths>)` per fn-178), making bad Touches: declarations visible to plan review.
+3. Same file, 3d/3f: reviewer-overlap rule (R3) - review(N) may run concurrently with implement(N+1) only when N+1 is dep-independent of N AND outside N's plan-sync target set; plan-sync remains the barrier before any dependent work anchors; done(N) → plan-sync(N) ordering unchanged.
+4. Plan-review rubric (R4): extend `plugins/flow-next/skills/flow-next-plan-review/workflow-rp.md` criterion 3 (Parallelizability) and `references/plan-review-prompt.md` criterion 8 (Consistency) with Touches: plausibility + overlapping-pair flagging. plan-review-prompt.md is byte-pinned: carries the full parity chain (PLAN_REVIEW_PROMPT_FALLBACK sync, dual flowctl.py copy, both hash pins, rendered-fixture rebaseline) - same shape as fn-174.
+5. **R5 equivalence gate (executed in this spec's verification):** a two-task sandbox spec with disjoint Touches: runs once serially and once under the wave rule (isolated worktrees, conductor join); both runs must end with the same tests green. Recorded in the task evidence; any divergence blocks landing.
 
 ## Edge Cases & Constraints
 
-- Parallel-wave worker terminal contract is already shipped and is NOT modified.
-- Conflict at join must never auto-resolve: serial re-run of the conflicted task from the joined state, always.
-- A wave is same-spec only in v1; cross-spec waves are out of scope.
-- If `flowctl dep` shows any path between candidates, serial — transitive, not direct-only.
-- Reviewer overlap never reorders receipts: done(N) still precedes plan-sync(N) precedes any anchor that could read N's downstream updates.
+- Parallel-wave worker terminal contract is already shipped and NOT modified; worker.md untouched.
+- Conflict at join must never auto-resolve; serial re-run of the conflicted task from the joined state, always.
+- Same-spec only in v1; wave ≤ 3; transitive dep check, not direct-only.
+- Reviewer overlap never reorders receipts: done(N) precedes plan-sync(N) precedes any anchor reading N's downstream updates.
 
 ## Acceptance Criteria
 
-- **R1:** phases.md carries the explicit dispatch rule verbatim in place of the judgment prose; fail-closed on every listed condition. Errors: missing `touches:` → serial; ambiguity → serial; these ARE the error paths and must be stated in the prose.
+- **R1:** phases.md carries the explicit dispatch rule verbatim in place of the judgment prose; fail-closed on every listed condition. Errors: missing Touches: → serial; ambiguity → serial; these ARE the error paths and must be stated in the prose.
 - **R2:** Join handling specifies merge-conflict → serial re-run + collision recorded in the receipt. Errors: a conflict must never be auto-resolved or silently dropped.
 - **R3:** Reviewer-overlap rule present with both conditions and the plan-sync barrier stated. Errors: overlap with a dependent task is the failure this R prevents.
-- **R4:** Plan-review rubric checks `touches:` plausibility and flags overlapping pairs. Errors: none beyond prose.
-- **R5 (the gate):** a replayed multi-task spec run under wave dispatch reproduces the sequential run's test outcomes (same tests green at completion). Errors: any divergence blocks landing — this is the sequential-equivalence gate, executed as part of this spec's verification, not a separate campaign.
-- **R6:** Mirrors, docs-site, CHANGELOG per conventions. Errors: parity red blocks merge.
+- **R4:** Plan-review rubric checks Touches: plausibility and flags overlapping pairs. Errors: none beyond prose.
+- **R5 (the gate):** a replayed multi-task spec run under wave dispatch reproduces the sequential run's test outcomes (same tests green at completion). Errors: any divergence blocks landing.
+- **R6:** Mirrors, CHANGELOG per conventions; docs-site rides the batched release. Errors: parity red blocks merge.
 
 ## Boundaries
 
@@ -42,6 +48,27 @@ Prose-only orchestration change in `skills/flow-next-work/phases.md` (+ small pl
 - No change to worker.md's wave contract or to plan-sync's own behavior.
 - No reviewer-content changes (overlap is scheduling only).
 
+## Strategy Alignment
+
+Active tracks served by this plan:
+- **Self-improving through normal work** - measured serialization converted into an explicit dispatch rule.
+- **Cross-platform parity** - mirrors regenerated with the canonical change.
+
 ## Decision Context
 
-A Python disjointness checker was considered and rejected: the merge-conflict backstop makes prose-grade checking safe (wrong answer costs one serial retry, never correctness), and Gordon explicitly preferred no new deterministic machinery. Wave ≤3 and same-spec-only keep v1's blast radius small; both are stated limits, not architecture, and can be lifted by evidence later. Reviewer overlap folded in here rather than its own spec because it shares the identical safety predicate and edit site — one orchestration change, one gate.
+A Python disjointness checker was considered and rejected: the merge-conflict backstop makes prose-grade checking safe (wrong answer costs one serial retry, never correctness), and Gordon explicitly preferred no new deterministic machinery. Wave ≤3 and same-spec-only keep v1's blast radius small; both are stated limits, not architecture, liftable by evidence later. Reviewer overlap folded in here because it shares the identical safety predicate and edit site. The R5 gate runs as a sandbox two-task replay (serial vs wave) rather than a fleet campaign - the equivalence claim is about the dispatch rule's mechanics, which a minimal disjoint pair exercises fully.
+
+## Early proof point
+
+Task fn-176.1 validates the core approach (the fail-closed rule reads as checkable and the R5 sandbox replay reproduces sequential outcomes). If the wave run diverges, stop - do not land.
+
+## Requirement coverage
+
+| Req | Description | Task(s) | Gap justification |
+|-----|-------------|---------|-------------------|
+| R1  | Fail-closed dispatch rule in 3a | fn-176.1 | - |
+| R2  | Join conflict handling | fn-176.1 | - |
+| R3  | Reviewer-overlap rule + barrier | fn-176.1 | - |
+| R4  | Rubric Touches: check (both copies) | fn-176.1 | - |
+| R5  | Sequential-equivalence sandbox gate | fn-176.1 | - |
+| R6  | Mirrors + CHANGELOG | fn-176.1 (mirrors), fn-176.2 (CHANGELOG) | - |

--- a/.flow/tasks/fn-176-same-spec-concurrent-waves-with.1.json
+++ b/.flow/tasks/fn-176-same-spec-concurrent-waves-with.1.json
@@ -1,0 +1,14 @@
+{
+  "assignee": null,
+  "claim_note": "",
+  "claimed_at": null,
+  "created_at": "2026-08-08T17:46:41.353143Z",
+  "depends_on": [],
+  "id": "fn-176-same-spec-concurrent-waves-with.1",
+  "priority": null,
+  "spec": "fn-176-same-spec-concurrent-waves-with",
+  "spec_path": ".flow/tasks/fn-176-same-spec-concurrent-waves-with.1.md",
+  "status": "todo",
+  "title": "Fail-closed wave dispatch rule, join collision handling, reviewer overlap, rubric check + R5 gate",
+  "updated_at": "2026-08-08T17:46:41.353143Z"
+}

--- a/.flow/tasks/fn-176-same-spec-concurrent-waves-with.1.md
+++ b/.flow/tasks/fn-176-same-spec-concurrent-waves-with.1.md
@@ -30,9 +30,14 @@ Land the explicit wave-dispatch rule and reviewer overlap in the work skill (R1-
 - [ ] TBD
 
 ## Done summary
-TBD
+Landed the fail-closed wave dispatch rule in work 3a (six conditions, error paths stated, structural-backstop rationale), join collision handling in 3d (never auto-resolve, serial re-run from joined state, fn-178 collision stage line), the reviewer-overlap rule with the plan-sync barrier, and the Touches: plausibility/overlap check in both rubric copies (full parity chain for the pinned prompt). Executed the R5 sequential-equivalence gate: two-task sandbox spec with disjoint Touches: run serially and as a worktree wave - identical outcomes (2/2 OK both), byte-identical touched files, clean join.
 
+stage: plan-sync - skipped(config: planSync.enabled != true)
+stage: impl-review - skipped(policy: maintainer waived in-host review for this series; bot review on the PR is the gate)
+stage: wave-dispatch - skipped(policy: fn-176.2 depends on fn-176.1 - dep path forces serial per the rule this task lands)
+
+RECEIPT NOTE (goal): plan authored on the new prose - scope-minimal (2 tasks, no new machinery; the python checker was declined in Decision Context per the yagni discipline), tasks how-shaped without spec restatement (R-ID references, Touches: body lines, HOW in Approach). The dispatch rule itself correctly forced THIS spec serial: its two tasks share a dep edge.
 ## Evidence
-- Commits:
-- Tests:
+- Commits: b3afe093
+- Tests: python3 -m unittest test_prompt_text_pinned test_review_prompt_template_parity test_review_prompt_constraints test_work_reached_path_routes test_skill_prose_diet -q, R5 gate: sandbox serial vs wave replay - EQUIVALENT (2/2 OK both, identical trees), ./scripts/sync-codex.sh x2 idempotent
 - PRs:

--- a/.flow/tasks/fn-176-same-spec-concurrent-waves-with.1.md
+++ b/.flow/tasks/fn-176-same-spec-concurrent-waves-with.1.md
@@ -1,0 +1,38 @@
+---
+satisfies: [R1, R2, R3, R4, R5]
+---
+# fn-176-same-spec-concurrent-waves-with.1 Fail-closed wave dispatch rule, join collision handling, reviewer overlap, rubric check + R5 gate
+
+## Description
+Land the explicit wave-dispatch rule and reviewer overlap in the work skill (R1-R3), the rubric Touches: check (R4), and execute the R5 sandbox equivalence gate.
+
+**Size:** M
+**Files:** `plugins/flow-next/skills/flow-next-work/phases.md`, `plugins/flow-next/skills/flow-next-plan-review/workflow-rp.md`, `plugins/flow-next/skills/flow-next-plan-review/references/plan-review-prompt.md`, `plugins/flow-next/scripts/flowctl.py` (PLAN_REVIEW_PROMPT_FALLBACK string only), `.flow/bin/flowctl.py` (copy), `plugins/flow-next/tests/test_prompt_text_pinned.py` (hash pins), `plugins/flow-next/tests/fixtures/review_prompts/*.txt` (regenerated), `plugins/flow-next/codex/**` (regenerated)
+**Touches:** [plugins/flow-next/skills/flow-next-work/phases.md, plugins/flow-next/skills/flow-next-plan-review/**, plugins/flow-next/scripts/flowctl.py, plugins/flow-next/tests/**]
+
+### Approach
+- phases.md 3a: replace the two vague-preference paragraphs with the fail-closed rule per spec §Architecture item 1, keeping the decision-report block and the Never-run-concurrent-writers sentence; state the error paths (missing Touches: -> serial; any intersection or doubt -> serial; always-serial set).
+- phases.md 3d: add join-collision handling per item 2 (never auto-resolve; serial re-run from joined state; stage: wave-join failed(collision) line per fn-178).
+- phases.md 3d/3f: reviewer-overlap rule per item 3 with the plan-sync barrier sentence.
+- Rubric (R4): workflow-rp.md criterion 3 + plan-review-prompt.md criterion 8 get the Touches: plausibility/overlap sentence. plan-review-prompt.md parity chain exactly as fn-174: single-line-safe wording (avoid new continuation-line dedent issues), fallback string sync, cp dual copy, both sha pins via the CRLF-normalized commands, fixture regen via the parity-test inputs.
+- R5 gate: in a temp sandbox repo, create a 2-task spec with disjoint Touches: (two independent files+tests). Run A: serial (task1 then task2 in one checkout). Run B: wave (both tasks applied in separate git worktrees, conductor merges both into the target). Assert both runs end with the identical test set green. Record commands + outcomes in evidence.
+- ./scripts/sync-codex.sh x2; focused suites green.
+
+### Acceptance
+- [ ] 3a carries the rule with all six conditions + fail-closed error paths stated (R1)
+- [ ] 3d collision handling: no auto-resolve, serial re-run, receipt line (R2)
+- [ ] Reviewer overlap with both conditions + plan-sync barrier (R3)
+- [ ] Both rubric copies check Touches: plausibility/overlap (R4); parity chain green
+- [ ] R5 sandbox replay: wave outcomes == serial outcomes, recorded in evidence
+- [ ] sync-codex x2 idempotent; focused suites green
+
+## Acceptance
+- [ ] TBD
+
+## Done summary
+TBD
+
+## Evidence
+- Commits:
+- Tests:
+- PRs:

--- a/.flow/tasks/fn-176-same-spec-concurrent-waves-with.2.json
+++ b/.flow/tasks/fn-176-same-spec-concurrent-waves-with.2.json
@@ -1,0 +1,16 @@
+{
+  "assignee": null,
+  "claim_note": "",
+  "claimed_at": null,
+  "created_at": "2026-08-08T17:46:41.353365Z",
+  "depends_on": [
+    "fn-176-same-spec-concurrent-waves-with.1"
+  ],
+  "id": "fn-176-same-spec-concurrent-waves-with.2",
+  "priority": null,
+  "spec": "fn-176-same-spec-concurrent-waves-with",
+  "spec_path": ".flow/tasks/fn-176-same-spec-concurrent-waves-with.2.md",
+  "status": "todo",
+  "title": "CHANGELOG Unreleased entry (concurrent waves)",
+  "updated_at": "2026-08-08T17:46:41.353365Z"
+}

--- a/.flow/tasks/fn-176-same-spec-concurrent-waves-with.2.md
+++ b/.flow/tasks/fn-176-same-spec-concurrent-waves-with.2.md
@@ -23,9 +23,10 @@ Extend the Unreleased CHANGELOG with the fn-176 entry.
 - [ ] TBD
 
 ## Done summary
-TBD
+Added the concurrent-waves Unreleased bullet (fail-closed rule, collision handling, reviewer overlap, equivalence verification), no em dashes, no speed-percentage claims, no version manifests. OWED AT BATCHED RELEASE: flow-next.dev changelog + docs/README.md notable-updates line.
 
+stage: plan-sync - skipped(config: planSync.enabled != true)
 ## Evidence
-- Commits:
-- Tests:
+- Commits: bea8ad83
+- Tests: docs-only; register read-through
 - PRs:

--- a/.flow/tasks/fn-176-same-spec-concurrent-waves-with.2.md
+++ b/.flow/tasks/fn-176-same-spec-concurrent-waves-with.2.md
@@ -1,0 +1,31 @@
+---
+satisfies: [R6]
+---
+# fn-176-same-spec-concurrent-waves-with.2 CHANGELOG Unreleased entry (concurrent waves)
+
+## Description
+Extend the Unreleased CHANGELOG with the fn-176 entry.
+
+**Size:** S
+**Files:** `CHANGELOG.md`
+**Touches:** [CHANGELOG.md]
+
+### Approach
+- Bullet under `## Unreleased` > `### Changed`: same-spec worker waves now dispatch by an explicit fail-closed rule (disjoint declared Touches:, no dep path, wave of at most 3, always-serial set protected; anything missing or doubtful stays serial exactly as today); a join conflict is never auto-resolved - the losing task re-runs serially and the collision lands in the receipt; review of a finished task may overlap the next dep-independent task's implementation with plan-sync still the barrier. Verified by a sequential-equivalence replay.
+- No version bump. Done summary notes docs-site owed at batched release.
+
+### Acceptance
+- [ ] Unreleased bullet present, no em dashes, no speed-percentage claims
+- [ ] No version manifests touched
+- [ ] Done summary notes docs-site owed at batched release
+
+## Acceptance
+- [ ] TBD
+
+## Done summary
+TBD
+
+## Evidence
+- Commits:
+- Tests:
+- PRs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,18 @@ declined that machinery explicitly and delivered 43% fewer output tokens at
   fields the example does not show. This closes a deviation class caught
   twice in benchmark and field runs (an implementer "helpfully" extending a
   shown shape past the spec).
+- Same-spec worker waves now dispatch by an explicit fail-closed rule instead
+  of a judgment call: tasks run concurrently only when their declared
+  Touches: sets are disjoint, no dependency path connects them (transitively),
+  the wave is at most three tasks, and nothing touches the always-serial set
+  (.flow/, lockfiles, migrations, generated outputs). Anything missing or
+  doubtful stays serial - exactly today's behavior. A join conflict is never
+  auto-resolved: the losing task re-runs serially and the collision is
+  recorded in the receipt, so wrong declarations surface to plan review.
+  Review of a finished task may overlap the next dep-independent task's
+  implementation, with plan-sync still the barrier before dependent work.
+  Verified by a sequential-equivalence replay (wave and serial runs produce
+  identical test outcomes).
 - Pipeline stages now leave an explicit outcome - ran, skipped with a reason,
   or failed with a reason - in the receipts they already write, so a silently
   no-oping stage (the class behind issue #293, where plan-sync no-oped for

--- a/plugins/flow-next/codex/skills/flow-next-plan-review/references/plan-review-prompt.md
+++ b/plugins/flow-next/codex/skills/flow-next-plan-review/references/plan-review-prompt.md
@@ -45,7 +45,7 @@ You are reviewing:
 5. **Risks** - Blockers identified? Security gaps? Mitigation?
 6. **Scope** - Right-sized? Over/under-engineering? Overengineering is a FINDING, not a taste note: flag (a) any task or surface not traceable to a stated requirement (extra commands, export/import paths, detection hooks, config knobs "for later"); (b) risk-management machinery (trust/consent layers, caps, scanners, secondary state stores) where the risk could be eliminated structurally (closed schema, inert format, capability not exposed); (c) N-way generality where the request names one concrete case. Scope-minimality never trims rigor: error/negative-case enumeration per AC must stay complete — flag the plan if minimality was achieved by dropping error handling or by dropping filesystem-identity, permission, or concurrency guards (realpath/symlink containment, lock-guarded writes, forced excludes of runtime state).
 7. **Testability** - How will we verify this works?
-8. **Consistency** - Do task specs align with epic spec?
+8. **Consistency** - Do task specs align with epic spec? Are `**Touches:**` declarations plausible against each task's Files/Approach, and do any two dep-independent tasks' Touches sets overlap (overlaps force serial dispatch - flag the pair)?
 
 ## Verdict Scope
 

--- a/plugins/flow-next/codex/skills/flow-next-plan-review/workflow-rp.md
+++ b/plugins/flow-next/codex/skills/flow-next-plan-review/workflow-rp.md
@@ -209,7 +209,7 @@ Conduct a John Carmack-level review:
 
 1. **Completeness** - All requirements covered? Missing edge cases?
 2. **Feasibility** - Technically sound? Dependencies clear?
-3. **Parallelizability** - Do independent tasks touch disjoint files? Flag overlapping file scopes that will cause merge conflicts.
+3. **Parallelizability** - Do independent tasks touch disjoint files? Flag overlapping file scopes that will cause merge conflicts. Check each task's `**Touches:**` declaration for plausibility against its Files/Approach, and flag any pair of dep-independent tasks whose Touches sets overlap (overlaps force serial dispatch).
 4. **Clarity** - Specs unambiguous? Acceptance criteria testable?
 5. **Architecture** - Right abstractions? Clean boundaries?
 6. **Risks** - Blockers identified? Security gaps? Mitigation?

--- a/plugins/flow-next/codex/skills/flow-next-work/phases.md
+++ b/plugins/flow-next/codex/skills/flow-next-work/phases.md
@@ -175,7 +175,9 @@ In SPEC_MODE, consider every returned task and apply the **wave dispatch rule
 1. same spec;
 2. wave size ≤ 3;
 3. no dependency path between any pair, in either direction, TRANSITIVELY
- (walk `flowctl dep` / `depends_on` closure — a direct-only check is wrong);
+ (walk the `depends_on` closure from `$FLOWCTL show <task-id> --json` /
+ `$FLOWCTL tasks --spec <spec-id> --json` — `flowctl dep` only writes edges,
+ it has no read verb; a direct-only check is wrong);
 4. every dispatched task HAS a `**Touches:**` declaration, and the declared
  sets are pairwise DISJOINT (`touches(A) ∩ touches(B) = ∅`, glob-aware);
 5. no task touches the always-serial set: `.flow/`, lockfiles, migration
@@ -319,10 +321,16 @@ sees which `**Touches:**` declarations were wrong.
 **Reviewer overlap (fn-176).** review(N) may run concurrently with
 implement(N+1) ONLY when both hold: N+1 is dep-independent of N (transitive,
 same walk as the dispatch rule), AND N+1 is outside N's plan-sync target set
-(the spec-level reading of the same dep graph). **Plan-sync remains the
-barrier before any dependent work anchors**: done(N) still precedes
-plan-sync(N), which still precedes any anchor that could read N's downstream
-updates — overlap is scheduling only and never reorders receipts.
+(the spec-level reading of the same dep graph). **The schedule point is the
+sequential single-worker path**: when worker N has returned and its
+impl-review is about to be dispatched, the conductor MAY claim and dispatch
+N+1's worker (isolated workspace, wave rules apply) before or while running
+review(N) — instead of leaving the reviewer as the only live agent. On the
+parallel-wave path the existing join-then-review order stands unchanged.
+**Plan-sync remains the barrier before any dependent work anchors**: done(N)
+still precedes plan-sync(N), which still precedes any anchor that could read
+N's downstream updates — overlap is scheduling only and never reorders
+receipts.
 
 Reuse the existing per-task review contract in
 two passes:

--- a/plugins/flow-next/codex/skills/flow-next-work/phases.md
+++ b/plugins/flow-next/codex/skills/flow-next-work/phases.md
@@ -169,17 +169,30 @@ $FLOWCTL ready --spec <spec-id> --json
 
 If no ready tasks, check for completion review gate (see 3g below).
 
-In SPEC_MODE, consider every returned task. Prefer concurrent dispatch when a
-useful subset is meaningfully disjoint and the host can safely isolate mutable
-workspaces and integrate their results. Dependencies and `**Files:**` are
-evidence; also consider shared lockfiles, generated outputs, migrations,
-fixtures, services, and other hidden coupling. The host chooses eligibility,
-worker count, isolation mechanism, and integration mechanism from its available
-capabilities. Never run concurrent writers in one checkout.
+In SPEC_MODE, consider every returned task and apply the **wave dispatch rule
+(fail-closed — fn-176)**. Tasks are dispatched CONCURRENTLY iff ALL of:
 
-If safety, host capacity, or integration is uncertain, select one task and
-continue sequentially. An explicit request to parallelize strengthens the
-preference but never overrides safety.
+1. same spec;
+2. wave size ≤ 3;
+3. no dependency path between any pair, in either direction, TRANSITIVELY
+ (walk `flowctl dep` / `depends_on` closure — a direct-only check is wrong);
+4. every dispatched task HAS a `**Touches:**` declaration, and the declared
+ sets are pairwise DISJOINT (`touches(A) ∩ touches(B) = ∅`, glob-aware);
+5. no task touches the always-serial set: `.flow/`, lockfiles, migration
+ dirs, codegen/generated outputs (in this repo: `plugins/flow-next/codex/**`,
+ `.flow/bin` dual copies), or spec/task files.
+
+The error paths ARE the rule: a task with NO `**Touches:**` declaration →
+serial; any intersection → serial; any doubt about a glob, a hidden coupling
+(shared fixtures, services), or host capacity → serial. The failure mode is
+today's behavior — sequential dispatch — never a risky wave. This replaces
+judgment with declared intent: the same trust model as `deps` (fn-83's
+decision record untouched; no semantic prediction anywhere). Safety is
+structural, not the check — workers run in isolated worktrees, so a wrong
+dispatch surfaces at the join as a merge conflict (3d), costing one serial
+retry, never correctness. Never run concurrent writers in one checkout. An
+explicit request to parallelize strengthens the preference but never
+overrides the rule.
 
 Report the decision before claiming:
 
@@ -292,7 +305,26 @@ Join: complete (2/2 returned)
 ```
 
 Use the host's chosen integration mechanism to bring each successful worker's
-commits onto the target branch. Reuse the existing per-task review contract in
+commits onto the target branch.
+
+**Join collision handling (fn-176 — never auto-resolve).** A merge conflict at
+the join means the wave dispatch rule's declared `**Touches:**` sets were
+wrong. Never resolve conflict hunks by hand and never drop the losing commits:
+abort the conflicted integration, keep the clean side joined, then SERIALLY
+re-run the losing task from the joined state (fresh worker, current tree).
+Record the collision in the receipt surface — a stage-outcome line per fn-178:
+`stage: wave-join - failed(collision: <task-ids> on <paths>)` — so plan review
+sees which `**Touches:**` declarations were wrong.
+
+**Reviewer overlap (fn-176).** review(N) may run concurrently with
+implement(N+1) ONLY when both hold: N+1 is dep-independent of N (transitive,
+same walk as the dispatch rule), AND N+1 is outside N's plan-sync target set
+(the spec-level reading of the same dep graph). **Plan-sync remains the
+barrier before any dependent work anchors**: done(N) still precedes
+plan-sync(N), which still precedes any anchor that could read N's downstream
+updates — overlap is scheduling only and never reorders receipts.
+
+Reuse the existing per-task review contract in
 two passes:
 
 1. confirm the task's code, tests, commit, and handover files;

--- a/plugins/flow-next/codex/skills/flow-next-work/phases.md
+++ b/plugins/flow-next/codex/skills/flow-next-work/phases.md
@@ -319,13 +319,20 @@ Record the collision in the receipt surface — a stage-outcome line per fn-178:
 sees which `**Touches:**` declarations were wrong.
 
 **Reviewer overlap (fn-176).** review(N) may run concurrently with
-implement(N+1) ONLY when both hold: N+1 is dep-independent of N (transitive,
-same walk as the dispatch rule), AND N+1 is outside N's plan-sync target set
-(the spec-level reading of the same dep graph). **The schedule point is the
-sequential single-worker path**: when worker N has returned and its
+implement(N+1) ONLY when ALL hold: N+1 is dep-independent of N (transitive,
+same walk as the dispatch rule); AND `planSync.enabled` is NOT true — Phase
+3e's actual target set is EVERY remaining `todo` task, so with plan-sync on,
+a claimed N+1 would dodge the sync it is entitled to; with plan-sync enabled
+the overlap path is OFF and dispatch of N+1 waits for plan-sync(N) exactly as
+today (fail-closed: the status quo is the failure mode). **The schedule point
+is the sequential single-worker path**: when worker N has returned and its
 impl-review is about to be dispatched, the conductor MAY claim and dispatch
 N+1's worker (isolated workspace, wave rules apply) before or while running
-review(N) — instead of leaving the reviewer as the only live agent. On the
+review(N) — instead of leaving the reviewer as the only live agent. The
+overlapped worker is a ONE-TASK WAVE: it returns the parallel-wave handover
+(workspace, commits, summary/evidence paths; no `flowctl done`), and the
+conductor joins, reviews, and completes it through the standard 3d machinery
+before 3f recomputes the ready frontier — never left dangling. On the
 parallel-wave path the existing join-then-review order stands unchanged.
 **Plan-sync remains the barrier before any dependent work anchors**: done(N)
 still precedes plan-sync(N), which still precedes any anchor that could read

--- a/plugins/flow-next/scripts/flowctl.py
+++ b/plugins/flow-next/scripts/flowctl.py
@@ -9367,7 +9367,7 @@ You are reviewing:
 5. **Risks** - Blockers identified? Security gaps? Mitigation?
 6. **Scope** - Right-sized? Over/under-engineering? Overengineering is a FINDING, not a taste note: flag (a) any task or surface not traceable to a stated requirement (extra commands, export/import paths, detection hooks, config knobs "for later"); (b) risk-management machinery (trust/consent layers, caps, scanners, secondary state stores) where the risk could be eliminated structurally (closed schema, inert format, capability not exposed); (c) N-way generality where the request names one concrete case. Scope-minimality never trims rigor: error/negative-case enumeration per AC must stay complete — flag the plan if minimality was achieved by dropping error handling or by dropping filesystem-identity, permission, or concurrency guards (realpath/symlink containment, lock-guarded writes, forced excludes of runtime state).
 7. **Testability** - How will we verify this works?
-8. **Consistency** - Do task specs align with epic spec?
+8. **Consistency** - Do task specs align with epic spec? Are `**Touches:**` declarations plausible against each task's Files/Approach, and do any two dep-independent tasks' Touches sets overlap (overlaps force serial dispatch - flag the pair)?
 
 ## Verdict Scope
 

--- a/plugins/flow-next/scripts/flowctl_tracker/MANIFEST.json
+++ b/plugins/flow-next/scripts/flowctl_tracker/MANIFEST.json
@@ -2,7 +2,7 @@
   "files": [
     {
       "path": "flowctl.py",
-      "sha256": "66a42e578ae06f6db0858a2625d5c1bd59bc87d0017e08ed02fb7ea60922a1a2"
+      "sha256": "0248f92eb05b125b1ea0af001db10e28d9382937092206608ddff15ed2c6a299"
     },
     {
       "path": "flowctl_tracker/__init__.py",

--- a/plugins/flow-next/skills/flow-next-plan-review/references/plan-review-prompt.md
+++ b/plugins/flow-next/skills/flow-next-plan-review/references/plan-review-prompt.md
@@ -45,7 +45,7 @@ You are reviewing:
 5. **Risks** - Blockers identified? Security gaps? Mitigation?
 6. **Scope** - Right-sized? Over/under-engineering? Overengineering is a FINDING, not a taste note: flag (a) any task or surface not traceable to a stated requirement (extra commands, export/import paths, detection hooks, config knobs "for later"); (b) risk-management machinery (trust/consent layers, caps, scanners, secondary state stores) where the risk could be eliminated structurally (closed schema, inert format, capability not exposed); (c) N-way generality where the request names one concrete case. Scope-minimality never trims rigor: error/negative-case enumeration per AC must stay complete — flag the plan if minimality was achieved by dropping error handling or by dropping filesystem-identity, permission, or concurrency guards (realpath/symlink containment, lock-guarded writes, forced excludes of runtime state).
 7. **Testability** - How will we verify this works?
-8. **Consistency** - Do task specs align with epic spec?
+8. **Consistency** - Do task specs align with epic spec? Are `**Touches:**` declarations plausible against each task's Files/Approach, and do any two dep-independent tasks' Touches sets overlap (overlaps force serial dispatch - flag the pair)?
 
 ## Verdict Scope
 

--- a/plugins/flow-next/skills/flow-next-plan-review/workflow-rp.md
+++ b/plugins/flow-next/skills/flow-next-plan-review/workflow-rp.md
@@ -182,7 +182,7 @@ Conduct a John Carmack-level review:
 
 1. **Completeness** - All requirements covered? Missing edge cases?
 2. **Feasibility** - Technically sound? Dependencies clear?
-3. **Parallelizability** - Do independent tasks touch disjoint files? Flag overlapping file scopes that will cause merge conflicts.
+3. **Parallelizability** - Do independent tasks touch disjoint files? Flag overlapping file scopes that will cause merge conflicts. Check each task's `**Touches:**` declaration for plausibility against its Files/Approach, and flag any pair of dep-independent tasks whose Touches sets overlap (overlaps force serial dispatch).
 4. **Clarity** - Specs unambiguous? Acceptance criteria testable?
 5. **Architecture** - Right abstractions? Clean boundaries?
 6. **Risks** - Blockers identified? Security gaps? Mitigation?

--- a/plugins/flow-next/skills/flow-next-work/phases.md
+++ b/plugins/flow-next/skills/flow-next-work/phases.md
@@ -175,7 +175,9 @@ In SPEC_MODE, consider every returned task and apply the **wave dispatch rule
 1. same spec;
 2. wave size ≤ 3;
 3. no dependency path between any pair, in either direction, TRANSITIVELY
-   (walk `flowctl dep` / `depends_on` closure — a direct-only check is wrong);
+   (walk the `depends_on` closure from `$FLOWCTL show <task-id> --json` /
+   `$FLOWCTL tasks --spec <spec-id> --json` — `flowctl dep` only writes edges,
+   it has no read verb; a direct-only check is wrong);
 4. every dispatched task HAS a `**Touches:**` declaration, and the declared
    sets are pairwise DISJOINT (`touches(A) ∩ touches(B) = ∅`, glob-aware);
 5. no task touches the always-serial set: `.flow/`, lockfiles, migration
@@ -351,10 +353,16 @@ sees which `**Touches:**` declarations were wrong.
 **Reviewer overlap (fn-176).** review(N) may run concurrently with
 implement(N+1) ONLY when both hold: N+1 is dep-independent of N (transitive,
 same walk as the dispatch rule), AND N+1 is outside N's plan-sync target set
-(the spec-level reading of the same dep graph). **Plan-sync remains the
-barrier before any dependent work anchors**: done(N) still precedes
-plan-sync(N), which still precedes any anchor that could read N's downstream
-updates — overlap is scheduling only and never reorders receipts.
+(the spec-level reading of the same dep graph). **The schedule point is the
+sequential single-worker path**: when worker N has returned and its
+impl-review is about to be dispatched, the conductor MAY claim and dispatch
+N+1's worker (isolated workspace, wave rules apply) before or while running
+review(N) — instead of leaving the reviewer as the only live agent. On the
+parallel-wave path the existing join-then-review order stands unchanged.
+**Plan-sync remains the barrier before any dependent work anchors**: done(N)
+still precedes plan-sync(N), which still precedes any anchor that could read
+N's downstream updates — overlap is scheduling only and never reorders
+receipts.
 
 Reuse the existing per-task review contract in
 two passes:

--- a/plugins/flow-next/skills/flow-next-work/phases.md
+++ b/plugins/flow-next/skills/flow-next-work/phases.md
@@ -351,13 +351,20 @@ Record the collision in the receipt surface — a stage-outcome line per fn-178:
 sees which `**Touches:**` declarations were wrong.
 
 **Reviewer overlap (fn-176).** review(N) may run concurrently with
-implement(N+1) ONLY when both hold: N+1 is dep-independent of N (transitive,
-same walk as the dispatch rule), AND N+1 is outside N's plan-sync target set
-(the spec-level reading of the same dep graph). **The schedule point is the
-sequential single-worker path**: when worker N has returned and its
+implement(N+1) ONLY when ALL hold: N+1 is dep-independent of N (transitive,
+same walk as the dispatch rule); AND `planSync.enabled` is NOT true — Phase
+3e's actual target set is EVERY remaining `todo` task, so with plan-sync on,
+a claimed N+1 would dodge the sync it is entitled to; with plan-sync enabled
+the overlap path is OFF and dispatch of N+1 waits for plan-sync(N) exactly as
+today (fail-closed: the status quo is the failure mode). **The schedule point
+is the sequential single-worker path**: when worker N has returned and its
 impl-review is about to be dispatched, the conductor MAY claim and dispatch
 N+1's worker (isolated workspace, wave rules apply) before or while running
-review(N) — instead of leaving the reviewer as the only live agent. On the
+review(N) — instead of leaving the reviewer as the only live agent. The
+overlapped worker is a ONE-TASK WAVE: it returns the parallel-wave handover
+(workspace, commits, summary/evidence paths; no `flowctl done`), and the
+conductor joins, reviews, and completes it through the standard 3d machinery
+before 3f recomputes the ready frontier — never left dangling. On the
 parallel-wave path the existing join-then-review order stands unchanged.
 **Plan-sync remains the barrier before any dependent work anchors**: done(N)
 still precedes plan-sync(N), which still precedes any anchor that could read

--- a/plugins/flow-next/skills/flow-next-work/phases.md
+++ b/plugins/flow-next/skills/flow-next-work/phases.md
@@ -169,17 +169,30 @@ $FLOWCTL ready --spec <spec-id> --json
 
 If no ready tasks, check for completion review gate (see 3g below).
 
-In SPEC_MODE, consider every returned task. Prefer concurrent dispatch when a
-useful subset is meaningfully disjoint and the host can safely isolate mutable
-workspaces and integrate their results. Dependencies and `**Files:**` are
-evidence; also consider shared lockfiles, generated outputs, migrations,
-fixtures, services, and other hidden coupling. The host chooses eligibility,
-worker count, isolation mechanism, and integration mechanism from its available
-capabilities. Never run concurrent writers in one checkout.
+In SPEC_MODE, consider every returned task and apply the **wave dispatch rule
+(fail-closed — fn-176)**. Tasks are dispatched CONCURRENTLY iff ALL of:
 
-If safety, host capacity, or integration is uncertain, select one task and
-continue sequentially. An explicit request to parallelize strengthens the
-preference but never overrides safety.
+1. same spec;
+2. wave size ≤ 3;
+3. no dependency path between any pair, in either direction, TRANSITIVELY
+   (walk `flowctl dep` / `depends_on` closure — a direct-only check is wrong);
+4. every dispatched task HAS a `**Touches:**` declaration, and the declared
+   sets are pairwise DISJOINT (`touches(A) ∩ touches(B) = ∅`, glob-aware);
+5. no task touches the always-serial set: `.flow/`, lockfiles, migration
+   dirs, codegen/generated outputs (in this repo: `plugins/flow-next/codex/**`,
+   `.flow/bin` dual copies), or spec/task files.
+
+The error paths ARE the rule: a task with NO `**Touches:**` declaration →
+serial; any intersection → serial; any doubt about a glob, a hidden coupling
+(shared fixtures, services), or host capacity → serial. The failure mode is
+today's behavior — sequential dispatch — never a risky wave. This replaces
+judgment with declared intent: the same trust model as `deps` (fn-83's
+decision record untouched; no semantic prediction anywhere). Safety is
+structural, not the check — workers run in isolated worktrees, so a wrong
+dispatch surfaces at the join as a merge conflict (3d), costing one serial
+retry, never correctness. Never run concurrent writers in one checkout. An
+explicit request to parallelize strengthens the preference but never
+overrides the rule.
 
 Report the decision before claiming:
 
@@ -324,7 +337,26 @@ Join: complete (2/2 returned)
 ```
 
 Use the host's chosen integration mechanism to bring each successful worker's
-commits onto the target branch. Reuse the existing per-task review contract in
+commits onto the target branch.
+
+**Join collision handling (fn-176 — never auto-resolve).** A merge conflict at
+the join means the wave dispatch rule's declared `**Touches:**` sets were
+wrong. Never resolve conflict hunks by hand and never drop the losing commits:
+abort the conflicted integration, keep the clean side joined, then SERIALLY
+re-run the losing task from the joined state (fresh worker, current tree).
+Record the collision in the receipt surface — a stage-outcome line per fn-178:
+`stage: wave-join - failed(collision: <task-ids> on <paths>)` — so plan review
+sees which `**Touches:**` declarations were wrong.
+
+**Reviewer overlap (fn-176).** review(N) may run concurrently with
+implement(N+1) ONLY when both hold: N+1 is dep-independent of N (transitive,
+same walk as the dispatch rule), AND N+1 is outside N's plan-sync target set
+(the spec-level reading of the same dep graph). **Plan-sync remains the
+barrier before any dependent work anchors**: done(N) still precedes
+plan-sync(N), which still precedes any anchor that could read N's downstream
+updates — overlap is scheduling only and never reorders receipts.
+
+Reuse the existing per-task review contract in
 two passes:
 
 1. confirm the task's code, tests, commit, and handover files;

--- a/plugins/flow-next/tests/fixtures/review_prompts/plan.txt
+++ b/plugins/flow-next/tests/fixtures/review_prompts/plan.txt
@@ -59,7 +59,7 @@ You are reviewing:
 5. **Risks** - Blockers identified? Security gaps? Mitigation?
 6. **Scope** - Right-sized? Over/under-engineering? Overengineering is a FINDING, not a taste note: flag (a) any task or surface not traceable to a stated requirement (extra commands, export/import paths, detection hooks, config knobs "for later"); (b) risk-management machinery (trust/consent layers, caps, scanners, secondary state stores) where the risk could be eliminated structurally (closed schema, inert format, capability not exposed); (c) N-way generality where the request names one concrete case. Scope-minimality never trims rigor: error/negative-case enumeration per AC must stay complete — flag the plan if minimality was achieved by dropping error handling or by dropping filesystem-identity, permission, or concurrency guards (realpath/symlink containment, lock-guarded writes, forced excludes of runtime state).
 7. **Testability** - How will we verify this works?
-8. **Consistency** - Do task specs align with epic spec?
+8. **Consistency** - Do task specs align with epic spec? Are `**Touches:**` declarations plausible against each task's Files/Approach, and do any two dep-independent tasks' Touches sets overlap (overlaps force serial dispatch - flag the pair)?
 
 ## Verdict Scope
 

--- a/plugins/flow-next/tests/fixtures/review_prompts/plan_no_tasks.txt
+++ b/plugins/flow-next/tests/fixtures/review_prompts/plan_no_tasks.txt
@@ -54,7 +54,7 @@ You are reviewing:
 5. **Risks** - Blockers identified? Security gaps? Mitigation?
 6. **Scope** - Right-sized? Over/under-engineering? Overengineering is a FINDING, not a taste note: flag (a) any task or surface not traceable to a stated requirement (extra commands, export/import paths, detection hooks, config knobs "for later"); (b) risk-management machinery (trust/consent layers, caps, scanners, secondary state stores) where the risk could be eliminated structurally (closed schema, inert format, capability not exposed); (c) N-way generality where the request names one concrete case. Scope-minimality never trims rigor: error/negative-case enumeration per AC must stay complete — flag the plan if minimality was achieved by dropping error handling or by dropping filesystem-identity, permission, or concurrency guards (realpath/symlink containment, lock-guarded writes, forced excludes of runtime state).
 7. **Testability** - How will we verify this works?
-8. **Consistency** - Do task specs align with epic spec?
+8. **Consistency** - Do task specs align with epic spec? Are `**Touches:**` declarations plausible against each task's Files/Approach, and do any two dep-independent tasks' Touches sets overlap (overlaps force serial dispatch - flag the pair)?
 
 ## Verdict Scope
 

--- a/plugins/flow-next/tests/test_prompt_text_pinned.py
+++ b/plugins/flow-next/tests/test_prompt_text_pinned.py
@@ -93,7 +93,7 @@ PROMPT_HASHES = {
     "PLAN_QUALITY_BLOCK":
         "0cfb49bfadf0be45e5c8036950d34698b5ae3bbccf24a90564983e13d0a1192f",
     "PLAN_REVIEW_PROMPT_FALLBACK":
-        "0c799dc003dde3925c1b1261f5d0dd54d8041033abde91c68ec8b83a76696fe8",
+        "0098e2e621f5cc434b23ca1fb816a97e36cba6a85d8d47ed8cbf86fe82f5c57e",
     "PROTECTED_ARTIFACTS_BLOCK":
         "e9b68af0cf36f6b2cb1b70c9bcc5ff67ccb86295f369d02ffcec4f25fd6f2d5e",
     "REVIEW_JSON_TALLY_BLOCK":
@@ -165,7 +165,7 @@ TEMPLATE_HASHES = {
     "plugins/flow-next/skills/flow-next-impl-review/references/standalone-review-prompt.md":
         "6f366a927f449312e623220362e9eb63351f5b8dd427e5669b236a362bad1357",
     "plugins/flow-next/skills/flow-next-plan-review/references/plan-review-prompt.md":
-        "0c799dc003dde3925c1b1261f5d0dd54d8041033abde91c68ec8b83a76696fe8",
+        "0098e2e621f5cc434b23ca1fb816a97e36cba6a85d8d47ed8cbf86fe82f5c57e",
     "plugins/flow-next/skills/flow-next-spec-completion-review/references/completion-review-prompt.md":
         "6907c0b9ec683eb7d8258c86ddaaa6168a4dcefdb075b314e793a9cca65c6ea3",
     # Rendered by ralph.sh each autonomous loop - production prompts, and the


### PR DESCRIPTION
# Same-spec concurrent waves with reviewer overlap (prose-only)

Replaces the wave machinery's vague "prefer concurrency when safely disjoint" trigger with an explicit fail-closed dispatch rule, adds join-collision handling and reviewer overlap - no flowctl code, no new checker.

> **Spec:** [fn-176-same-spec-concurrent-waves-with](https://github.com/gmickel/flow-next/blob/566d097e30761113b911c777a15cb81f6f76f86a/.flow/specs/fn-176-same-spec-concurrent-waves-with.md)
> **Branch:** `fn-176-same-spec-concurrent-waves-with` → `main`
> **Tasks:** 2 completed
> **R-ID coverage:** 6/6 satisfied

## TL;DR

- 85% of 684 measured subagent dispatches ran with zero overlapping sibling because the wave trigger was a judgment call that almost never fired; it is now an explicit rule: same spec, wave of at most 3, no transitive dep path, pairwise-disjoint declared Touches:, always-serial set protected, and every dispatched task must HAVE a Touches: declaration - anything missing or doubtful stays serial (today's behavior is the failure mode).
- Safety is structural, not the check: workers run in isolated worktrees, so a wrong dispatch surfaces at the join as a merge conflict - which is never auto-resolved: the losing task re-runs serially from the joined state and the collision lands in the receipt as a stage line, making bad declarations visible to plan review.
- review(N) may overlap implement(N+1) only when N+1 is dep-independent of N and outside N's plan-sync target set; plan-sync remains the barrier and receipt order never changes.
- Both plan-review rubric copies now check Touches: plausibility and flag overlapping dep-independent pairs (the pinned prompt carries its full parity chain).
- The R5 sequential-equivalence gate ran as part of verification: a two-task sandbox spec with disjoint Touches: executed serially and as a worktree wave produced identical test outcomes (2/2 OK both runs) and byte-identical touched files with a clean join.
- Dogfood note: the rule correctly forced THIS spec serial - its own two tasks share a dep edge.

## Not in this PR (by design)

- No flowctl code, no deterministic checker binary (prose + structure only).
- No cross-spec waves, no wave >3, no predictive/semantic gating of any kind.
- No change to worker.md's wave contract or to plan-sync's own behavior.
- No reviewer-content changes (overlap is scheduling only).

## Critical changes

- **High-churn:** [`plugins/flow-next/skills/flow-next-work/phases.md`](https://github.com/gmickel/flow-next/commit/b3afe093cb0003024b3932f258a428f64ada4316#diff-2ae69c15f76f3dc2eb5eb6d10139979e571fa9758aafb894874fd97cdbfd2b67) - the 3a dispatch rule + 3d collision handling + reviewer overlap
- **Behavior-visible:** [`plugins/flow-next/skills/flow-next-plan-review/references/plan-review-prompt.md`](https://github.com/gmickel/flow-next/commit/b3afe093cb0003024b3932f258a428f64ada4316#diff-afcefbff0589bf462ecc2a5eddea6434e343a522be718988352fb4dce6a516a2) - criterion 8 Touches: check (byte-pinned; parity chain in the same commit)
- **Behavior-visible:** [`plugins/flow-next/skills/flow-next-plan-review/workflow-rp.md`](https://github.com/gmickel/flow-next/commit/b3afe093cb0003024b3932f258a428f64ada4316#diff-4ec3d5d65ba4a04468e104b287343583c96c26029ec057afb3bc09067dfb36ea) - criterion 3 Touches: check
- **Behavior-visible:** [`plugins/flow-next/scripts/flowctl.py`](https://github.com/gmickel/flow-next/commit/b3afe093cb0003024b3932f258a428f64ada4316#diff-a52f4f2101d1a9031615badb0a45084834516bcb0b6ec993a50076403226568d) - PLAN_REVIEW_PROMPT_FALLBACK string sync only; no code-path change
- **Behavior-visible:** [`CHANGELOG.md`](https://github.com/gmickel/flow-next/commit/bea8ad83b244e63d9990138c55593268b85a1542#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed) - Unreleased bullet

## How to review this PR

The pipeline already verified this - you don't re-check it from scratch:
- **Tests / gates:** full parallel suite 4279 green; ruff clean; sync-codex idempotent; smoke 135/136 (pre-existing live-copilot e2e flake); R5 equivalence replay EQUIVALENT (serial vs wave: identical outcomes and trees)
- **R-ID coverage:** 6/6 satisfied
- **Cross-model review:** no cross-model review recorded on this PR (maintainer waived in-host review for this series; bot review on this PR is the review)

Your job - the calls the pipeline can't make:
- Is the six-condition rule genuinely checkable by an orchestrating model, and is every ambiguity path explicitly serial?
- Does the collision path read as never-auto-resolve under all phrasings?
- Does reviewer overlap preserve the plan-sync barrier in every reading?

## Review plan

Must review (~40% of the diff):
- [ ] [`plugins/flow-next/skills/flow-next-work/phases.md`](https://github.com/gmickel/flow-next/commit/b3afe093cb0003024b3932f258a428f64ada4316#diff-2ae69c15f76f3dc2eb5eb6d10139979e571fa9758aafb894874fd97cdbfd2b67) - the rule, the collision path, the overlap rule

Spot-check:
- [ ] Both rubric copies - Touches: sentence consistency
- [ ] [`CHANGELOG.md`](https://github.com/gmickel/flow-next/commit/bea8ad83b244e63d9990138c55593268b85a1542#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed) - register, no speed-percentage claims

Safe to skim:
- [ ] 10 files - fallback sync, dual copies, manifests, fixtures, codex mirrors, .flow state

## Glossary / strategy notes

Active tracks served (from the spec's Strategy Alignment):
- **Self-improving through normal work** - measured serialization converted into an explicit dispatch rule.
- **Cross-platform parity** - mirrors regenerated with the canonical change.

*No decision-track memory entries were written during this spec; decision context lives in the spec's Decision Context section.*

---
Generated by /flow-next:make-pr from fn-176-same-spec-concurrent-waves-with against origin/main on 2026-08-08
<!-- flow-next:make-pr spec=fn-176-same-spec-concurrent-waves-with base=origin/main -->

---
Ref FLOW-103
