### PR TITLE
Wrong answers become marked answers: status output carries its provena…

### DIFF
--- a/.flow/bin/flowctl.py
+++ b/.flow/bin/flowctl.py
@@ -33629,11 +33629,14 @@ def upstream_behind() -> Optional[tuple]:
 
     `git status --porcelain=v2 --branch` reports the upstream ref name and
     the ahead/behind pair in a single spawn, so the advisory never needs a
-    second `rev-parse` to name the ref. `-uno` skips the untracked walk.
+    second `rev-parse` to name the ref. `-uno` skips the untracked walk;
+    `--no-optional-locks` keeps the probe strictly read-only (no opportunistic
+    index.lock refresh under a concurrent git process).
     """
     try:
         result = subprocess.run(
-            ["git", "status", "--porcelain=v2", "--branch", "-uno"],
+            ["git", "--no-optional-locks", "status", "--porcelain=v2",
+             "--branch", "-uno"],
             capture_output=True,
             text=True, encoding="utf-8",
             check=True,

--- a/.flow/bin/flowctl.py
+++ b/.flow/bin/flowctl.py
@@ -298,6 +298,17 @@ RUNTIME_FIELDS = {
     "blocked_reason",
 }
 
+# fn-181 R1: provenance of the `status` a read surface just answered with.
+# "flow-state" = the runtime state store answered (authoritative).
+# "committed"  = no runtime entry; the answer came from the tracked task
+#                definition file, which is a snapshot and may be stale.
+STATUS_SOURCE_FLOW_STATE = "flow-state"
+STATUS_SOURCE_COMMITTED = "committed"
+STATUS_SOURCE_ABSENT_NOTE = (
+    "note: runtime state absent; task status read from committed files "
+    "and may be stale"
+)
+
 
 # --- Helpers ---
 
@@ -1044,15 +1055,46 @@ def load_task_with_state(task_id: str, use_json: bool = True) -> dict:
 
 
 def merge_task_runtime(definition: dict, runtime: Optional[dict]) -> dict:
-    """Merge one tracked task definition with its authoritative runtime state."""
+    """Merge one tracked task definition with its authoritative runtime state.
+
+    fn-181 R1: the merge already knows which store answered, so it stamps
+    `status_source` — "flow-state" when the runtime store had an entry,
+    "committed" when the answer came from the tracked definition file (the
+    legacy fallback, which can be arbitrarily stale). Provenance only: no
+    merge semantics change. The key is stripped on every persisted write
+    (`canonicalize_task_for_write`) so it never lands in a tracked file.
+    """
+    source = STATUS_SOURCE_FLOW_STATE
     if runtime is None:
+        source = STATUS_SOURCE_COMMITTED
         # Backward compat: extract runtime fields from definition.
         runtime = {k: definition[k] for k in RUNTIME_FIELDS if k in definition}
         if not runtime:
             runtime = {"status": "todo"}
 
     # Merge: runtime overwrites definition for runtime fields.
-    return normalize_task({**definition, **runtime})
+    merged = normalize_task({**definition, **runtime})
+    merged["status_source"] = source
+    return merged
+
+
+def runtime_state_absent() -> bool:
+    """True when the runtime state directory does not exist (fn-181 R1).
+
+    Read surfaces use this for ONE plain-output advisory per invocation.
+    No new git spawn: `get_state_dir` is memoized and every caller of this
+    helper has already resolved the state dir to merge runtime state.
+    """
+    try:
+        return not get_state_dir().exists()
+    except OSError:
+        return False
+
+
+def print_status_source_advisory() -> None:
+    """Print the one-per-invocation stale-status advisory when warranted."""
+    if runtime_state_absent():
+        print(STATUS_SOURCE_ABSENT_NOTE)
 
 
 def save_task_runtime(task_id: str, updates: dict) -> None:
@@ -3716,6 +3758,10 @@ def canonicalize_task_for_write(task_data: dict) -> dict:
     if "spec" not in task_data and "epic" in task_data:
         task_data["spec"] = task_data["epic"]
     task_data.pop("epic", None)
+    # fn-181 R1: `status_source` is a read-surface annotation stamped by
+    # merge_task_runtime — never persisted. Stripping it here keeps every
+    # write path (which may start from a merged task) free of it.
+    task_data.pop("status_source", None)
     # Same shape for the historic _id form (very few callers use it; cheap to handle).
     if "spec_id" not in task_data and "epic_id" in task_data:
         task_data["spec_id"] = task_data["epic_id"]
@@ -29533,6 +29579,10 @@ def cmd_show(args: argparse.Namespace) -> None:
                     "id": task_data["id"],
                     "title": task_data["title"],
                     "status": task_data["status"],
+                    # fn-181 R1: same field, same merge — not a parallel path.
+                    "status_source": task_data.get(
+                        "status_source", STATUS_SOURCE_COMMITTED
+                    ),
                     "priority": task_data.get("priority"),
                     "depends_on": task_data.get(
                         "depends_on", task_data.get("deps", [])
@@ -29552,6 +29602,7 @@ def cmd_show(args: argparse.Namespace) -> None:
         if args.json:
             json_output(result)
         else:
+            print_status_source_advisory()
             print(f"Spec: {epic_data['id']}")
             print(f"Title: {epic_data['title']}")
             print(f"Status: {epic_data['status']}")
@@ -29577,6 +29628,7 @@ def cmd_show(args: argparse.Namespace) -> None:
         if args.json:
             json_output(task_data)
         else:
+            print_status_source_advisory()
             print(f"Task: {task_data['id']}")
             print(f"Spec: {spec_value}")
             print(f"Title: {task_data['title']}")
@@ -29764,6 +29816,10 @@ def cmd_list(args: argparse.Namespace) -> None:
                 "spec": spec_value,
                 "title": task_data["title"],
                 "status": task_data["status"],
+                # fn-181 R1: provenance of the status above; always present.
+                "status_source": task_data.get(
+                    "status_source", STATUS_SOURCE_COMMITTED
+                ),
                 "priority": task_data.get("priority"),
                 "depends_on": task_data.get(
                     "depends_on", task_data.get("deps", [])
@@ -29797,6 +29853,7 @@ def cmd_list(args: argparse.Namespace) -> None:
             }
         )
     else:
+        print_status_source_advisory()
         if not specs:
             print("No specs or tasks found.")
             return
@@ -33553,6 +33610,68 @@ def _task_set_section(
         print(f"Task {task_id} {section} updated")
 
 
+# --- fn-181 R3/R4/R5: behind-upstream staleness advisory ---
+#
+# INSPECTION NOTE (R4): the ONLY call sites are `cmd_ready` / `cmd_ready_all`
+# and `cmd_anchor` — the ask-before-work commands. `list`, `status`, and
+# `next` deliberately do NOT call it: they are the high-frequency polls fn-109
+# made 60x faster, and a git spawn there regresses that win. Adding a call
+# site is a spec change, not a refactor (guarded by
+# `test_upstream_advisory.py`).
+#
+# ONE git spawn per invocation (R5), never a fetch, never blocking. Any git
+# failure — no upstream, detached HEAD, not a repo, git missing, offline —
+# degrades to "no advisory", never to a command failure (R3 error clause).
+
+
+def upstream_behind() -> Optional[tuple]:
+    """Return ``(behind_count, upstream_ref)`` when HEAD is behind, else None.
+
+    `git status --porcelain=v2 --branch` reports the upstream ref name and
+    the ahead/behind pair in a single spawn, so the advisory never needs a
+    second `rev-parse` to name the ref. `-uno` skips the untracked walk.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "status", "--porcelain=v2", "--branch", "-uno"],
+            capture_output=True,
+            text=True, encoding="utf-8",
+            check=True,
+        )
+    except (subprocess.CalledProcessError, OSError, ValueError):
+        return None
+
+    upstream = None
+    behind = 0
+    for line in result.stdout.splitlines():
+        if not line.startswith("# branch."):
+            # Branch headers precede all file entries; nothing left to read.
+            if not line.startswith("#"):
+                break
+            continue
+        if line.startswith("# branch.upstream "):
+            upstream = line[len("# branch.upstream "):].strip()
+        elif line.startswith("# branch.ab "):
+            for token in line.split()[2:]:
+                if token.startswith("-"):
+                    try:
+                        behind = int(token[1:])
+                    except ValueError:
+                        return None
+    if not upstream or behind <= 0:
+        return None
+    return behind, upstream
+
+
+def upstream_stale_note(behind: int, upstream: str) -> str:
+    """The one advisory line printed by ready/anchor when behind upstream."""
+    plural = "" if behind == 1 else "s"
+    return (
+        f"note: checkout is {behind} commit{plural} behind {upstream}; "
+        f"spec-level state may be stale"
+    )
+
+
 def cmd_ready_all(args: argparse.Namespace) -> None:
     """Spec-level eligibility FACTS for the whole backlog (fn-68.1, R1/R8/R9).
 
@@ -33581,6 +33700,7 @@ def cmd_ready_all(args: argparse.Namespace) -> None:
     Done specs are skipped — the backlog is the open frontier.
     """
     flow_dir = get_flow_dir()
+    stale = upstream_behind()  # fn-181 R3/R5: one check per invocation.
 
     rows = []
     for spec_file in iter_spec_json_files(flow_dir):
@@ -33633,8 +33753,13 @@ def cmd_ready_all(args: argparse.Namespace) -> None:
     rows.sort(key=lambda r: id_sort_key(r["id"]))
 
     if args.json:
-        json_output({"success": True, "specs": rows, "count": len(rows)})
+        payload = {"success": True, "specs": rows, "count": len(rows)}
+        if stale:
+            payload["stale_vs_upstream"] = stale[0]
+        json_output(payload)
     else:
+        if stale:
+            print(upstream_stale_note(*stale))
         if not rows:
             print("No open specs.")
         else:
@@ -33661,6 +33786,10 @@ def cmd_ready(args: argparse.Namespace) -> None:
     if getattr(args, "all", False):
         cmd_ready_all(args)
         return
+
+    # fn-181 R3/R5: one upstream check per invocation, AFTER the --all
+    # dispatch so the two branches never both run it.
+    stale = upstream_behind()
 
     spec_id = resolve_spec_arg(args, get_flow_dir())
     if not spec_id or not is_spec_id(spec_id):
@@ -33699,17 +33828,20 @@ def cmd_ready(args: argparse.Namespace) -> None:
             blocked_by_specs.append(dep)
     if blocked_by_specs:
         if args.json:
-            json_output(
-                {
-                    "spec": spec_id,
-                    "actor": current_actor,
-                    "ready": [],
-                    "in_progress": [],
-                    "blocked": [],
-                    "blocked_by_specs": blocked_by_specs,
-                }
-            )
+            payload = {
+                "spec": spec_id,
+                "actor": current_actor,
+                "ready": [],
+                "in_progress": [],
+                "blocked": [],
+                "blocked_by_specs": blocked_by_specs,
+            }
+            if stale:
+                payload["stale_vs_upstream"] = stale[0]
+            json_output(payload)
         else:
+            if stale:
+                print(upstream_stale_note(*stale))
             print(f"Spec {spec_id} is blocked by: {', '.join(blocked_by_specs)}")
         return
 
@@ -33777,29 +33909,32 @@ def cmd_ready(args: argparse.Namespace) -> None:
     blocked.sort(key=lambda x: sort_key(x["task"]))
 
     if args.json:
-        json_output(
-            {
-                "spec": spec_id,
-                "actor": current_actor,
-                "ready": [
-                    {"id": t["id"], "title": t["title"], "depends_on": t["depends_on"]}
-                    for t in ready
-                ],
-                "in_progress": [
-                    {"id": t["id"], "title": t["title"], "assignee": t.get("assignee")}
-                    for t in in_progress
-                ],
-                "blocked": [
-                    {
-                        "id": b["task"]["id"],
-                        "title": b["task"]["title"],
-                        "blocked_by": b["blocked_by"],
-                    }
-                    for b in blocked
-                ],
-            }
-        )
+        payload = {
+            "spec": spec_id,
+            "actor": current_actor,
+            "ready": [
+                {"id": t["id"], "title": t["title"], "depends_on": t["depends_on"]}
+                for t in ready
+            ],
+            "in_progress": [
+                {"id": t["id"], "title": t["title"], "assignee": t.get("assignee")}
+                for t in in_progress
+            ],
+            "blocked": [
+                {
+                    "id": b["task"]["id"],
+                    "title": b["task"]["title"],
+                    "blocked_by": b["blocked_by"],
+                }
+                for b in blocked
+            ],
+        }
+        if stale:
+            payload["stale_vs_upstream"] = stale[0]
+        json_output(payload)
     else:
+        if stale:
+            print(upstream_stale_note(*stale))
         print(f"Ready tasks for {spec_id} (actor: {current_actor}):")
         if ready:
             for t in ready:
@@ -35495,16 +35630,18 @@ def cmd_anchor(args: argparse.Namespace) -> None:
 
     sections = _anchor_sections(task_id, spec_id)
     dependencies = _anchor_dependencies(flow_dir, task_data)
+    stale = upstream_behind()  # fn-181 R3/R5: one check per invocation.
 
     if use_json:
-        json_output(
-            {
-                "task": task_id,
-                "spec": spec_id,
-                "sections": sections,
-                "dependencies": dependencies,
-            }
-        )
+        payload = {
+            "task": task_id,
+            "spec": spec_id,
+            "sections": sections,
+            "dependencies": dependencies,
+        }
+        if stale:
+            payload["stale_vs_upstream"] = stale[0]
+        json_output(payload)
         return
 
     # Markdown render (default): worker-facing, clear banners, same order
@@ -35520,6 +35657,9 @@ def cmd_anchor(args: argparse.Namespace) -> None:
         "available.",
         "",
     ]
+    if stale:
+        lines.append(upstream_stale_note(*stale))
+        lines.append("")
     for i, s in enumerate(sections, start=1):
         lines.append(f"===== [{i}/{total}] {s['name']}: `{s['command']}` =====")
         if s.get("note"):

--- a/.flow/bin/flowctl.py
+++ b/.flow/bin/flowctl.py
@@ -9427,6 +9427,11 @@ Do NOT mark NEEDS_WORK for:
 - Pre-existing codebase issues unrelated to this plan
 - Suggestions for features outside the plan scope
 - "While we're at it" improvements
+- Task lifecycle: a task looking not-started or not-done in committed files
+
+Committed `.flow/tasks/<id>.json` `status` fields are snapshots, not authoritative; live
+lifecycle state is runtime state in the git-common-dir flow-state store, outside the diff and
+unreachable from this review context. Read task files for their content, never for their status.
 
 You MAY mention these as "FYI" observations without affecting the verdict.
 
@@ -9506,6 +9511,12 @@ All tasks are marked done. Your job is to find gaps between spec and implementat
 
 This is NOT a code quality review (per-task impl-review handles that).
 Focus ONLY on requirement coverage and completeness.
+
+It is also NOT a task-bookkeeping review: committed `.flow/tasks/<id>.json` `status` fields are
+snapshots, not authoritative, and live lifecycle state is runtime state in the git-common-dir
+flow-state store, outside the diff and unreachable from this review context. Never base a
+finding or verdict on a task looking not-started or not-done in committed files; judge the
+implementation's spec compliance.
 
 ## Two-Phase Review Process
 

--- a/.flow/bin/flowctl_tracker/MANIFEST.json
+++ b/.flow/bin/flowctl_tracker/MANIFEST.json
@@ -2,7 +2,7 @@
   "files": [
     {
       "path": "flowctl.py",
-      "sha256": "a0353e1c8e1ce75ce106809cb2698fbec053aa9181af70e20afc865c24712e71"
+      "sha256": "36c673732d4054a26405505639f91df2abf5ceac7525b76fbf71381ad5300c23"
     },
     {
       "path": "flowctl_tracker/__init__.py",

--- a/.flow/bin/flowctl_tracker/MANIFEST.json
+++ b/.flow/bin/flowctl_tracker/MANIFEST.json
@@ -2,7 +2,7 @@
   "files": [
     {
       "path": "flowctl.py",
-      "sha256": "36c673732d4054a26405505639f91df2abf5ceac7525b76fbf71381ad5300c23"
+      "sha256": "61836272dcac53731afe02ff26d924afe96895b90a3d69d59cde86e836bf896b"
     },
     {
       "path": "flowctl_tracker/__init__.py",

--- a/.flow/bin/flowctl_tracker/MANIFEST.json
+++ b/.flow/bin/flowctl_tracker/MANIFEST.json
@@ -2,7 +2,7 @@
   "files": [
     {
       "path": "flowctl.py",
-      "sha256": "0248f92eb05b125b1ea0af001db10e28d9382937092206608ddff15ed2c6a299"
+      "sha256": "a0353e1c8e1ce75ce106809cb2698fbec053aa9181af70e20afc865c24712e71"
     },
     {
       "path": "flowctl_tracker/__init__.py",

--- a/.flow/tasks/fn-181-state-provenance-status-source-review.1.md
+++ b/.flow/tasks/fn-181-state-provenance-status-source-review.1.md
@@ -12,9 +12,8 @@ Spec fn-181 item 1 (#304 half 1). status_source: "flow-state"|"committed" on sho
 R1 of the spec.
 
 ## Done summary
-TBD
-
+Added status_source provenance ("flow-state"|"committed") to show/list --json via merge_task_runtime (stamped at merge, stripped on every persisted write), plus one plain-output advisory line when the runtime state dir is absent. Field always present under --json; no merge-semantics change. 12 new tests (test_status_source.py).
 ## Evidence
-- Commits:
-- Tests:
+- Commits: 19577611
+- Tests: cd plugins/flow-next/tests && python3 -m unittest test_status_source -q
 - PRs:

--- a/.flow/tasks/fn-181-state-provenance-status-source-review.2.md
+++ b/.flow/tasks/fn-181-state-provenance-status-source-review.2.md
@@ -14,9 +14,8 @@ Post-capture (3.19-3.21, see spec Edge Cases): routers no longer carry judgment 
 R2 of the spec. Occurrence-3 shape (sidecar read while flow-state says done) is ruled out by prose a skill-following reviewer cannot miss.
 
 ## Done summary
-TBD
-
+Both shared review prompt templates (plan-review, completion-review) now bar reviewers from judging task lifecycle from committed sidecars: status fields named as snapshots, authoritative state located in git-common-dir flow-state (unreachable from a diff-scoped context), read-for-content-never-for-status. Landed inside each template's verdict-scope framing. Byte parity with both flowctl FALLBACK constants, 4 hash pins + 4 rendered fixtures rebaselined, codex mirror regenerated, prompt rationale in commit message.
 ## Evidence
-- Commits:
-- Tests:
+- Commits: 7970ef64
+- Tests: cd plugins/flow-next/tests && python3 -m unittest test_prompt_text_pinned test_review_prompt_constraints test_review_prompt_template_parity -q
 - PRs:

--- a/.flow/tasks/fn-181-state-provenance-status-source-review.3.md
+++ b/.flow/tasks/fn-181-state-provenance-status-source-review.3.md
@@ -12,9 +12,8 @@ Spec fn-181 item 3 (#307 RESCOPED). One advisory line + stale_vs_upstream JSON f
 R3, R4, R5 of the spec.
 
 ## Done summary
-TBD
-
+ready (incl. --all) and anchor emit a behind-upstream advisory (plain note + stale_vs_upstream JSON count) via one read-only git spawn per invocation (git --no-optional-locks status --porcelain=v2 --branch -uno; upstream name comes from the same spawn). Any git failure degrades to no advisory. list/status/next proven spawn-clean by git-shim counting tests; inspection note pins the sanctioned call sites. 12 new tests (test_upstream_advisory.py) + orchestrator review fix dc329c12.
 ## Evidence
-- Commits:
-- Tests:
+- Commits: 19577611, dc329c12
+- Tests: cd plugins/flow-next/tests && python3 -m unittest test_upstream_advisory -q
 - PRs:

--- a/.flow/tasks/fn-181-state-provenance-status-source-review.4.md
+++ b/.flow/tasks/fn-181-state-provenance-status-source-review.4.md
@@ -10,9 +10,8 @@ Spec fn-181 R6. flowctl.md documents status_source and the advisory; CHANGELOG U
 R6 of the spec. Full gate green; no version bump.
 
 ## Done summary
-TBD
-
+flowctl.md documents status_source (show/list), the absent-runtime advisory, and the ready/anchor behind-upstream advisory with the explicit list/status/next exclusion. CHANGELOG Unreleased entry (user-outcome-first) credits @sn-furali for #304/#307. Full gate green: run_tests_parallel 4313/0/0, ruff clean, sync-codex idempotent, dual copies + manifest current.
 ## Evidence
-- Commits:
-- Tests:
+- Commits: 784b1558
+- Tests: python3 scripts/run_tests_parallel.py, uvx ruff@0.16.0 check .
 - PRs:

--- a/.flow/tasks/fn-181-state-provenance-status-source-review.4.md
+++ b/.flow/tasks/fn-181-state-provenance-status-source-review.4.md
@@ -12,6 +12,6 @@ R6 of the spec. Full gate green; no version bump.
 ## Done summary
 flowctl.md documents status_source (show/list), the absent-runtime advisory, and the ready/anchor behind-upstream advisory with the explicit list/status/next exclusion. CHANGELOG Unreleased entry (user-outcome-first) credits @sn-furali for #304/#307. Full gate green: run_tests_parallel 4313/0/0, ruff clean, sync-codex idempotent, dual copies + manifest current.
 ## Evidence
-- Commits: 784b1558
+- Commits: ef38a423
 - Tests: python3 scripts/run_tests_parallel.py, uvx ruff@0.16.0 check .
 - PRs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,38 @@
 
 All notable changes to the flow-next.
 
+## Unreleased
+
+A wrong answer you can recognize costs a glance; a wrong answer dressed as a
+right one costs review rounds. Status reads now say where their answer came
+from, reviewers stop judging task lifecycle from files that were never the
+authority, and the pre-work commands warn when the checkout itself is behind.
+Fixes #304 and #307 — thanks @sn-furali for the measured reports.
+
+### Added
+
+- **Status output carries its provenance.** `flowctl show` and `list` task
+  entries under `--json` now include `status_source` — `"flow-state"` when the
+  authoritative runtime store answered, `"committed"` when the answer came from
+  a tracked snapshot that may be stale — and plain output prints one advisory
+  line when the runtime state directory is absent. A fresh clone or diff-scoped
+  sandbox can no longer present a stale snapshot as a confident answer. (#304)
+- **The pre-work commands notice a stale checkout.** `ready` (including
+  `--all`) and `anchor` warn once per invocation when HEAD is behind its
+  upstream (`stale_vs_upstream` under `--json`), because a wrong answer just
+  before starting work is the most expensive one. One read-only git probe,
+  never a fetch, never blocking — and deliberately NOT added to `list`,
+  `status`, or `next`, whose fast-poll performance stays untouched. (#307)
+
+### Changed
+
+- **Reviewers no longer judge task bookkeeping.** Both shared review prompts
+  (plan review, completion review) now state that committed task-file `status`
+  fields are snapshots — live lifecycle state lives outside a diff-scoped
+  review context — and that a task looking not-started in committed files is
+  never grounds for a finding. Closes the measured failure where a compliant
+  spec ate three review rounds over sidecar staleness. (#304)
+
 ## [flow-next 3.22.0] - 2026-08-09
 
 When one agent hands work to the next — a worker returning to its conductor, a

--- a/plugins/flow-next/codex/skills/flow-next-plan-review/references/plan-review-prompt.md
+++ b/plugins/flow-next/codex/skills/flow-next-plan-review/references/plan-review-prompt.md
@@ -59,6 +59,11 @@ Do NOT mark NEEDS_WORK for:
 - Pre-existing codebase issues unrelated to this plan
 - Suggestions for features outside the plan scope
 - "While we're at it" improvements
+- Task lifecycle: a task looking not-started or not-done in committed files
+
+Committed `.flow/tasks/<id>.json` `status` fields are snapshots, not authoritative; live
+lifecycle state is runtime state in the git-common-dir flow-state store, outside the diff and
+unreachable from this review context. Read task files for their content, never for their status.
 
 You MAY mention these as "FYI" observations without affecting the verdict.
 

--- a/plugins/flow-next/codex/skills/flow-next-spec-completion-review/references/completion-review-prompt.md
+++ b/plugins/flow-next/codex/skills/flow-next-spec-completion-review/references/completion-review-prompt.md
@@ -35,6 +35,12 @@ All tasks are marked done. Your job is to find gaps between spec and implementat
 This is NOT a code quality review (per-task impl-review handles that).
 Focus ONLY on requirement coverage and completeness.
 
+It is also NOT a task-bookkeeping review: committed `.flow/tasks/<id>.json` `status` fields are
+snapshots, not authoritative, and live lifecycle state is runtime state in the git-common-dir
+flow-state store, outside the diff and unreachable from this review context. Never base a
+finding or verdict on a task looking not-started or not-done in committed files; judge the
+implementation's spec compliance.
+
 ## Two-Phase Review Process
 
 ### Phase 1: Extract Requirements

--- a/plugins/flow-next/docs/flowctl.md
+++ b/plugins/flow-next/docs/flowctl.md
@@ -574,6 +574,8 @@ flowctl show fn-1.2 [--json]   # Task only
 
 Spec output includes `tasks` array with id/title/status/priority/depends_on, plus an explicit `"ready": <bool>` (1.12.0+ — absent on-disk key reads `false`, so consumers always see a stable boolean).
 
+Task entries under `--json` always carry `status_source`: `"flow-state"` when the runtime state store answered (authoritative), `"committed"` when the answer came from the tracked task file — a snapshot that can be arbitrarily stale in a fresh or diff-scoped checkout. Plain output prints one advisory line per invocation when the runtime state directory is absent entirely (`note: runtime state absent; task status read from committed files and may be stale`). Provenance only — no status semantics change, and the field is never persisted.
+
 ### specs
 
 List all specs.
@@ -612,6 +614,8 @@ Output:
 List all specs with their tasks grouped together.
 
 Perf: repo-root/state-dir git lookups are memoized per process (fn-109), so listing hundreds of tasks costs a handful of subprocess spawns instead of two per task (30.8s -> <1s at 400 tasks).
+
+Task entries under `--json` carry the same `status_source` provenance field as `show`, and plain output prints the same absent-runtime advisory (one line per invocation). `list`, `status`, and `next` deliberately perform NO upstream-staleness check — they are the high-frequency polls the fn-109 win protects; the behind-upstream advisory below belongs to `ready`/`anchor` only.
 
 ```bash
 flowctl list [--json]
@@ -700,6 +704,8 @@ List tasks ready to start, in progress, and blocked.
 ```bash
 flowctl ready --spec fn-1 [--json]
 ```
+
+As an ask-before-work command, `ready` (including `--all`) also checks once per invocation whether HEAD is behind its configured upstream: when behind, plain output appends `note: checkout is N commits behind <upstream>; spec-level state may be stale` and `--json` carries `stale_vs_upstream: <N>`. One read-only git spawn, never a fetch, never blocking; no upstream, detached HEAD, or any git failure means the advisory is silently absent. `anchor` carries the same advisory.
 
 Output:
 ```json

--- a/plugins/flow-next/scripts/flowctl.py
+++ b/plugins/flow-next/scripts/flowctl.py
@@ -33629,11 +33629,14 @@ def upstream_behind() -> Optional[tuple]:
 
     `git status --porcelain=v2 --branch` reports the upstream ref name and
     the ahead/behind pair in a single spawn, so the advisory never needs a
-    second `rev-parse` to name the ref. `-uno` skips the untracked walk.
+    second `rev-parse` to name the ref. `-uno` skips the untracked walk;
+    `--no-optional-locks` keeps the probe strictly read-only (no opportunistic
+    index.lock refresh under a concurrent git process).
     """
     try:
         result = subprocess.run(
-            ["git", "status", "--porcelain=v2", "--branch", "-uno"],
+            ["git", "--no-optional-locks", "status", "--porcelain=v2",
+             "--branch", "-uno"],
             capture_output=True,
             text=True, encoding="utf-8",
             check=True,

--- a/plugins/flow-next/scripts/flowctl.py
+++ b/plugins/flow-next/scripts/flowctl.py
@@ -298,6 +298,17 @@ RUNTIME_FIELDS = {
     "blocked_reason",
 }
 
+# fn-181 R1: provenance of the `status` a read surface just answered with.
+# "flow-state" = the runtime state store answered (authoritative).
+# "committed"  = no runtime entry; the answer came from the tracked task
+#                definition file, which is a snapshot and may be stale.
+STATUS_SOURCE_FLOW_STATE = "flow-state"
+STATUS_SOURCE_COMMITTED = "committed"
+STATUS_SOURCE_ABSENT_NOTE = (
+    "note: runtime state absent; task status read from committed files "
+    "and may be stale"
+)
+
 
 # --- Helpers ---
 
@@ -1044,15 +1055,46 @@ def load_task_with_state(task_id: str, use_json: bool = True) -> dict:
 
 
 def merge_task_runtime(definition: dict, runtime: Optional[dict]) -> dict:
-    """Merge one tracked task definition with its authoritative runtime state."""
+    """Merge one tracked task definition with its authoritative runtime state.
+
+    fn-181 R1: the merge already knows which store answered, so it stamps
+    `status_source` — "flow-state" when the runtime store had an entry,
+    "committed" when the answer came from the tracked definition file (the
+    legacy fallback, which can be arbitrarily stale). Provenance only: no
+    merge semantics change. The key is stripped on every persisted write
+    (`canonicalize_task_for_write`) so it never lands in a tracked file.
+    """
+    source = STATUS_SOURCE_FLOW_STATE
     if runtime is None:
+        source = STATUS_SOURCE_COMMITTED
         # Backward compat: extract runtime fields from definition.
         runtime = {k: definition[k] for k in RUNTIME_FIELDS if k in definition}
         if not runtime:
             runtime = {"status": "todo"}
 
     # Merge: runtime overwrites definition for runtime fields.
-    return normalize_task({**definition, **runtime})
+    merged = normalize_task({**definition, **runtime})
+    merged["status_source"] = source
+    return merged
+
+
+def runtime_state_absent() -> bool:
+    """True when the runtime state directory does not exist (fn-181 R1).
+
+    Read surfaces use this for ONE plain-output advisory per invocation.
+    No new git spawn: `get_state_dir` is memoized and every caller of this
+    helper has already resolved the state dir to merge runtime state.
+    """
+    try:
+        return not get_state_dir().exists()
+    except OSError:
+        return False
+
+
+def print_status_source_advisory() -> None:
+    """Print the one-per-invocation stale-status advisory when warranted."""
+    if runtime_state_absent():
+        print(STATUS_SOURCE_ABSENT_NOTE)
 
 
 def save_task_runtime(task_id: str, updates: dict) -> None:
@@ -3716,6 +3758,10 @@ def canonicalize_task_for_write(task_data: dict) -> dict:
     if "spec" not in task_data and "epic" in task_data:
         task_data["spec"] = task_data["epic"]
     task_data.pop("epic", None)
+    # fn-181 R1: `status_source` is a read-surface annotation stamped by
+    # merge_task_runtime — never persisted. Stripping it here keeps every
+    # write path (which may start from a merged task) free of it.
+    task_data.pop("status_source", None)
     # Same shape for the historic _id form (very few callers use it; cheap to handle).
     if "spec_id" not in task_data and "epic_id" in task_data:
         task_data["spec_id"] = task_data["epic_id"]
@@ -29533,6 +29579,10 @@ def cmd_show(args: argparse.Namespace) -> None:
                     "id": task_data["id"],
                     "title": task_data["title"],
                     "status": task_data["status"],
+                    # fn-181 R1: same field, same merge — not a parallel path.
+                    "status_source": task_data.get(
+                        "status_source", STATUS_SOURCE_COMMITTED
+                    ),
                     "priority": task_data.get("priority"),
                     "depends_on": task_data.get(
                         "depends_on", task_data.get("deps", [])
@@ -29552,6 +29602,7 @@ def cmd_show(args: argparse.Namespace) -> None:
         if args.json:
             json_output(result)
         else:
+            print_status_source_advisory()
             print(f"Spec: {epic_data['id']}")
             print(f"Title: {epic_data['title']}")
             print(f"Status: {epic_data['status']}")
@@ -29577,6 +29628,7 @@ def cmd_show(args: argparse.Namespace) -> None:
         if args.json:
             json_output(task_data)
         else:
+            print_status_source_advisory()
             print(f"Task: {task_data['id']}")
             print(f"Spec: {spec_value}")
             print(f"Title: {task_data['title']}")
@@ -29764,6 +29816,10 @@ def cmd_list(args: argparse.Namespace) -> None:
                 "spec": spec_value,
                 "title": task_data["title"],
                 "status": task_data["status"],
+                # fn-181 R1: provenance of the status above; always present.
+                "status_source": task_data.get(
+                    "status_source", STATUS_SOURCE_COMMITTED
+                ),
                 "priority": task_data.get("priority"),
                 "depends_on": task_data.get(
                     "depends_on", task_data.get("deps", [])
@@ -29797,6 +29853,7 @@ def cmd_list(args: argparse.Namespace) -> None:
             }
         )
     else:
+        print_status_source_advisory()
         if not specs:
             print("No specs or tasks found.")
             return
@@ -33553,6 +33610,68 @@ def _task_set_section(
         print(f"Task {task_id} {section} updated")
 
 
+# --- fn-181 R3/R4/R5: behind-upstream staleness advisory ---
+#
+# INSPECTION NOTE (R4): the ONLY call sites are `cmd_ready` / `cmd_ready_all`
+# and `cmd_anchor` — the ask-before-work commands. `list`, `status`, and
+# `next` deliberately do NOT call it: they are the high-frequency polls fn-109
+# made 60x faster, and a git spawn there regresses that win. Adding a call
+# site is a spec change, not a refactor (guarded by
+# `test_upstream_advisory.py`).
+#
+# ONE git spawn per invocation (R5), never a fetch, never blocking. Any git
+# failure — no upstream, detached HEAD, not a repo, git missing, offline —
+# degrades to "no advisory", never to a command failure (R3 error clause).
+
+
+def upstream_behind() -> Optional[tuple]:
+    """Return ``(behind_count, upstream_ref)`` when HEAD is behind, else None.
+
+    `git status --porcelain=v2 --branch` reports the upstream ref name and
+    the ahead/behind pair in a single spawn, so the advisory never needs a
+    second `rev-parse` to name the ref. `-uno` skips the untracked walk.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "status", "--porcelain=v2", "--branch", "-uno"],
+            capture_output=True,
+            text=True, encoding="utf-8",
+            check=True,
+        )
+    except (subprocess.CalledProcessError, OSError, ValueError):
+        return None
+
+    upstream = None
+    behind = 0
+    for line in result.stdout.splitlines():
+        if not line.startswith("# branch."):
+            # Branch headers precede all file entries; nothing left to read.
+            if not line.startswith("#"):
+                break
+            continue
+        if line.startswith("# branch.upstream "):
+            upstream = line[len("# branch.upstream "):].strip()
+        elif line.startswith("# branch.ab "):
+            for token in line.split()[2:]:
+                if token.startswith("-"):
+                    try:
+                        behind = int(token[1:])
+                    except ValueError:
+                        return None
+    if not upstream or behind <= 0:
+        return None
+    return behind, upstream
+
+
+def upstream_stale_note(behind: int, upstream: str) -> str:
+    """The one advisory line printed by ready/anchor when behind upstream."""
+    plural = "" if behind == 1 else "s"
+    return (
+        f"note: checkout is {behind} commit{plural} behind {upstream}; "
+        f"spec-level state may be stale"
+    )
+
+
 def cmd_ready_all(args: argparse.Namespace) -> None:
     """Spec-level eligibility FACTS for the whole backlog (fn-68.1, R1/R8/R9).
 
@@ -33581,6 +33700,7 @@ def cmd_ready_all(args: argparse.Namespace) -> None:
     Done specs are skipped — the backlog is the open frontier.
     """
     flow_dir = get_flow_dir()
+    stale = upstream_behind()  # fn-181 R3/R5: one check per invocation.
 
     rows = []
     for spec_file in iter_spec_json_files(flow_dir):
@@ -33633,8 +33753,13 @@ def cmd_ready_all(args: argparse.Namespace) -> None:
     rows.sort(key=lambda r: id_sort_key(r["id"]))
 
     if args.json:
-        json_output({"success": True, "specs": rows, "count": len(rows)})
+        payload = {"success": True, "specs": rows, "count": len(rows)}
+        if stale:
+            payload["stale_vs_upstream"] = stale[0]
+        json_output(payload)
     else:
+        if stale:
+            print(upstream_stale_note(*stale))
         if not rows:
             print("No open specs.")
         else:
@@ -33661,6 +33786,10 @@ def cmd_ready(args: argparse.Namespace) -> None:
     if getattr(args, "all", False):
         cmd_ready_all(args)
         return
+
+    # fn-181 R3/R5: one upstream check per invocation, AFTER the --all
+    # dispatch so the two branches never both run it.
+    stale = upstream_behind()
 
     spec_id = resolve_spec_arg(args, get_flow_dir())
     if not spec_id or not is_spec_id(spec_id):
@@ -33699,17 +33828,20 @@ def cmd_ready(args: argparse.Namespace) -> None:
             blocked_by_specs.append(dep)
     if blocked_by_specs:
         if args.json:
-            json_output(
-                {
-                    "spec": spec_id,
-                    "actor": current_actor,
-                    "ready": [],
-                    "in_progress": [],
-                    "blocked": [],
-                    "blocked_by_specs": blocked_by_specs,
-                }
-            )
+            payload = {
+                "spec": spec_id,
+                "actor": current_actor,
+                "ready": [],
+                "in_progress": [],
+                "blocked": [],
+                "blocked_by_specs": blocked_by_specs,
+            }
+            if stale:
+                payload["stale_vs_upstream"] = stale[0]
+            json_output(payload)
         else:
+            if stale:
+                print(upstream_stale_note(*stale))
             print(f"Spec {spec_id} is blocked by: {', '.join(blocked_by_specs)}")
         return
 
@@ -33777,29 +33909,32 @@ def cmd_ready(args: argparse.Namespace) -> None:
     blocked.sort(key=lambda x: sort_key(x["task"]))
 
     if args.json:
-        json_output(
-            {
-                "spec": spec_id,
-                "actor": current_actor,
-                "ready": [
-                    {"id": t["id"], "title": t["title"], "depends_on": t["depends_on"]}
-                    for t in ready
-                ],
-                "in_progress": [
-                    {"id": t["id"], "title": t["title"], "assignee": t.get("assignee")}
-                    for t in in_progress
-                ],
-                "blocked": [
-                    {
-                        "id": b["task"]["id"],
-                        "title": b["task"]["title"],
-                        "blocked_by": b["blocked_by"],
-                    }
-                    for b in blocked
-                ],
-            }
-        )
+        payload = {
+            "spec": spec_id,
+            "actor": current_actor,
+            "ready": [
+                {"id": t["id"], "title": t["title"], "depends_on": t["depends_on"]}
+                for t in ready
+            ],
+            "in_progress": [
+                {"id": t["id"], "title": t["title"], "assignee": t.get("assignee")}
+                for t in in_progress
+            ],
+            "blocked": [
+                {
+                    "id": b["task"]["id"],
+                    "title": b["task"]["title"],
+                    "blocked_by": b["blocked_by"],
+                }
+                for b in blocked
+            ],
+        }
+        if stale:
+            payload["stale_vs_upstream"] = stale[0]
+        json_output(payload)
     else:
+        if stale:
+            print(upstream_stale_note(*stale))
         print(f"Ready tasks for {spec_id} (actor: {current_actor}):")
         if ready:
             for t in ready:
@@ -35495,16 +35630,18 @@ def cmd_anchor(args: argparse.Namespace) -> None:
 
     sections = _anchor_sections(task_id, spec_id)
     dependencies = _anchor_dependencies(flow_dir, task_data)
+    stale = upstream_behind()  # fn-181 R3/R5: one check per invocation.
 
     if use_json:
-        json_output(
-            {
-                "task": task_id,
-                "spec": spec_id,
-                "sections": sections,
-                "dependencies": dependencies,
-            }
-        )
+        payload = {
+            "task": task_id,
+            "spec": spec_id,
+            "sections": sections,
+            "dependencies": dependencies,
+        }
+        if stale:
+            payload["stale_vs_upstream"] = stale[0]
+        json_output(payload)
         return
 
     # Markdown render (default): worker-facing, clear banners, same order
@@ -35520,6 +35657,9 @@ def cmd_anchor(args: argparse.Namespace) -> None:
         "available.",
         "",
     ]
+    if stale:
+        lines.append(upstream_stale_note(*stale))
+        lines.append("")
     for i, s in enumerate(sections, start=1):
         lines.append(f"===== [{i}/{total}] {s['name']}: `{s['command']}` =====")
         if s.get("note"):

--- a/plugins/flow-next/scripts/flowctl.py
+++ b/plugins/flow-next/scripts/flowctl.py
@@ -9427,6 +9427,11 @@ Do NOT mark NEEDS_WORK for:
 - Pre-existing codebase issues unrelated to this plan
 - Suggestions for features outside the plan scope
 - "While we're at it" improvements
+- Task lifecycle: a task looking not-started or not-done in committed files
+
+Committed `.flow/tasks/<id>.json` `status` fields are snapshots, not authoritative; live
+lifecycle state is runtime state in the git-common-dir flow-state store, outside the diff and
+unreachable from this review context. Read task files for their content, never for their status.
 
 You MAY mention these as "FYI" observations without affecting the verdict.
 
@@ -9506,6 +9511,12 @@ All tasks are marked done. Your job is to find gaps between spec and implementat
 
 This is NOT a code quality review (per-task impl-review handles that).
 Focus ONLY on requirement coverage and completeness.
+
+It is also NOT a task-bookkeeping review: committed `.flow/tasks/<id>.json` `status` fields are
+snapshots, not authoritative, and live lifecycle state is runtime state in the git-common-dir
+flow-state store, outside the diff and unreachable from this review context. Never base a
+finding or verdict on a task looking not-started or not-done in committed files; judge the
+implementation's spec compliance.
 
 ## Two-Phase Review Process
 

--- a/plugins/flow-next/scripts/flowctl_tracker/MANIFEST.json
+++ b/plugins/flow-next/scripts/flowctl_tracker/MANIFEST.json
@@ -2,7 +2,7 @@
   "files": [
     {
       "path": "flowctl.py",
-      "sha256": "a0353e1c8e1ce75ce106809cb2698fbec053aa9181af70e20afc865c24712e71"
+      "sha256": "36c673732d4054a26405505639f91df2abf5ceac7525b76fbf71381ad5300c23"
     },
     {
       "path": "flowctl_tracker/__init__.py",

--- a/plugins/flow-next/scripts/flowctl_tracker/MANIFEST.json
+++ b/plugins/flow-next/scripts/flowctl_tracker/MANIFEST.json
@@ -2,7 +2,7 @@
   "files": [
     {
       "path": "flowctl.py",
-      "sha256": "36c673732d4054a26405505639f91df2abf5ceac7525b76fbf71381ad5300c23"
+      "sha256": "61836272dcac53731afe02ff26d924afe96895b90a3d69d59cde86e836bf896b"
     },
     {
       "path": "flowctl_tracker/__init__.py",

--- a/plugins/flow-next/scripts/flowctl_tracker/MANIFEST.json
+++ b/plugins/flow-next/scripts/flowctl_tracker/MANIFEST.json
@@ -2,7 +2,7 @@
   "files": [
     {
       "path": "flowctl.py",
-      "sha256": "0248f92eb05b125b1ea0af001db10e28d9382937092206608ddff15ed2c6a299"
+      "sha256": "a0353e1c8e1ce75ce106809cb2698fbec053aa9181af70e20afc865c24712e71"
     },
     {
       "path": "flowctl_tracker/__init__.py",

--- a/plugins/flow-next/skills/flow-next-plan-review/references/plan-review-prompt.md
+++ b/plugins/flow-next/skills/flow-next-plan-review/references/plan-review-prompt.md
@@ -59,6 +59,11 @@ Do NOT mark NEEDS_WORK for:
 - Pre-existing codebase issues unrelated to this plan
 - Suggestions for features outside the plan scope
 - "While we're at it" improvements
+- Task lifecycle: a task looking not-started or not-done in committed files
+
+Committed `.flow/tasks/<id>.json` `status` fields are snapshots, not authoritative; live
+lifecycle state is runtime state in the git-common-dir flow-state store, outside the diff and
+unreachable from this review context. Read task files for their content, never for their status.
 
 You MAY mention these as "FYI" observations without affecting the verdict.
 

--- a/plugins/flow-next/skills/flow-next-spec-completion-review/references/completion-review-prompt.md
+++ b/plugins/flow-next/skills/flow-next-spec-completion-review/references/completion-review-prompt.md
@@ -35,6 +35,12 @@ All tasks are marked done. Your job is to find gaps between spec and implementat
 This is NOT a code quality review (per-task impl-review handles that).
 Focus ONLY on requirement coverage and completeness.
 
+It is also NOT a task-bookkeeping review: committed `.flow/tasks/<id>.json` `status` fields are
+snapshots, not authoritative, and live lifecycle state is runtime state in the git-common-dir
+flow-state store, outside the diff and unreachable from this review context. Never base a
+finding or verdict on a task looking not-started or not-done in committed files; judge the
+implementation's spec compliance.
+
 ## Two-Phase Review Process
 
 ### Phase 1: Extract Requirements

--- a/plugins/flow-next/tests/fixtures/review_prompts/completion.txt
+++ b/plugins/flow-next/tests/fixtures/review_prompts/completion.txt
@@ -61,6 +61,12 @@ All tasks are marked done. Your job is to find gaps between spec and implementat
 This is NOT a code quality review (per-task impl-review handles that).
 Focus ONLY on requirement coverage and completeness.
 
+It is also NOT a task-bookkeeping review: committed `.flow/tasks/<id>.json` `status` fields are
+snapshots, not authoritative, and live lifecycle state is runtime state in the git-common-dir
+flow-state store, outside the diff and unreachable from this review context. Never base a
+finding or verdict on a task looking not-started or not-done in committed files; judge the
+implementation's spec compliance.
+
 ## Two-Phase Review Process
 
 ### Phase 1: Extract Requirements

--- a/plugins/flow-next/tests/fixtures/review_prompts/completion_no_tasks.txt
+++ b/plugins/flow-next/tests/fixtures/review_prompts/completion_no_tasks.txt
@@ -56,6 +56,12 @@ All tasks are marked done. Your job is to find gaps between spec and implementat
 This is NOT a code quality review (per-task impl-review handles that).
 Focus ONLY on requirement coverage and completeness.
 
+It is also NOT a task-bookkeeping review: committed `.flow/tasks/<id>.json` `status` fields are
+snapshots, not authoritative, and live lifecycle state is runtime state in the git-common-dir
+flow-state store, outside the diff and unreachable from this review context. Never base a
+finding or verdict on a task looking not-started or not-done in committed files; judge the
+implementation's spec compliance.
+
 ## Two-Phase Review Process
 
 ### Phase 1: Extract Requirements

--- a/plugins/flow-next/tests/fixtures/review_prompts/plan.txt
+++ b/plugins/flow-next/tests/fixtures/review_prompts/plan.txt
@@ -73,6 +73,11 @@ Do NOT mark NEEDS_WORK for:
 - Pre-existing codebase issues unrelated to this plan
 - Suggestions for features outside the plan scope
 - "While we're at it" improvements
+- Task lifecycle: a task looking not-started or not-done in committed files
+
+Committed `.flow/tasks/<id>.json` `status` fields are snapshots, not authoritative; live
+lifecycle state is runtime state in the git-common-dir flow-state store, outside the diff and
+unreachable from this review context. Read task files for their content, never for their status.
 
 You MAY mention these as "FYI" observations without affecting the verdict.
 

--- a/plugins/flow-next/tests/fixtures/review_prompts/plan_no_tasks.txt
+++ b/plugins/flow-next/tests/fixtures/review_prompts/plan_no_tasks.txt
@@ -68,6 +68,11 @@ Do NOT mark NEEDS_WORK for:
 - Pre-existing codebase issues unrelated to this plan
 - Suggestions for features outside the plan scope
 - "While we're at it" improvements
+- Task lifecycle: a task looking not-started or not-done in committed files
+
+Committed `.flow/tasks/<id>.json` `status` fields are snapshots, not authoritative; live
+lifecycle state is runtime state in the git-common-dir flow-state store, outside the diff and
+unreachable from this review context. Read task files for their content, never for their status.
 
 You MAY mention these as "FYI" observations without affecting the verdict.
 

--- a/plugins/flow-next/tests/test_prompt_text_pinned.py
+++ b/plugins/flow-next/tests/test_prompt_text_pinned.py
@@ -121,6 +121,11 @@ PROMPT_HASHES = {
     # when .flow/criteria.md exists; empty otherwise.
     "_GLOBAL_CRITERIA_BLOCK_TEMPLATE":
         "58eece8cecd3cfb56f6a3a2105bf1c9287258a25950d37a3e541f1cf8cdaabdd",
+    # fn-181 R1: printed on plain `show`/`list` when the runtime state store
+    # is absent. Agents read it and decide whether to trust the status they
+    # were just given, so its wording is deliberate-change territory.
+    "STATUS_SOURCE_ABSENT_NOTE":
+        "0f6697e1ed3d099666d5be48252bacfb5172871dd4e2e4bfc1d2e99268e6ac24",
     # Lands in the receipt `note` field and on stdout; agents read receipts.
     "HOST_JUDGES_NOTE":
         "47b75b60635754b4267077dc782a7b026af6dce3669619c4ffca6ec920c5d878",

--- a/plugins/flow-next/tests/test_prompt_text_pinned.py
+++ b/plugins/flow-next/tests/test_prompt_text_pinned.py
@@ -85,7 +85,7 @@ PROMPT_HASHES = {
     "CLASSIFICATION_RUBRIC_BLOCK":
         "fbde8f499ba3d82b50901b12a984912490b66c6e69f1b74c38edf80c28567a06",
     "COMPLETION_REVIEW_PROMPT_FALLBACK":
-        "6907c0b9ec683eb7d8258c86ddaaa6168a4dcefdb075b314e793a9cca65c6ea3",
+        "e952d93e24e0d780ea17f0b3ee5785a12526961c66cae3d2599bb52bd8aa39be",
     "CONFIDENCE_RUBRIC_BLOCK":
         "b8cc9e9594a3fed35498040e222bc9000333f4407f48374464115a69c231ae15",
     "IMPL_REVIEW_PROMPT_FALLBACK":
@@ -93,7 +93,7 @@ PROMPT_HASHES = {
     "PLAN_QUALITY_BLOCK":
         "0cfb49bfadf0be45e5c8036950d34698b5ae3bbccf24a90564983e13d0a1192f",
     "PLAN_REVIEW_PROMPT_FALLBACK":
-        "0098e2e621f5cc434b23ca1fb816a97e36cba6a85d8d47ed8cbf86fe82f5c57e",
+        "e36bfc43b35d127576527189fcc1d813c2a1e434d71199b04f66edf61fde44be",
     "PROTECTED_ARTIFACTS_BLOCK":
         "e9b68af0cf36f6b2cb1b70c9bcc5ff67ccb86295f369d02ffcec4f25fd6f2d5e",
     "REVIEW_JSON_TALLY_BLOCK":
@@ -170,9 +170,9 @@ TEMPLATE_HASHES = {
     "plugins/flow-next/skills/flow-next-impl-review/references/standalone-review-prompt.md":
         "6f366a927f449312e623220362e9eb63351f5b8dd427e5669b236a362bad1357",
     "plugins/flow-next/skills/flow-next-plan-review/references/plan-review-prompt.md":
-        "0098e2e621f5cc434b23ca1fb816a97e36cba6a85d8d47ed8cbf86fe82f5c57e",
+        "e36bfc43b35d127576527189fcc1d813c2a1e434d71199b04f66edf61fde44be",
     "plugins/flow-next/skills/flow-next-spec-completion-review/references/completion-review-prompt.md":
-        "6907c0b9ec683eb7d8258c86ddaaa6168a4dcefdb075b314e793a9cca65c6ea3",
+        "e952d93e24e0d780ea17f0b3ee5785a12526961c66cae3d2599bb52bd8aa39be",
     # Rendered by ralph.sh each autonomous loop - production prompts, and the
     # ones an unattended run depends on most. fn-159.6 clarifies that a review
     # call's tag set differs from the step's return set: NEEDS_WORK loops

--- a/plugins/flow-next/tests/test_review_prompt_constraints.py
+++ b/plugins/flow-next/tests/test_review_prompt_constraints.py
@@ -200,6 +200,10 @@ class ReviewPromptConstraintTest(unittest.TestCase):
                 ("subprocess.run", "_export_run_git"): 1,
                 ("subprocess.run", "_export_read_base_blobs"): 1,
                 ("subprocess.run", "_psp_run_git"): 1,
+                # fn-181 R3/R5: the behind-upstream advisory for ready/anchor -
+                # ONE deterministic `git status --porcelain=v2 --branch` read
+                # per invocation, never a fetch, never an execution bridge.
+                ("subprocess.run", "upstream_behind"): 1,
                 # fn-169 R3/R4: `--numstat --no-renames` for the prompt's scope
                 # map and the full diff for the artifact identity, both through
                 # ONE runner that raises rather than returning "" — an empty

--- a/plugins/flow-next/tests/test_status_source.py
+++ b/plugins/flow-next/tests/test_status_source.py
@@ -1,0 +1,207 @@
+"""fn-181.1 (R1): `status_source` provenance on show/list + absent-state advisory.
+
+Behavioral, production-wire-form tests (the CLI a caller actually runs):
+
+  * `show <task> --json`, `show <spec> --json` task rows, and `list --json`
+    task rows ALWAYS carry `status_source`.
+  * The value tracks which store answered: "committed" while no runtime
+    entry exists for the task, "flow-state" once one does (after `start`).
+  * Plain (non-JSON) `show` / `list` print exactly ONE advisory line per
+    invocation when the runtime state directory is absent, and none when it
+    exists — the advisory is a property of the invocation, not of each task.
+  * The annotation is never persisted: a merged task that round-trips
+    through a write path leaves no `status_source` in the tracked JSON.
+
+Run:
+    cd plugins/flow-next/tests && python3 -m unittest test_status_source -q
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+# fn-139.1: the tracker package sits beside flowctl.py; under a test module
+# sys.path[0] is THIS directory, not scripts/, so it would not import.
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+
+HERE = Path(__file__).resolve()
+FLOWCTL_PY = HERE.parent.parent / "scripts" / "flowctl.py"
+
+SPEC_ID = "fn-1-sample-spec"
+TASK_ID = "fn-1-sample-spec.1"
+
+
+class StatusSourceProvenanceTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmpdir = Path(tempfile.mkdtemp())
+        subprocess.run(
+            ["git", "init", "-q"], cwd=self.tmpdir, check=True, capture_output=True
+        )
+        self._flowctl("init")
+        self._flowctl("spec", "create", "--title", "Sample spec", "--json")
+        self._flowctl(
+            "task", "create", "--spec", SPEC_ID,
+            "--title", "T one", "--acceptance", "acc", "--json",
+        )
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    # --- drivers ---------------------------------------------------------
+
+    def _flowctl(self, *args: str) -> "subprocess.CompletedProcess[str]":
+        result = subprocess.run(
+            [sys.executable, str(FLOWCTL_PY)] + list(args),
+            cwd=str(self.tmpdir),
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        return result
+
+    def _json(self, *args: str) -> dict:
+        return json.loads(self._flowctl(*args).stdout)
+
+    def _start_task(self) -> None:
+        """Claim the task so the runtime state store owns its status."""
+        self._flowctl("start", TASK_ID, "--json")
+
+    @property
+    def _state_dir(self) -> Path:
+        return self.tmpdir / ".git" / "flow-state"
+
+    # --- R1: the field is always present ---------------------------------
+
+    def test_show_task_json_carries_status_source(self) -> None:
+        self.assertEqual(
+            self._json("show", TASK_ID, "--json")["status_source"], "committed"
+        )
+        self._start_task()
+        self.assertEqual(
+            self._json("show", TASK_ID, "--json")["status_source"], "flow-state"
+        )
+
+    def test_list_json_task_rows_carry_status_source(self) -> None:
+        (row,) = self._json("list", "--json")["tasks"]
+        self.assertEqual(row["status_source"], "committed")
+        self._start_task()
+        (row,) = self._json("list", "--json")["tasks"]
+        self.assertEqual(row["status_source"], "flow-state")
+
+    def test_spec_show_task_rows_share_the_field(self) -> None:
+        """Spec `show` reuses the same merge, not a parallel path."""
+        (row,) = self._json("show", SPEC_ID, "--json")["tasks"]
+        self.assertEqual(row["status_source"], "committed")
+        self._start_task()
+        (row,) = self._json("show", SPEC_ID, "--json")["tasks"]
+        self.assertEqual(row["status_source"], "flow-state")
+
+    # --- R1: the plain-output advisory -----------------------------------
+
+    def _advisory_lines(self, text: str) -> list:
+        return [
+            line for line in text.splitlines()
+            if line.startswith("note: runtime state absent")
+        ]
+
+    def test_plain_output_advises_once_when_state_dir_absent(self) -> None:
+        self.assertFalse(self._state_dir.exists())
+        for args in (("list",), ("show", TASK_ID), ("show", SPEC_ID)):
+            with self.subTest(args=args):
+                lines = self._advisory_lines(self._flowctl(*args).stdout)
+                self.assertEqual(len(lines), 1, lines)
+                self.assertIn("may be stale", lines[0])
+
+    def test_advisory_is_per_invocation_not_per_task(self) -> None:
+        for suffix in ("2", "3"):
+            self._flowctl(
+                "task", "create", "--spec", SPEC_ID,
+                "--title", f"T {suffix}", "--acceptance", "acc", "--json",
+            )
+        listing = self._flowctl("list").stdout
+        self.assertEqual(len(self._json("list", "--json")["tasks"]), 3)
+        self.assertEqual(len(self._advisory_lines(listing)), 1)
+
+    def test_no_advisory_once_state_dir_exists(self) -> None:
+        self._start_task()
+        self.assertTrue(self._state_dir.exists())
+        for args in (("list",), ("show", TASK_ID), ("show", SPEC_ID)):
+            with self.subTest(args=args):
+                self.assertEqual(
+                    self._advisory_lines(self._flowctl(*args).stdout), []
+                )
+
+    def test_json_output_never_prints_the_advisory(self) -> None:
+        """--json stays machine-clean; the field carries the provenance."""
+        out = self._flowctl("list", "--json").stdout
+        self.assertNotIn("note: runtime state absent", out)
+        json.loads(out)
+
+    # --- R1: never persisted ---------------------------------------------
+
+    def test_status_source_is_not_written_to_tracked_task_json(self) -> None:
+        self._start_task()
+        body = self.tmpdir / "desc.md"
+        body.write_text("updated body\n", encoding="utf-8")
+        self._flowctl(
+            "task", "set-description", TASK_ID, "--file", str(body), "--json"
+        )
+        payload = json.loads(
+            (self.tmpdir / ".flow" / "tasks" / f"{TASK_ID}.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        self.assertNotIn("status_source", payload)
+
+
+class MergeProvenanceUnitTest(unittest.TestCase):
+    """The merge point itself stamps provenance without changing semantics."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        import importlib.util
+
+        spec = importlib.util.spec_from_file_location(
+            "flowctl_status_source_under_test", FLOWCTL_PY
+        )
+        cls.flowctl = importlib.util.module_from_spec(spec)
+        assert spec.loader is not None
+        sys.modules[spec.name] = cls.flowctl
+        spec.loader.exec_module(cls.flowctl)
+
+    def test_runtime_present_reads_flow_state(self) -> None:
+        merged = self.flowctl.merge_task_runtime(
+            {"id": TASK_ID, "status": "todo"}, {"status": "done"}
+        )
+        self.assertEqual(merged["status"], "done")
+        self.assertEqual(merged["status_source"], "flow-state")
+
+    def test_runtime_absent_reads_committed(self) -> None:
+        merged = self.flowctl.merge_task_runtime(
+            {"id": TASK_ID, "status": "in_progress"}, None
+        )
+        self.assertEqual(merged["status"], "in_progress")
+        self.assertEqual(merged["status_source"], "committed")
+
+    def test_legacy_definition_without_runtime_fields_still_marked(self) -> None:
+        merged = self.flowctl.merge_task_runtime({"id": TASK_ID}, None)
+        self.assertEqual(merged["status"], "todo")
+        self.assertEqual(merged["status_source"], "committed")
+
+    def test_write_canonicalization_strips_the_annotation(self) -> None:
+        merged = self.flowctl.merge_task_runtime(
+            {"id": TASK_ID, "status": "todo"}, {"status": "done"}
+        )
+        self.assertNotIn(
+            "status_source", self.flowctl.canonicalize_task_for_write(merged)
+        )
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/plugins/flow-next/tests/test_upstream_advisory.py
+++ b/plugins/flow-next/tests/test_upstream_advisory.py
@@ -1,0 +1,280 @@
+"""fn-181.3 (R3/R4/R5): behind-upstream staleness advisory on ready/anchor.
+
+Behavioral, production-wire-form tests against a REAL git repo with a real
+upstream (a local bare remote — never the network, never a fetch):
+
+  * R3 — `ready`, `ready --all`, and `anchor` emit ONE advisory line (plain)
+    and a `stale_vs_upstream` count (JSON) when HEAD is behind its upstream.
+  * R3 — not behind / no upstream / detached HEAD / not a git repo: the
+    advisory is silently absent, `stale_vs_upstream` is omitted, and the
+    rest of the output is byte-identical to the same command run in a repo
+    that is up to date.
+  * R4 — `list`, `status`, and `next` perform NO upstream check. Asserted by
+    spawn counting through a `git` shim on PATH, not by inspection.
+  * R5 — at most ONE upstream spawn per invocation regardless of how many
+    specs/tasks the command walks.
+
+Run:
+    cd plugins/flow-next/tests && python3 -m unittest test_upstream_advisory -q
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+# fn-139.1: the tracker package sits beside flowctl.py; under a test module
+# sys.path[0] is THIS directory, not scripts/, so it would not import.
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+
+HERE = Path(__file__).resolve()
+FLOWCTL_PY = HERE.parent.parent / "scripts" / "flowctl.py"
+
+SPEC_ID = "fn-1-sample-spec"
+TASK_ID = "fn-1-sample-spec.1"
+
+# The upstream probe's wire form. Spawn counting keys off this fragment, so a
+# rewrite of the probe command must update it here — deliberately.
+UPSTREAM_PROBE = "status --porcelain=v2 --branch"
+
+REAL_GIT = shutil.which("git")
+
+
+@unittest.skipIf(os.name == "nt", "POSIX git-shim spawn counting")
+@unittest.skipIf(REAL_GIT is None, "git not available")
+class UpstreamAdvisoryTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.root = Path(tempfile.mkdtemp())
+        self.upstream = self.root / "upstream.git"
+        self.repo = self.root / "work"
+        self._git_log = self.root / "git-spawns.log"
+        self._shim_dir = self.root / "shim"
+        self._install_git_shim()
+
+        subprocess.run(
+            ["git", "init", "-q", "--bare", str(self.upstream)],
+            check=True, capture_output=True,
+        )
+        subprocess.run(
+            ["git", "init", "-q", str(self.repo)], check=True, capture_output=True
+        )
+        for key, value in (("user.email", "t@t"), ("user.name", "t")):
+            self._git("config", key, value)
+
+        self._flowctl("init")
+        self._flowctl("spec", "create", "--title", "Sample spec", "--json")
+        self._flowctl(
+            "task", "create", "--spec", SPEC_ID,
+            "--title", "T one", "--acceptance", "acc", "--json",
+        )
+        self._git("add", "-A")
+        self._git("commit", "-qm", "base")
+        self._git("remote", "add", "origin", str(self.upstream))
+        self._git("push", "-q", "origin", "HEAD:refs/heads/main")
+        self._git("branch", "--set-upstream-to=origin/main", "-q")
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.root, ignore_errors=True)
+
+    # --- fixture plumbing -------------------------------------------------
+
+    def _install_git_shim(self) -> None:
+        """A `git` on PATH that logs its argv, then delegates to the real git.
+
+        Lets the spawn-count assertions (R4/R5) run against the production
+        CLI in a subprocess instead of a stubbed in-process module.
+        """
+        self._shim_dir.mkdir()
+        shim = self._shim_dir / "git"
+        shim.write_text(
+            "#!/bin/sh\n"
+            'printf "%s\\n" "$*" >> "$FLOW_TEST_GIT_LOG"\n'
+            f'exec {REAL_GIT} "$@"\n',
+            encoding="utf-8",
+        )
+        shim.chmod(0o755)
+
+    def _env(self, *, shim: bool = False) -> dict:
+        env = dict(os.environ)
+        env["FLOW_TEST_GIT_LOG"] = str(self._git_log)
+        if shim:
+            env["PATH"] = f"{self._shim_dir}{os.pathsep}{env.get('PATH', '')}"
+        return env
+
+    def _git(self, *args: str) -> None:
+        result = subprocess.run(
+            ["git", *args], cwd=str(self.repo), capture_output=True, text=True
+        )
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
+    def _flowctl(
+        self, *args: str, shim: bool = False, cwd: "Path | None" = None
+    ) -> "subprocess.CompletedProcess[str]":
+        result = subprocess.run(
+            [sys.executable, str(FLOWCTL_PY)] + list(args),
+            cwd=str(cwd or self.repo),
+            capture_output=True,
+            text=True,
+            env=self._env(shim=shim),
+        )
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        return result
+
+    def _json(self, *args: str) -> dict:
+        return json.loads(self._flowctl(*args).stdout)
+
+    def _upstream_spawns(self) -> int:
+        if not self._git_log.exists():
+            return 0
+        return sum(
+            1 for line in self._git_log.read_text(encoding="utf-8").splitlines()
+            if UPSTREAM_PROBE in line
+        )
+
+    def _fall_behind(self, commits: int = 1) -> None:
+        """Push N commits, then rewind HEAD — behind without a fetch."""
+        for i in range(commits):
+            self._git("commit", "-q", "--allow-empty", "-m", f"ahead-{i}")
+        self._git("push", "-q", "origin", "HEAD:main")
+        self._git("reset", "-q", "--hard", f"HEAD~{commits}")
+
+    @staticmethod
+    def _notes(text: str) -> list:
+        return [
+            line for line in text.splitlines()
+            if line.startswith("note: checkout is")
+        ]
+
+    # --- R3: behind ------------------------------------------------------
+
+    def test_ready_plain_emits_one_note_when_behind(self) -> None:
+        self._fall_behind(2)
+        notes = self._notes(self._flowctl("ready", "--spec", SPEC_ID).stdout)
+        self.assertEqual(
+            notes,
+            ["note: checkout is 2 commits behind origin/main; "
+             "spec-level state may be stale"],
+        )
+
+    def test_singular_commit_wording(self) -> None:
+        self._fall_behind(1)
+        (note,) = self._notes(self._flowctl("ready", "--spec", SPEC_ID).stdout)
+        self.assertIn("1 commit behind origin/main", note)
+
+    def test_ready_json_carries_stale_vs_upstream(self) -> None:
+        self._fall_behind(3)
+        self.assertEqual(
+            self._json("ready", "--spec", SPEC_ID, "--json")["stale_vs_upstream"], 3
+        )
+
+    def test_ready_all_emits_the_advisory_in_both_forms(self) -> None:
+        self._fall_behind(1)
+        self.assertEqual(len(self._notes(self._flowctl("ready", "--all").stdout)), 1)
+        self.assertEqual(
+            self._json("ready", "--all", "--json")["stale_vs_upstream"], 1
+        )
+
+    def test_anchor_emits_the_advisory_in_both_forms(self) -> None:
+        self._fall_behind(1)
+        self.assertEqual(len(self._notes(self._flowctl("anchor", TASK_ID).stdout)), 1)
+        self.assertEqual(
+            self._json("anchor", TASK_ID, "--json")["stale_vs_upstream"], 1
+        )
+
+    def test_blocked_by_specs_branch_still_advises(self) -> None:
+        """The early-return branch of `ready` is a call site too."""
+        # Fall behind FIRST: `_fall_behind` ends in `reset --hard`, which
+        # would discard an edit to the tracked spec sidecar.
+        self._fall_behind(1)
+        spec_json = self.repo / ".flow" / "specs" / f"{SPEC_ID}.json"
+        payload = json.loads(spec_json.read_text(encoding="utf-8"))
+        payload["depends_on_epics"] = ["fn-99-missing"]
+        spec_json.write_text(json.dumps(payload), encoding="utf-8")
+        out = self._flowctl("ready", "--spec", SPEC_ID).stdout
+        self.assertEqual(len(self._notes(out)), 1)
+        self.assertIn("is blocked by", out)
+        self.assertEqual(
+            self._json("ready", "--spec", SPEC_ID, "--json")["stale_vs_upstream"], 1
+        )
+
+    # --- R3: every non-behind outcome is silent --------------------------
+
+    def _assert_silent(self, *args: str) -> str:
+        plain = self._flowctl(*args).stdout
+        self.assertEqual(self._notes(plain), [])
+        payload = self._json(*args, "--json")
+        self.assertNotIn("stale_vs_upstream", payload)
+        return plain
+
+    def test_up_to_date_is_silent(self) -> None:
+        self._assert_silent("ready", "--spec", SPEC_ID)
+        self._assert_silent("ready", "--all")
+        self._assert_silent("anchor", TASK_ID)
+
+    def test_no_upstream_is_silent_and_output_identical(self) -> None:
+        baseline = self._flowctl("ready", "--spec", SPEC_ID).stdout
+        self._git("checkout", "-q", "-b", "no-upstream")
+        self.assertEqual(self._assert_silent("ready", "--spec", SPEC_ID), baseline)
+
+    def test_detached_head_is_silent_and_output_identical(self) -> None:
+        baseline = self._flowctl("ready", "--spec", SPEC_ID).stdout
+        self._fall_behind(1)
+        self._git("checkout", "-q", "--detach")
+        self.assertEqual(self._assert_silent("ready", "--spec", SPEC_ID), baseline)
+
+    def test_git_failure_degrades_to_no_advisory(self) -> None:
+        """No git repo at all: the command still succeeds, silently."""
+        loose = self.root / "loose"
+        shutil.copytree(self.repo / ".flow", loose / ".flow")
+        result = self._flowctl("ready", "--spec", SPEC_ID, cwd=loose)
+        self.assertEqual(self._notes(result.stdout), [])
+        self.assertNotIn(
+            "stale_vs_upstream",
+            json.loads(
+                self._flowctl(
+                    "ready", "--spec", SPEC_ID, "--json", cwd=loose
+                ).stdout
+            ),
+        )
+
+    # --- R4 / R5: spawn counting -----------------------------------------
+
+    def test_hot_path_commands_never_probe_upstream(self) -> None:
+        """R4: list / status / next must not pay a git spawn for this."""
+        self._fall_behind(1)
+        for args in (("list",), ("list", "--json"), ("status",), ("next", "--json")):
+            with self.subTest(args=args):
+                self._git_log.unlink(missing_ok=True)
+                out = self._flowctl(*args, shim=True).stdout
+                self.assertEqual(self._upstream_spawns(), 0)
+                self.assertEqual(self._notes(out), [])
+                self.assertNotIn("stale_vs_upstream", out)
+
+    def test_one_upstream_spawn_per_invocation(self) -> None:
+        """R5: one check per invocation, however many items are walked."""
+        for suffix in ("2", "3", "4"):
+            self._flowctl(
+                "task", "create", "--spec", SPEC_ID,
+                "--title", f"T {suffix}", "--acceptance", "acc", "--json",
+            )
+        self._flowctl("spec", "create", "--title", "Second spec", "--json")
+        self._fall_behind(1)
+        for args in (
+            ("ready", "--spec", SPEC_ID),
+            ("ready", "--all"),
+            ("anchor", TASK_ID),
+        ):
+            with self.subTest(args=args):
+                self._git_log.unlink(missing_ok=True)
+                self._flowctl(*args, shim=True)
+                self.assertEqual(self._upstream_spawns(), 1)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
# State provenance: status_source, review-skill lifecycle rule, ready/anchor staleness advisory

Wrong answers become marked answers: status output carries its provenance, review skills stop judging task lifecycle from committed sidecars, and the pre-work commands note when the checkout is behind upstream. Advisory only - never fetch, never block.

> **Spec:** [fn-181-state-provenance-status-source-review](https://github.com/gmickel/flow-next/blob/75448051823bd3fb8fac27e312ae34b7b5dfeaba/.flow/specs/fn-181-state-provenance-status-source-review.md)
> **Branch:** `fn-181-state-provenance` → `origin/main`
> **Tasks:** 4 completed
> **R-ID coverage:** 6/6 satisfied

## TL;DR

- `flowctl show` and `list` now say where their status answer came from - `status_source: "flow-state"` (authoritative runtime store) vs `"committed"` (a tracked snapshot that may be stale) - and plain output prints one advisory line when the runtime state directory is absent.
- `ready` (including `--all`) and `anchor` warn once per invocation when the checkout is behind its upstream; `list`, `status`, and `next` are deliberately untouched so the fast-poll performance wins stay intact.
- Both shared review prompts (plan review, completion review) now bar reviewers from judging task lifecycle out of committed task files - the failure that cost three review rounds in the field report.
- 24 new behavioral tests, including git-shim spawn counting that proves the hot-path commands never probe upstream; full suite and lint green.

## Not in this PR (by design)

- Never fetch, never block, no freshness enforcement, no new commands.
- No change to where state lives (committed vs git-local placement stays as designed).
- No keeping committed status current (explicitly not requested in #304; writing runtime state into the tree is the thing the placement…
- Version bump deferred to the batched release.

## The change, top to bottom

Wrong answers become marked answers: flowctl status reads now carry their provenance and warn on stale substrates, and both shared review prompts stop reviewers from judging task lifecycle out of committed snapshots - closing the measured failure class where a stale sidecar cost three review rounds (#304) and a behind checkout answered confidently before work started (#307).

| Proof | Value | Sources |
|---|---|---|
| Artifact | `fn-181-state-provenance-status-source-review-aid-20260809a` | artifact identity |
| Base commit | `b5ac0f5dae243508593736aa0686034fd8b0d391` | artifact currentness |
| Head commit | `75448051823bd3fb8fac27e312ae34b7b5dfeaba` | artifact identity |
| Human-review lines | 793 | deterministic file stats |
| Canonical files | 9 | deterministic membership |
| Total files | 22 | deterministic membership |
| Tasks | 4/4 done, R1-R6 all satisfied | source:spec, source:t1, source:t2, source:t3, source:t4 |
| New tests | 24 behavioral fixtures (12 status_source, 12 upstream advisory) | source:c1 |
| Hot-path guarantee | list/status/next proven zero upstream probes by git-shim spawn counting | source:c1, source:r4 |
| Full gate | 4313 tests green, ruff clean, sync-codex idempotent | source:t4, source:c4 |
| Prompt parity | templates byte-identical to FALLBACK constants; hash pins updated with rationale | source:c3 |

**Legend:** `WHY` `PRINCIPLE` `STEP` `KEPT` `VERIFY` · `NEW` `MODIFIED` `DELETED` `RENAMED` `COPIED` · `CANONICAL` `GENERATED` `MECHANICAL`

<details>
<summary><code>WHY</code> 0. Confident answers from stale substrates — A flowctl read surface answered from a source the caller had no reason to distrust: the committed task-status fallback when runtime state is absent, and per-worktree committed spec state arbitrarily behind the shared store. Reporter measured three wasted review rounds including a NEEDS_WORK at confidence 100 on a 3/3-done spec.</summary>

Evidence: source:spec

</details>

<details open>
<summary><code>STEP</code> 1. flowctl: provenance field and staleness advisories — show/list --json always carry status_source (flow-state vs committed); plain output prints one advisory when the runtime dir is absent. ready (incl. --all) and anchor emit a behind-upstream advisory from one read-only git spawn (--no-optional-locks); any git failure degrades to silence. list/status/next deliberately untouched to protect the fn-109 fast-poll wins.</summary>

Evidence: source:t1, source:t3, source:r1, source:r3, source:r4, source:r5, source:c1, source:c2, R-ID:R1, R-ID:R3, R-ID:R4, R-ID:R5, task:fn-181-state-provenance-status-source-review.1, task:fn-181-state-provenance-status-source-review.3

| Change | Attention | File | Purpose | +/- | Diff | Evidence |
|---|---|---|---|---:|---|---|
| `MODIFIED` | `CANONICAL` | `plugins/flow-next/scripts/flowctl.py` | status_source stamped at the merge point and stripped on every persisted write; one-spawn read-only upstream probe called only from ready/anchor; both review-prompt FALLBACK constants re-synced. | +197/-43 | — | source:t1, source:t3, source:c1, source:c2, source:r1, source:r3, source:r5, source:dm, R-ID:R1, R-ID:R3, R-ID:R5, task:fn-181-state-provenance-status-source-review.1, task:fn-181-state-provenance-status-source-review.3 |
| `NEW` | `CANONICAL` | `plugins/flow-next/tests/test_status_source.py` | 12 behavioral fixtures: both status_source values, advisory presence/absence, field always present under --json. | +207/-0 | — | source:t1, source:c1, source:r1, source:dm, R-ID:R1, task:fn-181-state-provenance-status-source-review.1 |
| `NEW` | `CANONICAL` | `plugins/flow-next/tests/test_upstream_advisory.py` | 12 fixtures via a spawn-logging git shim: behind/not-behind/no-upstream/detached, zero probes on list/status/next, exactly one on ready/ready --all/anchor. | +280/-0 | — | source:t3, source:c1, source:r3, source:r4, source:r5, source:dm, R-ID:R3, R-ID:R4, R-ID:R5, task:fn-181-state-provenance-status-source-review.3 |

<details>
<summary>Generated/mechanical files (3)</summary>

| Change | Attention | File | Purpose | +/- | Diff | Evidence |
|---|---|---|---|---:|---|---|
| `MODIFIED` | `MECHANICAL` | `.flow/bin/flowctl.py` | Byte-identical dual copy of flowctl.py, parity-tested. | +197/-43 | — | source:t1, source:t3, source:c1, source:c2, source:dm, task:fn-181-state-provenance-status-source-review.1, task:fn-181-state-provenance-status-source-review.3 |
| `MODIFIED` | `GENERATED` | `plugins/flow-next/scripts/flowctl_tracker/MANIFEST.json` | Regenerated by gen_tracker_manifest.py after the flowctl.py hash change. | +1/-1 | — | source:c2, source:dm |
| `MODIFIED` | `GENERATED` | `.flow/bin/flowctl_tracker/MANIFEST.json` | Regenerated dual copy of the tracker manifest. | +1/-1 | — | source:c2, source:dm |

</details>

</details>

<details>
<summary><code>STEP</code> 2. Review prompts: task lifecycle is not the reviewer&#x27;s to judge — Both shared review prompt templates now state committed task-file status is a snapshot, locate the authoritative store outside a diff-scoped context, and bar findings based on tasks looking not-started/not-done. Prompt change rides the full pin/parity discipline.</summary>

Evidence: source:t2, source:r2, source:c3, R-ID:R2, task:fn-181-state-provenance-status-source-review.2

| Change | Attention | File | Purpose | +/- | Diff | Evidence |
|---|---|---|---|---:|---|---|
| `MODIFIED` | `CANONICAL` | `plugins/flow-next/skills/flow-next-plan-review/references/plan-review-prompt.md` | Verdict-scope list gains the task-lifecycle exclusion: committed status fields are snapshots; read task files for content, never for status. | +5/-0 | — | source:t2, source:c3, source:r2, source:dm, R-ID:R2, task:fn-181-state-provenance-status-source-review.2 |
| `MODIFIED` | `CANONICAL` | `plugins/flow-next/skills/flow-next-spec-completion-review/references/completion-review-prompt.md` | Completion review declared not a task-bookkeeping review; verdicts never rest on committed task status. | +6/-0 | — | source:t2, source:c3, source:r2, source:dm, R-ID:R2, task:fn-181-state-provenance-status-source-review.2 |

<details>
<summary>Generated/mechanical files (2)</summary>

| Change | Attention | File | Purpose | +/- | Diff | Evidence |
|---|---|---|---|---:|---|---|
| `MODIFIED` | `GENERATED` | `plugins/flow-next/codex/skills/flow-next-plan-review/references/plan-review-prompt.md` | Codex mirror twin, regenerated by sync-codex.sh. | +5/-0 | — | source:t2, source:c3, source:dm |
| `MODIFIED` | `GENERATED` | `plugins/flow-next/codex/skills/flow-next-spec-completion-review/references/completion-review-prompt.md` | Codex mirror twin, regenerated by sync-codex.sh. | +6/-0 | — | source:t2, source:c3, source:dm |

</details>

| Change | Attention | File | Purpose | +/- | Diff | Evidence |
|---|---|---|---|---:|---|---|
| `MODIFIED` | `CANONICAL` | `plugins/flow-next/tests/test_prompt_text_pinned.py` | Hash pins refreshed for the two templates and their FALLBACK constants (deliberate prompt change, rationale in commit message). | +9/-4 | — | source:t2, source:c3, source:dm, task:fn-181-state-provenance-status-source-review.2 |
| `MODIFIED` | `CANONICAL` | `plugins/flow-next/tests/test_review_prompt_constraints.py` | Frozen-inventory entries for the new advisory constant and probe. | +4/-0 | — | source:t2, source:c1, source:c3, source:dm |

<details>
<summary>Generated/mechanical files (4)</summary>

| Change | Attention | File | Purpose | +/- | Diff | Evidence |
|---|---|---|---|---:|---|---|
| `MODIFIED` | `GENERATED` | `plugins/flow-next/tests/fixtures/review_prompts/plan.txt` | Rendered-prompt fixture rebaselined; diff is purely the added lines. | +5/-0 | — | source:c3, source:dm |
| `MODIFIED` | `GENERATED` | `plugins/flow-next/tests/fixtures/review_prompts/plan_no_tasks.txt` | Rendered-prompt fixture rebaselined. | +5/-0 | — | source:c3, source:dm |
| `MODIFIED` | `GENERATED` | `plugins/flow-next/tests/fixtures/review_prompts/completion.txt` | Rendered-prompt fixture rebaselined. | +6/-0 | — | source:c3, source:dm |
| `MODIFIED` | `GENERATED` | `plugins/flow-next/tests/fixtures/review_prompts/completion_no_tasks.txt` | Rendered-prompt fixture rebaselined. | +6/-0 | — | source:c3, source:dm |

</details>

</details>

<details>
<summary><code>STEP</code> 3. Docs, changelog, task records — flowctl.md reference for the new field and advisories; CHANGELOG Unreleased crediting the reporter; task records with done summaries and evidence.</summary>

Evidence: source:t4, source:r6, source:c4, R-ID:R6, task:fn-181-state-provenance-status-source-review.4

| Change | Attention | File | Purpose | +/- | Diff | Evidence |
|---|---|---|---|---:|---|---|
| `MODIFIED` | `CANONICAL` | `plugins/flow-next/docs/flowctl.md` | Documents status_source, the absent-runtime advisory, and the ready/anchor behind-upstream advisory with the explicit list/status/next exclusion. | +6/-0 | — | source:t4, source:c4, source:r6, source:dm, R-ID:R6, task:fn-181-state-provenance-status-source-review.4 |
| `MODIFIED` | `CANONICAL` | `CHANGELOG.md` | Unreleased entry, user-outcome-first, crediting @sn-furali for #304/#307. | +32/-0 | — | source:t4, source:c4, source:r6, source:dm, R-ID:R6, task:fn-181-state-provenance-status-source-review.4 |

<details>
<summary>Generated/mechanical files (4)</summary>

| Change | Attention | File | Purpose | +/- | Diff | Evidence |
|---|---|---|---|---:|---|---|
| `MODIFIED` | `MECHANICAL` | `.flow/tasks/fn-181-state-provenance-status-source-review.1.md` | Task record: done summary and evidence. | +4/-5 | — | source:t1, source:c4, source:dm, task:fn-181-state-provenance-status-source-review.1 |
| `MODIFIED` | `MECHANICAL` | `.flow/tasks/fn-181-state-provenance-status-source-review.2.md` | Task record: done summary and evidence. | +4/-5 | — | source:t2, source:c4, source:dm, task:fn-181-state-provenance-status-source-review.2 |
| `MODIFIED` | `MECHANICAL` | `.flow/tasks/fn-181-state-provenance-status-source-review.3.md` | Task record: done summary and evidence. | +4/-5 | — | source:t3, source:c4, source:dm, task:fn-181-state-provenance-status-source-review.3 |
| `MODIFIED` | `MECHANICAL` | `.flow/tasks/fn-181-state-provenance-status-source-review.4.md` | Task record: done summary and evidence. | +4/-5 | — | source:t4, source:c4, source:dm, task:fn-181-state-provenance-status-source-review.4 |

</details>

</details>

<details>
<summary><code>VERIFY</code> 4. Gate — Full parallel suite 4313 tests green; ruff 0.16.0 clean; sync-codex.sh idempotent; dual copies and tracker manifest current; spawn-count assertions lock R4/R5 behaviorally.</summary>

Evidence: source:t4, source:c4

</details>

## Critical changes

- **High-churn:** [`plugins/flow-next/tests/test_upstream_advisory.py`](https://github.com/gmickel/flow-next/commit/19577611dc8a2201e6d370c6388d4d104bbff33c#diff-45fa08db9add3199259a8544e9694c033025ee6bbbaea6f6c16b53a86f547f77) (+280/-0 lines) - new spawn-counting fixtures
- **High-churn:** [`.flow/bin/flowctl.py`](https://github.com/gmickel/flow-next/commit/19577611dc8a2201e6d370c6388d4d104bbff33c) (+197/-43 lines) - byte-identical dual copy of flowctl.py
- **High-churn:** [`plugins/flow-next/scripts/flowctl.py`](https://github.com/gmickel/flow-next/commit/19577611dc8a2201e6d370c6388d4d104bbff33c#diff-a52f4f2101d1a9031615badb0a45084834516bcb0b6ec993a50076403226568d) (+197/-43 lines) - the provenance field, the advisories, and the prompt FALLBACK re-sync
- **High-churn:** [`plugins/flow-next/tests/test_status_source.py`](https://github.com/gmickel/flow-next/commit/19577611dc8a2201e6d370c6388d4d104bbff33c#diff-734feba18e27ef9296ea6c58c795117d67a4ed2e6b77fd5c6a3a582f55ce242c) (+207/-0 lines) - new provenance fixtures
- **High-churn:** [`CHANGELOG.md`](https://github.com/gmickel/flow-next/commit/ef38a42372a86effa09dff0136bdfdcf0afd9306) (+32/-0 lines) - Unreleased entry for #304/#307

## How to review this PR

The pipeline already verified this - you don't re-check it from scratch:
- **Tests / gates:** 24 new behavioral fixtures (12 status_source, 12 upstream advisory); full parallel suite 4313 tests green, ruff clean, sync-codex idempotent
- **R-ID coverage:** 6/6 acceptance criteria satisfied (see the walkthrough above)
- **Hot-path guarantee:** list/status/next proven zero upstream probes by git-shim spawn counting
- **Cross-model review:** no cross-model review recorded on this PR

Your job - the calls the pipeline can't make:
- Line-review the **Must review** bucket below - the ~23% that carries real judgment risk.
- Spot-check the verified claims above; sample, don't re-run everything.
- Own what machines can't judge: is an advisory line the right UX for staleness, and is the prompt wording strong enough to stop a sandboxed reviewer?

## Review plan

### Must review (~23%)

- [ ] 🔴 [`plugins/flow-next/scripts/flowctl.py`](https://github.com/gmickel/flow-next/commit/19577611dc8a2201e6d370c6388d4d104bbff33c#diff-a52f4f2101d1a9031615badb0a45084834516bcb0b6ec993a50076403226568d) - high-churn core change - Is `status_source` stripped on every persisted write path, and does the upstream probe stay the only new git spawn, called solely from ready/ready --all/anchor? - open `merge_task_runtime` and `upstream_behind`
- [ ] 🔴 [`plugins/flow-next/skills/flow-next-plan-review/references/plan-review-prompt.md`](https://github.com/gmickel/flow-next/commit/7970ef641932396ea4cdeae683e49c5c7af8b9c1#diff-afcefbff0589bf462ecc2a5eddea6434e343a522be718988352fb4dce6a516a2) - reviewer-facing prompt change - Does the added exclusion bar lifecycle verdicts without barring reading task files for content? - open the Verdict Scope list
- [ ] 🔴 [`plugins/flow-next/skills/flow-next-spec-completion-review/references/completion-review-prompt.md`](https://github.com/gmickel/flow-next/commit/7970ef641932396ea4cdeae683e49c5c7af8b9c1#diff-251375704eadc4a49bf2d316c7d5619a1ca2c7cf1bb196e5e8d0c10846ece3c8) - reviewer-facing prompt change - Does "not a task-bookkeeping review" stay compatible with the adjacent requirement-coverage framing? - open the Spec Completion Review preamble

### Spot-check

- [ ] 🟡 [`plugins/flow-next/tests/test_status_source.py`](https://github.com/gmickel/flow-next/commit/19577611dc8a2201e6d370c6388d4d104bbff33c#diff-734feba18e27ef9296ea6c58c795117d67a4ed2e6b77fd5c6a3a582f55ce242c) - do the fixtures cover both provenance values and the always-present-under-json contract?
- [ ] 🟡 [`plugins/flow-next/tests/test_upstream_advisory.py`](https://github.com/gmickel/flow-next/commit/19577611dc8a2201e6d370c6388d4d104bbff33c#diff-45fa08db9add3199259a8544e9694c033025ee6bbbaea6f6c16b53a86f547f77) - does the git shim count spawns on the production CLI path, not a parallel construction?
- [ ] 🟡 `plugins/flow-next/tests/test_prompt_text_pinned.py` + `test_review_prompt_constraints.py` - pin updates match exactly the artifacts changed
- [ ] 🟡 `plugins/flow-next/docs/flowctl.md` + `CHANGELOG.md` - docs match the shipped behavior

### Safe to skim (~28%)

- [ ] ⚪ `.flow/bin/flowctl.py` - byte-identical dual copy, parity-tested
- [ ] ⚪ 2 `flowctl_tracker/MANIFEST.json` files - regenerated by `gen_tracker_manifest.py`
- [ ] ⚪ 2 codex mirror prompt files - regenerated by `sync-codex.sh`, guard-verified
- [ ] ⚪ 4 `tests/fixtures/review_prompts/*.txt` - rendered-prompt rebaselines; diff is purely the added lines
- [ ] ⚪ 4 `.flow/tasks/*.md` - task-state records, not hand-written code

## Structural changes

The spec touches four areas in one pass: the flowctl CLI (`plugins/flow-next/scripts/flowctl.py` plus its byte-identical dual copy under `.flow/bin/`) gains the provenance field and the two advisories; the two shared review prompt templates under `plugins/flow-next/skills/` gain the lifecycle exclusion, with their codex mirrors and rendered fixtures regenerated; two new test files under `plugins/flow-next/tests/` lock the behavior including spawn counts; and `plugins/flow-next/docs/flowctl.md` plus `CHANGELOG.md` carry the reference and release story. The fan-out is mechanical - mirrors, fixtures, and task records follow the two real change sites.

```mermaid
graph TB
  spec["fn-181 state provenance"]
  spec --> flowctl["plugins/flow-next/scripts/flowctl.py (+ dual copy, manifests)"]
  spec --> prompts["review prompt templates (+ codex mirrors, 4 fixtures)"]
  spec --> tests["tests: test_status_source.py, test_upstream_advisory.py"]
  spec --> docs["docs/flowctl.md, CHANGELOG.md"]
  spec --> records[".flow/tasks records (4)"]
```

---

*Generated by `/flow-next:make-pr` from [fn-181-state-provenance-status-source-review](https://github.com/gmickel/flow-next/blob/75448051823bd3fb8fac27e312ae34b7b5dfeaba/.flow/specs/fn-181-state-provenance-status-source-review.md) against `origin/main` on 2026-08-09.*
<!-- flow-next:make-pr spec=fn-181-state-provenance-status-source-review base=origin/main -->
