### PR TITLE
Review attempt provenance: work volume, head_sha origin, base_sha

### DIFF
--- a/.flow/bin/flowctl.py
+++ b/.flow/bin/flowctl.py
@@ -10974,6 +10974,13 @@ def _record_review_attempt_locked(
             "reservation_id": reservation_id,
             "response": output,
             "response_sha256": output_sha256,
+            # fn-183 (#312), PR #324 bot finding: the provenance inputs are in
+            # hand at journal time - carry them so a crash between this write
+            # and the sidecar row replays the row with its measured provenance
+            # instead of degrading to the finalize-time fallback / unknown.
+            "reviewed_head_sha": reviewed_head_sha,
+            "reviewed_base_sha": reviewed_base_sha,
+            "tool_calls": tool_calls,
             "receipt_payload": receipt_payload,
             "receipt_target": receipt_target,
             "status_target": (
@@ -11837,6 +11844,12 @@ def _enforce_and_increment_review_cap_locked(
                 receipt_payload=(journal.get("receipt_payload") if isinstance(journal.get("receipt_payload"), dict) else None),
                 status_target=(journal.get("status_target") if isinstance(journal.get("status_target"), str) else None),
                 reset_rounds_on_ship=bool(journal.get("reset_rounds_on_ship", False)),
+                # fn-183 (#312): journaled provenance rides the replay so the
+                # recovered row keeps the observed snapshot and measured count
+                # (absent from pre-fn-183 journals -> honest fallback/unknown).
+                reviewed_head_sha=(journal.get("reviewed_head_sha") if isinstance(journal.get("reviewed_head_sha"), str) else None),
+                reviewed_base_sha=(journal.get("reviewed_base_sha") if isinstance(journal.get("reviewed_base_sha"), str) else None),
+                tool_calls=(journal.get("tool_calls") if isinstance(journal.get("tool_calls"), int) and not isinstance(journal.get("tool_calls"), bool) else None),
                 # Journaled evidence is authoritative: the crashed process
                 # bound the criteria and built the findings container from the
                 # reviewer MESSAGE, which is gone. `response` is the transport

--- a/.flow/bin/flowctl.py
+++ b/.flow/bin/flowctl.py
@@ -4823,6 +4823,57 @@ def extract_codex_final_message(output: str) -> str:
     return output
 
 
+# The only ``item.completed`` item types that are the reviewer TALKING or
+# THINKING rather than doing work. Everything else on the stream (command
+# execution, file change, MCP tool call, web search, ...) is work, so an
+# unrecognized future item type counts as work: under-reporting work is the
+# failure that would falsely accuse a real review of fabricating (issue #312).
+_CODEX_NON_TOOL_ITEM_TYPES = frozenset({"agent_message", "reasoning"})
+
+
+def count_codex_tool_calls(output: str) -> Optional[int]:
+    """Tool calls a codex ``exec --json`` stream actually performed, or None.
+
+    fn-183 (#312): work volume is the only signal that separates a review that
+    measured the repo from one that answered from a resumed session's context.
+    The fresh-dispatch path runs with ``--json``, so the event stream carries
+    every tool call the reviewer made and the count is a MEASURED fact.
+
+    Returns ``None`` - never 0 - when ``output`` is not a recognizable codex
+    event stream (a resumed session's plain-text stdout, another backend's
+    text, a synthetic dispatch-error string). Absence means unknown; a
+    recorded 0 means the reviewer genuinely touched nothing.
+    """
+    if not output:
+        return None
+    is_stream = False
+    count = 0
+    for line in output.split("\n"):
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            data = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(data, dict):
+            continue
+        event_type = data.get("type")
+        if not isinstance(event_type, str):
+            continue
+        if event_type == "thread.started" or event_type.startswith("item."):
+            is_stream = True
+        if event_type != "item.completed":
+            continue
+        item = data.get("item")
+        if not isinstance(item, dict):
+            continue
+        item_type = item.get("type")
+        if isinstance(item_type, str) and item_type not in _CODEX_NON_TOOL_ITEM_TYPES:
+            count += 1
+    return count if is_stream else None
+
+
 def parse_codex_verdict(output: str) -> Optional[str]:
     """Extract verdict from codex output.
 
@@ -10707,6 +10758,8 @@ def _record_review_attempt_locked(
     finalize_status_kind: Optional[str] = None,
     reset_rounds_on_ship: bool = False,
     reviewed_head_sha: Optional[str] = None,
+    reviewed_base_sha: Optional[str] = None,
+    tool_calls: Optional[int] = None,
     reservation_id: Optional[str] = None,
     receipt_target: Optional[str] = None,
     receipt_payload: Optional[dict] = None,
@@ -11058,6 +11111,17 @@ def _record_review_attempt_locked(
         # The sha the review OBSERVED (pre-dispatch snapshot) when the caller
         # has it; finalize-time HEAD is only the fallback (rp/refund paths).
         "head_sha": reviewed_head_sha or _review_head_sha(),
+        # fn-183 (#312) work volume: how much output the verdict actually cost.
+        # Bytes only - the output itself is never retained (see output_sha256).
+        "output_bytes": len((output or "").encode("utf-8", errors="replace")),
+        # fn-183 (#312) provenance MARKER (not omission): True when a
+        # pre-dispatch snapshot supplied head_sha, False when the finalize-time
+        # `git rev-parse HEAD` fallback did (the rp/host `review-rounds record`
+        # CLI path, and the dispatch-error refund paths). A row with NO
+        # head_sha_observed key predates fn-183 and means unknown - which is
+        # exactly why this is a marker and not an omission: omission would make
+        # "fallback" and "old row" indistinguishable.
+        "head_sha_observed": bool(reviewed_head_sha),
         "reservation_id": reservation_id,
         "hash_epoch": (metadata or {}).get(
             "epoch",
@@ -11073,6 +11137,13 @@ def _record_review_attempt_locked(
             }
         ),
     }
+    # fn-183 (#312): absent, never zero and never guessed. `tool_calls` is
+    # written only where the dispatcher genuinely measured one; `base_sha` only
+    # where a review snapshot supplied it.
+    if tool_calls is not None:
+        row["tool_calls"] = int(tool_calls)
+    if reviewed_base_sha:
+        row["base_sha"] = reviewed_base_sha
     if findings_built and findings_digest is not None:
         row["findings_digest"] = dict(findings_digest)
     if (
@@ -41131,6 +41202,7 @@ def _dispatch_backend_review(
     review_type: str,
     task_id: Optional[str] = None,
     reviewed_head_sha: Optional[str] = None,
+    reviewed_base_sha: Optional[str] = None,
     reservation_id: Optional[str] = None,
     injected_prompt: Optional[str] = None,
 ) -> tuple[str, Optional[str], int, str]:
@@ -41199,6 +41271,7 @@ def _dispatch_backend_review(
                 failure_class="dispatch_error",
                 task_id=task_id,
                 reviewed_head_sha=reviewed_head_sha,
+                reviewed_base_sha=reviewed_base_sha,
                 review_type=review_type,
                 use_json=args.json,
                 reservation_id=reservation_id,
@@ -41227,6 +41300,7 @@ def _dispatch_backend_review(
                 failure_class="dispatch_exception",
                 task_id=task_id,
                 reviewed_head_sha=reviewed_head_sha,
+                reviewed_base_sha=reviewed_base_sha,
                 review_type=review_type,
                 use_json=args.json,
                 reservation_id=reservation_id,
@@ -41399,6 +41473,7 @@ def _backend_impl_review(args: argparse.Namespace, backend: str) -> None:
         review_type="impl",
         task_id=None if standalone else task_id,
         reviewed_head_sha=reviewed_head_sha,
+        reviewed_base_sha=reviewed_base_sha,
         reservation_id=reservation_id,
         injected_prompt=injected_prompt,
     )
@@ -41465,6 +41540,7 @@ def _backend_impl_review(args: argparse.Namespace, backend: str) -> None:
         reset_rounds_on_ship=not standalone,
         attempt_out=attempt_summary,
         reviewed_head_sha=reviewed_head_sha,
+        reviewed_base_sha=reviewed_base_sha,
         reservation_id=reservation_id,
         findings_container=findings_container,
         findings_digest=findings_digest,
@@ -41580,6 +41656,7 @@ def _finish_backend_exec(
     reset_rounds_on_ship: bool = False,
     attempt_out: Optional[dict] = None,
     reviewed_head_sha: Optional[str] = None,
+    reviewed_base_sha: Optional[str] = None,
     reservation_id: Optional[str] = None,
     findings_container: Optional[dict] = None,
     findings_digest: Optional[dict] = None,
@@ -41595,6 +41672,10 @@ def _finish_backend_exec(
     the transport attempt is recorded before the existing error is surfaced.
     """
     verdict = parse_codex_verdict(output)
+    # fn-183 (#312): measured from the raw event stream this function was
+    # handed. None for a backend/path that returns plain text - the row then
+    # carries no tool_calls at all rather than a fabricated 0.
+    tool_calls = count_codex_tool_calls(output)
     if verdict:
         if spec_id and review_kind:
             summary = record_review_attempt(
@@ -41610,6 +41691,8 @@ def _finish_backend_exec(
                 deferred_status_target=deferred_status_target,
                 reset_rounds_on_ship=reset_rounds_on_ship,
                 reviewed_head_sha=reviewed_head_sha,
+                reviewed_base_sha=reviewed_base_sha,
+                tool_calls=tool_calls,
                 reservation_id=reservation_id,
                 findings_container=findings_container,
                 findings_digest=findings_digest,
@@ -41650,6 +41733,8 @@ def _finish_backend_exec(
             failure_class=failure_class,
             task_id=task_id,
             reviewed_head_sha=reviewed_head_sha,
+            reviewed_base_sha=reviewed_base_sha,
+            tool_calls=tool_calls,
             review_type=review_type,
             use_json=args.json,
             reservation_id=reservation_id,
@@ -41838,6 +41923,7 @@ def _backend_plan_review(args: argparse.Namespace, backend: str) -> None:
         review_kind="plan",
         review_type="plan",
         reviewed_head_sha=reviewed_head_sha,
+        reviewed_base_sha=reviewed_base_sha,
         reservation_id=reservation_id,
         injected_prompt=injected_prompt,
     )
@@ -41901,6 +41987,7 @@ def _backend_plan_review(args: argparse.Namespace, backend: str) -> None:
         reset_rounds_on_ship=True,
         attempt_out=attempt_summary,
         reviewed_head_sha=reviewed_head_sha,
+        reviewed_base_sha=reviewed_base_sha,
         reservation_id=reservation_id,
         findings_container=findings_container,
         findings_digest=findings_digest,
@@ -42137,6 +42224,7 @@ def _backend_completion_review(args: argparse.Namespace, backend: str) -> None:
         review_kind="plan",
         review_type="completion",
         reviewed_head_sha=reviewed_head_sha,
+        reviewed_base_sha=reviewed_base_sha,
         reservation_id=reservation_id,
         injected_prompt=injected_prompt,
     )
@@ -42205,6 +42293,7 @@ def _backend_completion_review(args: argparse.Namespace, backend: str) -> None:
         reset_rounds_on_ship=True,
         attempt_out=attempt_summary,
         reviewed_head_sha=reviewed_head_sha,
+        reviewed_base_sha=reviewed_base_sha,
         reservation_id=reservation_id,
         findings_container=findings_container,
         findings_digest=findings_digest,

--- a/.flow/bin/flowctl.py
+++ b/.flow/bin/flowctl.py
@@ -4874,6 +4874,19 @@ def count_codex_tool_calls(output: str) -> Optional[int]:
     return count if is_stream else None
 
 
+def measured_tool_calls(backend: str, output: str) -> Optional[int]:
+    """Tool-call count for the attempt row, or None when nothing was measured.
+
+    Gated on the codex backend: ``count_codex_tool_calls`` is content-sniffing,
+    and a copilot/cursor review whose plain text QUOTES codex-shaped event
+    lines must not get a fabricated measurement (PR #324 bot finding). Only
+    codex ``exec --json`` output is a stream the dispatcher genuinely measured.
+    """
+    if backend != "codex":
+        return None
+    return count_codex_tool_calls(output)
+
+
 def parse_codex_verdict(output: str) -> Optional[str]:
     """Extract verdict from codex output.
 
@@ -41675,7 +41688,7 @@ def _finish_backend_exec(
     # fn-183 (#312): measured from the raw event stream this function was
     # handed. None for a backend/path that returns plain text - the row then
     # carries no tool_calls at all rather than a fabricated 0.
-    tool_calls = count_codex_tool_calls(output)
+    tool_calls = measured_tool_calls(backend, output)
     if verdict:
         if spec_id and review_kind:
             summary = record_review_attempt(

--- a/.flow/bin/flowctl_tracker/MANIFEST.json
+++ b/.flow/bin/flowctl_tracker/MANIFEST.json
@@ -2,7 +2,7 @@
   "files": [
     {
       "path": "flowctl.py",
-      "sha256": "479bdf420f988de1d2f72e98879a36f2aee9ef8fd9e02ac202e006d6acafda19"
+      "sha256": "4d532447cd30c0b5e91e888e0ee8e9de743370cf0152fab4c388e4b74d4e34f9"
     },
     {
       "path": "flowctl_tracker/__init__.py",

--- a/.flow/bin/flowctl_tracker/MANIFEST.json
+++ b/.flow/bin/flowctl_tracker/MANIFEST.json
@@ -2,7 +2,7 @@
   "files": [
     {
       "path": "flowctl.py",
-      "sha256": "61836272dcac53731afe02ff26d924afe96895b90a3d69d59cde86e836bf896b"
+      "sha256": "479bdf420f988de1d2f72e98879a36f2aee9ef8fd9e02ac202e006d6acafda19"
     },
     {
       "path": "flowctl_tracker/__init__.py",

--- a/.flow/bin/flowctl_tracker/MANIFEST.json
+++ b/.flow/bin/flowctl_tracker/MANIFEST.json
@@ -2,7 +2,7 @@
   "files": [
     {
       "path": "flowctl.py",
-      "sha256": "4d532447cd30c0b5e91e888e0ee8e9de743370cf0152fab4c388e4b74d4e34f9"
+      "sha256": "5c198b50ad9449c9bcda90a23481e9b649fcc1bd5405242254428059cc55f2cb"
     },
     {
       "path": "flowctl_tracker/__init__.py",

--- a/.flow/tasks/fn-183-review-attempt-provenance-work-volume.1.md
+++ b/.flow/tasks/fn-183-review-attempt-provenance-work-volume.1.md
@@ -12,9 +12,8 @@ Spec fn-183 items 1-3 (#312). record_review_attempt gains output byte count (alw
 R1, R2, R3 of the spec.
 
 ## Done summary
-TBD
-
+Attempt-row write path extended per fn-183 R1-R3 (#312). Every new review_attempts row records output_bytes (computed in _record_review_attempt_locked from the output arg; output text never retained). tool_calls recorded only where measured: new count_codex_tool_calls() parses the codex exec --json event stream (None - never 0 - for plain text; unknown future item types count as work), wired at both _finish_backend_exec record sites. head_sha provenance is a marker, head_sha_observed: true|false (marker chosen over omission so fallback rows stay distinguishable from pre-fn-183 rows); the review-rounds record CLI path is the tested fallback fixture. base_sha forwarded via reviewed_base_sha from the existing _capture_review_snapshot unpacks in impl/plan/completion handlers; absent, not guessed, elsewhere. Dual copy + tracker manifests + sync-codex x2 propagated. 12 new focused tests.
 ## Evidence
-- Commits:
-- Tests:
+- Commits: 07cb1f72
+- Tests: cd plugins/flow-next/tests && python3 -m unittest test_review_convergence_cap test_review_convergence_journal test_host_review_backend test_flowctl_surface -q (314 OK), cd plugins/flow-next/tests && python3 -m unittest test_tracker_distribution -q (19 OK)
 - PRs:

--- a/.flow/tasks/fn-183-review-attempt-provenance-work-volume.2.md
+++ b/.flow/tasks/fn-183-review-attempt-provenance-work-volume.2.md
@@ -12,9 +12,8 @@ Spec fn-183 (#312). review-rounds attempts --json surfaces the new fields; rows 
 R4 of the spec.
 
 ## Done summary
-TBD
-
+R4 verified end-to-end through the real CLI (argparse -> cmd_review_rounds_attempts -> _review_attempt_summary -> json_output): rows return unprojected, so the .1 fields already surface. No code gap; pinned with 5 CLI-level tests (TestAttemptsReadSurface): writer-to-reader fallback fixture, snapshot row surfaces all four fields, measured tool_calls=0 survives read (falsy-drop guard), pre-fn-183 legacy rows read back with fields absent (assertNotIn) and exit 0 on both --json and human paths, mixed ledger clean. Mutation check confirmed tests fail if the read path starts projecting keys. Tests-only commit, no propagation needed.
 ## Evidence
-- Commits:
-- Tests:
+- Commits: 0f1a016e
+- Tests: cd plugins/flow-next/tests && python3 -m unittest test_review_convergence_cap -q (182 OK)
 - PRs:

--- a/.flow/tasks/fn-183-review-attempt-provenance-work-volume.3.md
+++ b/.flow/tasks/fn-183-review-attempt-provenance-work-volume.3.md
@@ -10,9 +10,8 @@ Spec fn-183 R5. Architecture notes: what each field answers; absence means unkno
 R5 of the spec. Full gate green; no version bump.
 
 ## Done summary
-TBD
-
+R5 closed out. architecture.md "Review bookkeeping" section documents each new attempt-row field and what it answers (output_bytes = did the verdict cost measured work; tool_calls = measured-only, recorded 0 is the fabrication signal; head_sha_observed = snapshot vs finalize-time fallback, marker not omission so fallback rows stay distinguishable from pre-fn-183 rows; base_sha = locate and re-render the judged diff), states absence means unknown never zero, and documents session_id as NOT a work-evidence signal (resume reuses the thread id). flowctl.md attempts surface links to the schema notes. CHANGELOG Unreleased entry, user-outcome-first, credits @sn-furali (#312). Full gate green; no version bump (batched release).
 ## Evidence
-- Commits:
-- Tests:
+- Commits: 17fe7a7b
+- Tests: python3 scripts/run_tests_parallel.py (4340 OK, 0 failures), uvx ruff@0.16.0 check . (clean), ./scripts/sync-codex.sh x2 (idempotent, no diff)
 - PRs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 All notable changes to the flow-next.
 
+## Unreleased
+
+A review verdict you cannot audit is a verdict you have to take on faith. A
+resumed reviewer session can answer from its previous round's context in ~1 KB
+with zero tool calls while asserting "measured" facts - and the verdict text
+looks identical to a real one. Attempt rows now record how the verdict was
+produced, so a consumer (or a human) can ask "was this measured?" instead of
+trusting narration. Fixes #312 - thanks @sn-furali for the measured report.
+
+### Added
+
+- **Review-attempt rows carry work volume and provenance.** Every new
+  `review_attempts[]` row records `output_bytes` (size only - the output is
+  never retained); `tool_calls` where the backend's event stream let the
+  dispatcher genuinely count them (codex `exec --json`) - a measured `0` is
+  recorded, the fabrication signal itself, while plain-text paths carry no
+  key; `head_sha_observed` marking whether `head_sha` came from the
+  pre-dispatch snapshot or the finalize-time fallback (the `review-rounds
+  record` CLI path always takes the fallback); and `base_sha` beside
+  `head_sha` wherever the review snapshot ran, so the judged diff can be
+  located and re-rendered. `review-rounds attempts --json` surfaces all of
+  it; rows written by older versions read back with the fields absent -
+  absence means unknown, never zero. (#312)
+
 ## [flow-next 3.23.0] - 2026-08-09
 
 A wrong answer you can recognize costs a glance; a wrong answer dressed as a

--- a/plugins/flow-next/docs/architecture.md
+++ b/plugins/flow-next/docs/architecture.md
@@ -129,6 +129,31 @@ finalize-time HEAD is the fallback where no snapshot exists, e.g. rp). `plan_rev
 `*_reviewed_at` stamps) are a denormalized read model derived from that
 ledger; when the two ever diverge, the ledger wins.
 
+Each row also answers "was this verdict measured, and against what?"
+(fn-183, #312):
+
+- `output_bytes` - how much output the verdict cost. A ~1 KB SHIP that claims
+  fresh measurement is the fabrication signature the field exists to expose;
+  only the size is recorded, never the output text (its `output_sha256` is the
+  identity).
+- `tool_calls` - present only where the backend's event stream let the
+  dispatcher genuinely count them (codex `exec --json`); a recorded `0` means
+  the reviewer touched nothing, which is the signal, not an error. Plain-text
+  paths (resumed sessions, rp/host) carry no key at all.
+- `head_sha_observed` - `true` when a pre-dispatch snapshot supplied
+  `head_sha`, `false` when the finalize-time `git rev-parse HEAD` fallback did
+  (always the case on the `review-rounds record` CLI path). A marker, not an
+  omission, so a fallback row stays distinguishable from a pre-fn-183 row.
+- `base_sha` - beside `head_sha` wherever the review snapshot ran, so the
+  judged diff can be located and re-rendered; absent, never guessed,
+  elsewhere.
+
+On every one of these fields, **absence means unknown - never zero**: rows
+written by older versions carry none of them and read back untouched.
+`session_id`-style identity is deliberately NOT a work-evidence signal - a
+resumed backend session reuses the same thread id for a fabricated round and a
+real one, so only work volume separates them.
+
 Write-ordering differs by path, on purpose:
 
 - **In-process plan review** (`flowctl codex|copilot|cursor plan-review`)

--- a/plugins/flow-next/docs/flowctl.md
+++ b/plugins/flow-next/docs/flowctl.md
@@ -287,7 +287,11 @@ receipt/status work. A terminal `SHIP`, `NEEDS_WORK`, `MAJOR_RETHINK`, or
 (backend, failure class, timestamp, findings digest) to the spec sidecar.
 `NEEDS_HUMAN` persists its receipt and `needs_human` status before exiting 4
 with `ESCALATE: reviewer requested human review`. `attempts` reports
-verdict-bearing versus refunded attempts for one review scope. A `SHIP` record
+verdict-bearing versus refunded attempts for one review scope; under `--json`
+each row carries its work-volume and provenance fields (`output_bytes`,
+`tool_calls` where measured, `head_sha_observed`, `base_sha` where a snapshot
+ran - absence means unknown, never zero; see
+[architecture.md § Review bookkeeping](architecture.md#review-bookkeeping-authority-and-write-ordering)). A `SHIP` record
 resets its own counter atomically; `reset` is the human-only manual recovery
 command, while explicit re-plans use `spec reset-review-rounds`. Completion passes `--kind plan --review-type
 completion`; impl requires `--task`.

--- a/plugins/flow-next/scripts/flowctl.py
+++ b/plugins/flow-next/scripts/flowctl.py
@@ -10974,6 +10974,13 @@ def _record_review_attempt_locked(
             "reservation_id": reservation_id,
             "response": output,
             "response_sha256": output_sha256,
+            # fn-183 (#312), PR #324 bot finding: the provenance inputs are in
+            # hand at journal time - carry them so a crash between this write
+            # and the sidecar row replays the row with its measured provenance
+            # instead of degrading to the finalize-time fallback / unknown.
+            "reviewed_head_sha": reviewed_head_sha,
+            "reviewed_base_sha": reviewed_base_sha,
+            "tool_calls": tool_calls,
             "receipt_payload": receipt_payload,
             "receipt_target": receipt_target,
             "status_target": (
@@ -11837,6 +11844,12 @@ def _enforce_and_increment_review_cap_locked(
                 receipt_payload=(journal.get("receipt_payload") if isinstance(journal.get("receipt_payload"), dict) else None),
                 status_target=(journal.get("status_target") if isinstance(journal.get("status_target"), str) else None),
                 reset_rounds_on_ship=bool(journal.get("reset_rounds_on_ship", False)),
+                # fn-183 (#312): journaled provenance rides the replay so the
+                # recovered row keeps the observed snapshot and measured count
+                # (absent from pre-fn-183 journals -> honest fallback/unknown).
+                reviewed_head_sha=(journal.get("reviewed_head_sha") if isinstance(journal.get("reviewed_head_sha"), str) else None),
+                reviewed_base_sha=(journal.get("reviewed_base_sha") if isinstance(journal.get("reviewed_base_sha"), str) else None),
+                tool_calls=(journal.get("tool_calls") if isinstance(journal.get("tool_calls"), int) and not isinstance(journal.get("tool_calls"), bool) else None),
                 # Journaled evidence is authoritative: the crashed process
                 # bound the criteria and built the findings container from the
                 # reviewer MESSAGE, which is gone. `response` is the transport

--- a/plugins/flow-next/scripts/flowctl.py
+++ b/plugins/flow-next/scripts/flowctl.py
@@ -4823,6 +4823,57 @@ def extract_codex_final_message(output: str) -> str:
     return output
 
 
+# The only ``item.completed`` item types that are the reviewer TALKING or
+# THINKING rather than doing work. Everything else on the stream (command
+# execution, file change, MCP tool call, web search, ...) is work, so an
+# unrecognized future item type counts as work: under-reporting work is the
+# failure that would falsely accuse a real review of fabricating (issue #312).
+_CODEX_NON_TOOL_ITEM_TYPES = frozenset({"agent_message", "reasoning"})
+
+
+def count_codex_tool_calls(output: str) -> Optional[int]:
+    """Tool calls a codex ``exec --json`` stream actually performed, or None.
+
+    fn-183 (#312): work volume is the only signal that separates a review that
+    measured the repo from one that answered from a resumed session's context.
+    The fresh-dispatch path runs with ``--json``, so the event stream carries
+    every tool call the reviewer made and the count is a MEASURED fact.
+
+    Returns ``None`` - never 0 - when ``output`` is not a recognizable codex
+    event stream (a resumed session's plain-text stdout, another backend's
+    text, a synthetic dispatch-error string). Absence means unknown; a
+    recorded 0 means the reviewer genuinely touched nothing.
+    """
+    if not output:
+        return None
+    is_stream = False
+    count = 0
+    for line in output.split("\n"):
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            data = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(data, dict):
+            continue
+        event_type = data.get("type")
+        if not isinstance(event_type, str):
+            continue
+        if event_type == "thread.started" or event_type.startswith("item."):
+            is_stream = True
+        if event_type != "item.completed":
+            continue
+        item = data.get("item")
+        if not isinstance(item, dict):
+            continue
+        item_type = item.get("type")
+        if isinstance(item_type, str) and item_type not in _CODEX_NON_TOOL_ITEM_TYPES:
+            count += 1
+    return count if is_stream else None
+
+
 def parse_codex_verdict(output: str) -> Optional[str]:
     """Extract verdict from codex output.
 
@@ -10707,6 +10758,8 @@ def _record_review_attempt_locked(
     finalize_status_kind: Optional[str] = None,
     reset_rounds_on_ship: bool = False,
     reviewed_head_sha: Optional[str] = None,
+    reviewed_base_sha: Optional[str] = None,
+    tool_calls: Optional[int] = None,
     reservation_id: Optional[str] = None,
     receipt_target: Optional[str] = None,
     receipt_payload: Optional[dict] = None,
@@ -11058,6 +11111,17 @@ def _record_review_attempt_locked(
         # The sha the review OBSERVED (pre-dispatch snapshot) when the caller
         # has it; finalize-time HEAD is only the fallback (rp/refund paths).
         "head_sha": reviewed_head_sha or _review_head_sha(),
+        # fn-183 (#312) work volume: how much output the verdict actually cost.
+        # Bytes only - the output itself is never retained (see output_sha256).
+        "output_bytes": len((output or "").encode("utf-8", errors="replace")),
+        # fn-183 (#312) provenance MARKER (not omission): True when a
+        # pre-dispatch snapshot supplied head_sha, False when the finalize-time
+        # `git rev-parse HEAD` fallback did (the rp/host `review-rounds record`
+        # CLI path, and the dispatch-error refund paths). A row with NO
+        # head_sha_observed key predates fn-183 and means unknown - which is
+        # exactly why this is a marker and not an omission: omission would make
+        # "fallback" and "old row" indistinguishable.
+        "head_sha_observed": bool(reviewed_head_sha),
         "reservation_id": reservation_id,
         "hash_epoch": (metadata or {}).get(
             "epoch",
@@ -11073,6 +11137,13 @@ def _record_review_attempt_locked(
             }
         ),
     }
+    # fn-183 (#312): absent, never zero and never guessed. `tool_calls` is
+    # written only where the dispatcher genuinely measured one; `base_sha` only
+    # where a review snapshot supplied it.
+    if tool_calls is not None:
+        row["tool_calls"] = int(tool_calls)
+    if reviewed_base_sha:
+        row["base_sha"] = reviewed_base_sha
     if findings_built and findings_digest is not None:
         row["findings_digest"] = dict(findings_digest)
     if (
@@ -41131,6 +41202,7 @@ def _dispatch_backend_review(
     review_type: str,
     task_id: Optional[str] = None,
     reviewed_head_sha: Optional[str] = None,
+    reviewed_base_sha: Optional[str] = None,
     reservation_id: Optional[str] = None,
     injected_prompt: Optional[str] = None,
 ) -> tuple[str, Optional[str], int, str]:
@@ -41199,6 +41271,7 @@ def _dispatch_backend_review(
                 failure_class="dispatch_error",
                 task_id=task_id,
                 reviewed_head_sha=reviewed_head_sha,
+                reviewed_base_sha=reviewed_base_sha,
                 review_type=review_type,
                 use_json=args.json,
                 reservation_id=reservation_id,
@@ -41227,6 +41300,7 @@ def _dispatch_backend_review(
                 failure_class="dispatch_exception",
                 task_id=task_id,
                 reviewed_head_sha=reviewed_head_sha,
+                reviewed_base_sha=reviewed_base_sha,
                 review_type=review_type,
                 use_json=args.json,
                 reservation_id=reservation_id,
@@ -41399,6 +41473,7 @@ def _backend_impl_review(args: argparse.Namespace, backend: str) -> None:
         review_type="impl",
         task_id=None if standalone else task_id,
         reviewed_head_sha=reviewed_head_sha,
+        reviewed_base_sha=reviewed_base_sha,
         reservation_id=reservation_id,
         injected_prompt=injected_prompt,
     )
@@ -41465,6 +41540,7 @@ def _backend_impl_review(args: argparse.Namespace, backend: str) -> None:
         reset_rounds_on_ship=not standalone,
         attempt_out=attempt_summary,
         reviewed_head_sha=reviewed_head_sha,
+        reviewed_base_sha=reviewed_base_sha,
         reservation_id=reservation_id,
         findings_container=findings_container,
         findings_digest=findings_digest,
@@ -41580,6 +41656,7 @@ def _finish_backend_exec(
     reset_rounds_on_ship: bool = False,
     attempt_out: Optional[dict] = None,
     reviewed_head_sha: Optional[str] = None,
+    reviewed_base_sha: Optional[str] = None,
     reservation_id: Optional[str] = None,
     findings_container: Optional[dict] = None,
     findings_digest: Optional[dict] = None,
@@ -41595,6 +41672,10 @@ def _finish_backend_exec(
     the transport attempt is recorded before the existing error is surfaced.
     """
     verdict = parse_codex_verdict(output)
+    # fn-183 (#312): measured from the raw event stream this function was
+    # handed. None for a backend/path that returns plain text - the row then
+    # carries no tool_calls at all rather than a fabricated 0.
+    tool_calls = count_codex_tool_calls(output)
     if verdict:
         if spec_id and review_kind:
             summary = record_review_attempt(
@@ -41610,6 +41691,8 @@ def _finish_backend_exec(
                 deferred_status_target=deferred_status_target,
                 reset_rounds_on_ship=reset_rounds_on_ship,
                 reviewed_head_sha=reviewed_head_sha,
+                reviewed_base_sha=reviewed_base_sha,
+                tool_calls=tool_calls,
                 reservation_id=reservation_id,
                 findings_container=findings_container,
                 findings_digest=findings_digest,
@@ -41650,6 +41733,8 @@ def _finish_backend_exec(
             failure_class=failure_class,
             task_id=task_id,
             reviewed_head_sha=reviewed_head_sha,
+            reviewed_base_sha=reviewed_base_sha,
+            tool_calls=tool_calls,
             review_type=review_type,
             use_json=args.json,
             reservation_id=reservation_id,
@@ -41838,6 +41923,7 @@ def _backend_plan_review(args: argparse.Namespace, backend: str) -> None:
         review_kind="plan",
         review_type="plan",
         reviewed_head_sha=reviewed_head_sha,
+        reviewed_base_sha=reviewed_base_sha,
         reservation_id=reservation_id,
         injected_prompt=injected_prompt,
     )
@@ -41901,6 +41987,7 @@ def _backend_plan_review(args: argparse.Namespace, backend: str) -> None:
         reset_rounds_on_ship=True,
         attempt_out=attempt_summary,
         reviewed_head_sha=reviewed_head_sha,
+        reviewed_base_sha=reviewed_base_sha,
         reservation_id=reservation_id,
         findings_container=findings_container,
         findings_digest=findings_digest,
@@ -42137,6 +42224,7 @@ def _backend_completion_review(args: argparse.Namespace, backend: str) -> None:
         review_kind="plan",
         review_type="completion",
         reviewed_head_sha=reviewed_head_sha,
+        reviewed_base_sha=reviewed_base_sha,
         reservation_id=reservation_id,
         injected_prompt=injected_prompt,
     )
@@ -42205,6 +42293,7 @@ def _backend_completion_review(args: argparse.Namespace, backend: str) -> None:
         reset_rounds_on_ship=True,
         attempt_out=attempt_summary,
         reviewed_head_sha=reviewed_head_sha,
+        reviewed_base_sha=reviewed_base_sha,
         reservation_id=reservation_id,
         findings_container=findings_container,
         findings_digest=findings_digest,

--- a/plugins/flow-next/scripts/flowctl.py
+++ b/plugins/flow-next/scripts/flowctl.py
@@ -4874,6 +4874,19 @@ def count_codex_tool_calls(output: str) -> Optional[int]:
     return count if is_stream else None
 
 
+def measured_tool_calls(backend: str, output: str) -> Optional[int]:
+    """Tool-call count for the attempt row, or None when nothing was measured.
+
+    Gated on the codex backend: ``count_codex_tool_calls`` is content-sniffing,
+    and a copilot/cursor review whose plain text QUOTES codex-shaped event
+    lines must not get a fabricated measurement (PR #324 bot finding). Only
+    codex ``exec --json`` output is a stream the dispatcher genuinely measured.
+    """
+    if backend != "codex":
+        return None
+    return count_codex_tool_calls(output)
+
+
 def parse_codex_verdict(output: str) -> Optional[str]:
     """Extract verdict from codex output.
 
@@ -41675,7 +41688,7 @@ def _finish_backend_exec(
     # fn-183 (#312): measured from the raw event stream this function was
     # handed. None for a backend/path that returns plain text - the row then
     # carries no tool_calls at all rather than a fabricated 0.
-    tool_calls = count_codex_tool_calls(output)
+    tool_calls = measured_tool_calls(backend, output)
     if verdict:
         if spec_id and review_kind:
             summary = record_review_attempt(

--- a/plugins/flow-next/scripts/flowctl_tracker/MANIFEST.json
+++ b/plugins/flow-next/scripts/flowctl_tracker/MANIFEST.json
@@ -2,7 +2,7 @@
   "files": [
     {
       "path": "flowctl.py",
-      "sha256": "479bdf420f988de1d2f72e98879a36f2aee9ef8fd9e02ac202e006d6acafda19"
+      "sha256": "4d532447cd30c0b5e91e888e0ee8e9de743370cf0152fab4c388e4b74d4e34f9"
     },
     {
       "path": "flowctl_tracker/__init__.py",

--- a/plugins/flow-next/scripts/flowctl_tracker/MANIFEST.json
+++ b/plugins/flow-next/scripts/flowctl_tracker/MANIFEST.json
@@ -2,7 +2,7 @@
   "files": [
     {
       "path": "flowctl.py",
-      "sha256": "61836272dcac53731afe02ff26d924afe96895b90a3d69d59cde86e836bf896b"
+      "sha256": "479bdf420f988de1d2f72e98879a36f2aee9ef8fd9e02ac202e006d6acafda19"
     },
     {
       "path": "flowctl_tracker/__init__.py",

--- a/plugins/flow-next/scripts/flowctl_tracker/MANIFEST.json
+++ b/plugins/flow-next/scripts/flowctl_tracker/MANIFEST.json
@@ -2,7 +2,7 @@
   "files": [
     {
       "path": "flowctl.py",
-      "sha256": "4d532447cd30c0b5e91e888e0ee8e9de743370cf0152fab4c388e4b74d4e34f9"
+      "sha256": "5c198b50ad9449c9bcda90a23481e9b649fcc1bd5405242254428059cc55f2cb"
     },
     {
       "path": "flowctl_tracker/__init__.py",

--- a/plugins/flow-next/tests/test_review_convergence_cap.py
+++ b/plugins/flow-next/tests/test_review_convergence_cap.py
@@ -2633,6 +2633,165 @@ class TestCodexToolCallCount(unittest.TestCase):
             self.assertIsNone(flowctl.count_codex_tool_calls(output))
 
 
+class TestAttemptsReadSurface(unittest.TestCase):
+    """fn-183 R4 (#312): `review-rounds attempts --json` is the audit surface.
+
+    The consumer asks "was this verdict measured?" of the CLI, not of an
+    internal helper - so these go through argparse and the real command. The
+    read path returns whole rows (no projection); that is the property being
+    pinned, so a later "tidy up the payload" refactor cannot silently drop the
+    provenance fields. Rows written before fn-183 must come back with the
+    fields ABSENT - unknown, never zero - and exit 0.
+    """
+
+    NEW_FIELDS = ("output_bytes", "tool_calls", "head_sha_observed", "base_sha")
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self._tmp.name)
+        _init_flow_repo(self.root)
+        self.spec_id = "fn-1-demo"
+        self._cwd = os.getcwd()
+        os.chdir(self.root)
+        self._old_env = os.environ.pop("MAX_REVIEW_ITERATIONS", None)
+
+    def tearDown(self):
+        os.chdir(self._cwd)
+        if self._old_env is not None:
+            os.environ["MAX_REVIEW_ITERATIONS"] = self._old_env
+        self._tmp.cleanup()
+
+    def _spec_path(self) -> Path:
+        return self.root / ".flow" / "specs" / f"{self.spec_id}.json"
+
+    def _run(self, *argv: str) -> "tuple[int, str, str]":
+        out, err = io.StringIO(), io.StringIO()
+        code = 0
+        with mock.patch.object(sys, "argv", ["flowctl", *argv]):
+            with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+                try:
+                    flowctl.main()
+                except SystemExit as e:
+                    code = int(e.code or 0)
+        return code, out.getvalue(), err.getvalue()
+
+    def _row(self, **overrides) -> dict:
+        row = {
+            "timestamp": flowctl.now_iso(),
+            "scope": flowctl._review_attempt_scope("plan", None, "plan"),
+            "backend": "codex",
+            "kind": "plan",
+            "counter_kind": "plan",
+            "task": None,
+            "outcome": "verdict",
+            "verdict": "SHIP",
+            "output_sha256": "0" * 64,
+            "round_consumed": True,
+            "head_sha": "d" * 40,
+        }
+        row.update(overrides)
+        return row
+
+    def _seed(self, *rows: dict) -> None:
+        data = json.loads(self._spec_path().read_text())
+        data["review_attempts"] = list(rows)
+        self._spec_path().write_text(json.dumps(data))
+
+    def _attempts_json(self) -> dict:
+        code, out, _ = self._run(
+            "review-rounds", "attempts", self.spec_id,
+            "--kind", "plan", "--review-type", "plan", "--json",
+        )
+        self.assertEqual(code, 0)
+        return json.loads(out)
+
+    def test_written_row_reaches_the_cli_read_surface(self):
+        """End to end: the writer's fields survive the CLI read, unprojected.
+
+        The `review-rounds record` path is the rp/host fixture - it measures
+        output bytes and marks head_sha as the finalize-time fallback, and
+        genuinely knows neither tool_calls nor base_sha.
+        """
+        self._run(
+            "review-rounds", "increment", self.spec_id, "--kind", "plan", "--json"
+        )
+        output_path = self.root / "review.txt"
+        output_path.write_text("<verdict>NEEDS_WORK</verdict> éé", encoding="utf-8")
+        code, _, _ = self._run(
+            "review-rounds", "record", self.spec_id,
+            "--kind", "plan", "--review-type", "plan",
+            "--backend", "rp", "--output-file", str(output_path), "--json",
+        )
+        self.assertEqual(code, 0)
+        row = self._attempts_json()["attempts"][-1]
+        self.assertEqual(
+            row["output_bytes"],
+            len(output_path.read_text(encoding="utf-8").encode("utf-8")),
+        )
+        self.assertIs(row["head_sha_observed"], False)
+        self.assertNotIn("tool_calls", row)
+        self.assertNotIn("base_sha", row)
+
+    def test_snapshot_row_surfaces_every_new_field(self):
+        self._seed(
+            self._row(
+                output_bytes=151_000,
+                tool_calls=22,
+                head_sha_observed=True,
+                head_sha="a" * 40,
+                base_sha="c" * 40,
+            )
+        )
+        row = self._attempts_json()["attempts"][-1]
+        self.assertEqual(row["output_bytes"], 151_000)
+        self.assertEqual(row["tool_calls"], 22)
+        self.assertIs(row["head_sha_observed"], True)
+        self.assertEqual(row["base_sha"], "c" * 40)
+        self.assertEqual(row["head_sha"], "a" * 40)
+
+    def test_measured_zero_tool_calls_survives_the_read(self):
+        """The #312 signal itself: a measured 0 must not be dropped as falsy."""
+        self._seed(self._row(output_bytes=1_180, tool_calls=0, head_sha_observed=True))
+        row = self._attempts_json()["attempts"][-1]
+        self.assertEqual(row["tool_calls"], 0)
+        self.assertEqual(row["output_bytes"], 1_180)
+
+    def test_pre_fn183_rows_read_back_with_fields_absent(self):
+        self._seed(self._row())
+        payload = self._attempts_json()
+        self.assertEqual(payload["verdict_attempts"], 1)
+        row = payload["attempts"][-1]
+        for field in self.NEW_FIELDS:
+            self.assertNotIn(field, row)
+        # Human-readable path over the same legacy ledger: also exit 0.
+        code, _, _ = self._run(
+            "review-rounds", "attempts", self.spec_id,
+            "--kind", "plan", "--review-type", "plan",
+        )
+        self.assertEqual(code, 0)
+
+    def test_mixed_legacy_and_new_ledger_reads_cleanly(self):
+        self._seed(
+            self._row(verdict="NEEDS_WORK"),
+            self._row(
+                verdict="SHIP",
+                output_bytes=248_000,
+                tool_calls=20,
+                head_sha_observed=True,
+                base_sha="c" * 40,
+            ),
+        )
+        payload = self._attempts_json()
+        self.assertEqual(payload["verdict_attempts"], 2)
+        old, new = payload["attempts"][0], payload["attempts"][1]
+        for field in self.NEW_FIELDS:
+            self.assertNotIn(field, old)
+        self.assertEqual(new["tool_calls"], 20)
+        self.assertEqual(new["output_bytes"], 248_000)
+        self.assertEqual(new["base_sha"], "c" * 40)
+        self.assertIs(new["head_sha_observed"], True)
+
+
 class TestFindingsDigestConvergenceTerminal(unittest.TestCase):
     """fn-159.2: bounded receipt digests drive a fail-inert early terminal."""
 

--- a/plugins/flow-next/tests/test_review_convergence_cap.py
+++ b/plugins/flow-next/tests/test_review_convergence_cap.py
@@ -2632,6 +2632,16 @@ class TestCodexToolCallCount(unittest.TestCase):
         for output in ("", "<verdict>SHIP</verdict>\nplain resumed stdout"):
             self.assertIsNone(flowctl.count_codex_tool_calls(output))
 
+    def test_non_codex_backend_never_measures_even_stream_shaped_text(self) -> None:
+        """PR #324 bot finding: the counter is content-sniffing, so a
+        copilot/cursor review whose plain text QUOTES codex event lines must
+        not get a fabricated measurement. Only the codex backend is gated in."""
+        stream_shaped = self._stream({"type": "command_execution", "command": "ls"})
+        for backend in ("copilot", "cursor", "rp", "host"):
+            self.assertIsNone(flowctl.measured_tool_calls(backend, stream_shaped))
+        self.assertEqual(flowctl.measured_tool_calls("codex", stream_shaped), 1)
+        self.assertIsNone(flowctl.measured_tool_calls("codex", "plain text"))
+
 
 class TestAttemptsReadSurface(unittest.TestCase):
     """fn-183 R4 (#312): `review-rounds attempts --json` is the audit surface.

--- a/plugins/flow-next/tests/test_review_convergence_cap.py
+++ b/plugins/flow-next/tests/test_review_convergence_cap.py
@@ -1480,6 +1480,30 @@ class TestReviewRoundsCLI(unittest.TestCase):
         self.assertEqual(payload["refunded_attempts"], 1)
         self.assertEqual(payload["attempts"][0]["backend"], "rp")
 
+    def test_record_cli_row_is_the_head_sha_fallback_fixture(self):
+        """fn-183 (#312): the rp/host `review-rounds record` path has no
+        pre-dispatch snapshot, so its row must mark head_sha as UNOBSERVED,
+        carry no base_sha and no tool_calls, and still record output bytes."""
+        self._run(
+            "review-rounds", "increment", self.spec_id, "--kind", "plan", "--json"
+        )
+        output_path = self.root / "review.txt"
+        output_path.write_text("<verdict>NEEDS_WORK</verdict>", encoding="utf-8")
+        code, _, _ = self._run(
+            "review-rounds", "record", self.spec_id,
+            "--kind", "plan", "--review-type", "plan",
+            "--backend", "rp", "--output-file", str(output_path), "--json",
+        )
+        self.assertEqual(code, 0)
+        row = self._spec_json()["review_attempts"][-1]
+        self.assertIs(row["head_sha_observed"], False)
+        self.assertNotIn("base_sha", row)
+        self.assertNotIn("tool_calls", row)
+        self.assertEqual(
+            row["output_bytes"],
+            len(output_path.read_text(encoding="utf-8").encode("utf-8")),
+        )
+
     def test_record_real_verdict_does_not_refund(self):
         self._run(
             "review-rounds", "increment", self.spec_id, "--kind", "plan", "--json"
@@ -2440,6 +2464,173 @@ class TestReviewedHeadShaBinding(TestCombinedFinalizeWrite):
         self.assertEqual(
             self._spec_data()["review_attempts"][-1]["head_sha"], "a" * 40
         )
+
+
+class TestAttemptRowWorkVolumeAndProvenance(TestCombinedFinalizeWrite):
+    """fn-183 (#312): a row must say how the verdict was produced.
+
+    Work volume (output bytes, and a tool-call count only where one was
+    genuinely measured), head_sha provenance (observed snapshot vs
+    finalize-time fallback), and base_sha beside head_sha. Absence is
+    UNKNOWN on every new field - never coerced to zero.
+    """
+
+    def _row(self) -> dict:
+        return self._spec_data()["review_attempts"][-1]
+
+    def test_output_bytes_recorded_on_every_row(self) -> None:
+        output = "<verdict>SHIP</verdict> éé"  # multibyte: bytes != chars
+        self._reserve()
+        flowctl.record_review_attempt(
+            self.spec_id, "plan", backend="codex", output=output, verdict="SHIP",
+        )
+        row = self._row()
+        self.assertEqual(row["output_bytes"], len(output.encode("utf-8")))
+        self.assertGreater(row["output_bytes"], len(output))
+        # The output itself is never retained - only its size and its hash.
+        self.assertNotIn("output", row)
+
+    def test_output_bytes_recorded_on_refunded_transport_row(self) -> None:
+        self._reserve()
+        flowctl.record_review_attempt(
+            self.spec_id, "plan", backend="rp", output="",
+            failure_class="empty_output",
+        )
+        row = self._row()
+        self.assertEqual(row["outcome"], "transport_failure")
+        self.assertEqual(row["output_bytes"], 0)
+
+    def test_tool_calls_absent_unless_supplied(self) -> None:
+        self._reserve()
+        flowctl.record_review_attempt(
+            self.spec_id, "plan", backend="rp",
+            output="<verdict>NEEDS_WORK</verdict>", verdict="NEEDS_WORK",
+        )
+        self.assertNotIn("tool_calls", self._row())
+
+    def test_tool_calls_recorded_when_measured_including_zero(self) -> None:
+        """A measured 0 is the whole point (#312): it is recorded, not dropped."""
+        self._reserve()
+        flowctl.record_review_attempt(
+            self.spec_id, "plan", backend="codex",
+            output="<verdict>SHIP</verdict>", verdict="SHIP", tool_calls=0,
+        )
+        self.assertEqual(self._row()["tool_calls"], 0)
+        self._reserve()
+        flowctl.record_review_attempt(
+            self.spec_id, "plan", backend="codex",
+            output="<verdict>NEEDS_WORK</verdict>", verdict="NEEDS_WORK",
+            tool_calls=22,
+        )
+        self.assertEqual(self._row()["tool_calls"], 22)
+
+    def test_head_sha_observed_marks_snapshot_vs_fallback(self) -> None:
+        self._reserve()
+        flowctl.record_review_attempt(
+            self.spec_id, "plan", backend="codex",
+            output="<verdict>SHIP</verdict>", verdict="SHIP",
+            reviewed_head_sha="a" * 40,
+        )
+        observed = self._row()
+        self.assertEqual(observed["head_sha"], "a" * 40)
+        self.assertIs(observed["head_sha_observed"], True)
+
+        self._reserve()
+        with mock.patch.object(flowctl, "_review_head_sha", return_value="b" * 40):
+            flowctl.record_review_attempt(
+                self.spec_id, "plan", backend="rp",
+                output="<verdict>NEEDS_WORK</verdict>", verdict="NEEDS_WORK",
+            )
+        fallback = self._row()
+        self.assertEqual(fallback["head_sha"], "b" * 40)
+        self.assertIs(fallback["head_sha_observed"], False)
+
+    def test_base_sha_present_only_when_snapshot_supplied_it(self) -> None:
+        self._reserve()
+        flowctl.record_review_attempt(
+            self.spec_id, "plan", backend="codex",
+            output="<verdict>SHIP</verdict>", verdict="SHIP",
+            reviewed_head_sha="a" * 40, reviewed_base_sha="c" * 40,
+        )
+        self.assertEqual(self._row()["base_sha"], "c" * 40)
+
+        self._reserve()
+        flowctl.record_review_attempt(
+            self.spec_id, "plan", backend="rp",
+            output="<verdict>NEEDS_WORK</verdict>", verdict="NEEDS_WORK",
+        )
+        self.assertNotIn("base_sha", self._row())
+
+    def test_pre_fn183_rows_read_back_without_crash(self) -> None:
+        """Old rows carry none of the new fields; nothing may crash or read 0."""
+        spec_path = self.root / ".flow" / "specs" / f"{self.spec_id}.json"
+        data = json.loads(spec_path.read_text())
+        legacy = {
+            "timestamp": flowctl.now_iso(),
+            "scope": flowctl._review_attempt_scope("plan", None, "plan"),
+            "backend": "codex",
+            "kind": "plan",
+            "counter_kind": "plan",
+            "task": None,
+            "outcome": "verdict",
+            "verdict": "SHIP",
+            "output_sha256": "0" * 64,
+            "round_consumed": True,
+            "head_sha": "d" * 40,
+        }
+        data["review_attempts"] = [legacy]
+        spec_path.write_text(json.dumps(data))
+
+        self._reserve()
+        flowctl.record_review_attempt(
+            self.spec_id, "plan", backend="codex",
+            output="<verdict>NEEDS_WORK</verdict>", verdict="NEEDS_WORK",
+            reviewed_head_sha="a" * 40, reviewed_base_sha="c" * 40, tool_calls=7,
+        )
+        summary = flowctl._review_attempt_summary(
+            self._spec_data(), "plan", None, review_type="plan"
+        )
+        old, new = summary["attempts"][0], summary["attempts"][-1]
+        self.assertEqual(summary["verdict_attempts"], 2)
+        for field in ("output_bytes", "tool_calls", "base_sha", "head_sha_observed"):
+            self.assertNotIn(field, old)
+        self.assertEqual(new["tool_calls"], 7)
+        self.assertEqual(new["base_sha"], "c" * 40)
+
+
+class TestCodexToolCallCount(unittest.TestCase):
+    """fn-183 (#312): tool calls are counted from the real codex event stream
+    and are None - never 0 - when no stream was returned."""
+
+    def _stream(self, *items: dict) -> str:
+        lines = ['{"type":"thread.started","thread_id":"t1"}']
+        lines += [
+            json.dumps({"type": "item.completed", "item": item}) for item in items
+        ]
+        return "\n".join(lines) + "\n"
+
+    def test_counts_work_items_and_ignores_talk_and_thought(self) -> None:
+        output = self._stream(
+            {"type": "command_execution", "command": "rg foo"},
+            {"type": "reasoning", "text": "thinking"},
+            {"type": "mcp_tool_call", "server": "x"},
+            {"type": "agent_message", "text": "<verdict>SHIP</verdict>"},
+            {"type": "file_change", "path": "a.py"},
+        )
+        self.assertEqual(flowctl.count_codex_tool_calls(output), 3)
+
+    def test_stream_with_no_tool_items_counts_zero(self) -> None:
+        output = self._stream({"type": "agent_message", "text": "SHIP"})
+        self.assertEqual(flowctl.count_codex_tool_calls(output), 0)
+
+    def test_unknown_item_type_counts_as_work(self) -> None:
+        """A future item type must not silently under-report work."""
+        output = self._stream({"type": "web_search_2", "query": "x"})
+        self.assertEqual(flowctl.count_codex_tool_calls(output), 1)
+
+    def test_plain_text_and_empty_output_are_unknown(self) -> None:
+        for output in ("", "<verdict>SHIP</verdict>\nplain resumed stdout"):
+            self.assertIsNone(flowctl.count_codex_tool_calls(output))
 
 
 class TestFindingsDigestConvergenceTerminal(unittest.TestCase):

--- a/plugins/flow-next/tests/test_review_convergence_journal.py
+++ b/plugins/flow-next/tests/test_review_convergence_journal.py
@@ -262,6 +262,53 @@ class TestFinalizationJournalReplay(_JournalReplayBase):
         row = self._data()["review_attempts"][-1]
         self.assertEqual(row["finalized"]["receipt"], "pending")
 
+    def test_crash_replay_preserves_provenance_fields(self):
+        """fn-183 (#312), PR #324 bot finding: a crash between the journal
+        write and the sidecar row write must not degrade the recovered row's
+        provenance - the journal carries reviewed_head_sha / reviewed_base_sha
+        / tool_calls and the replay forwards them, so the recovered row keeps
+        the observed snapshot and measured count instead of falling back to
+        replay-time HEAD and unknown."""
+        reservation_id = self._reserve()
+        target = self.root / "receipt.json"
+        real_write = flowctl.atomic_write_json
+
+        def crash_before_sidecar(path, data):
+            if str(path).endswith(f"{self.spec_id}.json"):
+                raise RuntimeError("crash before sidecar write")
+            return real_write(path, data)
+
+        with mock.patch.object(
+            flowctl, "atomic_write_json", side_effect=crash_before_sidecar
+        ):
+            with self.assertRaises(RuntimeError):
+                flowctl.record_review_attempt(
+                    self.spec_id, "plan", backend="codex",
+                    output="<verdict>NEEDS_WORK</verdict>", verdict="NEEDS_WORK",
+                    review_type="plan", reservation_id=reservation_id,
+                    receipt_target=str(target),
+                    receipt_payload=self._payload(),
+                    reviewed_head_sha="a" * 40,
+                    reviewed_base_sha="c" * 40,
+                    tool_calls=22,
+                )
+        # Crash boundary is real: journal persisted, row never landed.
+        journal = json.loads(self._journal_path(reservation_id).read_text())
+        self.assertEqual(journal["reviewed_head_sha"], "a" * 40)
+        self.assertEqual(journal["reviewed_base_sha"], "c" * 40)
+        self.assertEqual(journal["tool_calls"], 22)
+        self.assertEqual(self._data().get("review_attempts", []), [])
+
+        result = flowctl.enforce_and_increment_review_cap(
+            self.spec_id, "plan", return_reservation=True
+        )
+        self.assertTrue(result.get("replayed"))
+        row = self._data()["review_attempts"][-1]
+        self.assertEqual(row["head_sha"], "a" * 40)
+        self.assertIs(row["head_sha_observed"], True)
+        self.assertEqual(row["base_sha"], "c" * 40)
+        self.assertEqual(row["tool_calls"], 22)
+
     def test_gate_replays_receipt_typed_result_zero_dispatch(self):
         reservation_id = self._reserve()
         target = self.root / "receipt.json"


### PR DESCRIPTION
# Review attempt provenance: work volume, head_sha origin, base_sha

A review-attempt row recorded what was reviewed but not how the verdict was produced. This PR adds the three fields that make a verdict identifiable and credible - all known to the dispatcher at row-write time.

> **Spec:** [fn-183-review-attempt-provenance-work-volume](https://github.com/gmickel/flow-next/blob/d417e3581a97ae46de4127ed263006d6a8826f6a/.flow/specs/fn-183-review-attempt-provenance-work-volume.md)
> **Branch:** `fn-183-review-provenance` → `origin/main`
> **Tasks:** 3 completed
> **R-ID coverage:** 5/5 satisfied

## TL;DR

- Every new `review_attempts[]` row records how much output the verdict cost (`output_bytes`) - the fabrication signature from #312 (a ~1 KB "measured" SHIP with zero tool calls) becomes visible on the ledger.
- `tool_calls` is recorded only where the codex `exec --json` event stream let the dispatcher genuinely count them; a measured `0` is recorded (that is the signal), plain-text paths carry no key at all.
- `head_sha_observed` marks whether `head_sha` came from the pre-dispatch snapshot or the finalize-time fallback; `base_sha` lands beside it wherever the review snapshot ran, so the judged diff can be located and re-rendered.
- `review-rounds attempts --json` surfaces all of it; rows written by older versions read back with the fields absent - absence means unknown, never zero.
- Architecture notes document what each field answers, and that `session_id` is explicitly NOT a work-evidence signal (a resumed session reuses its thread id).

## Not in this PR (by design)

- No change to verdict validity, re-review policy, or the unchanged-artifact guard.
- No retention of review outputs; the byte count is recorded, the output is not.
- No new commands.
- Version bump deferred to the batched release.

## The change, top to bottom

Review-attempt ledger rows now say how a verdict was produced: output_bytes on every row, tool_calls where the codex event stream let the dispatcher measure them, a head_sha_observed marker separating pre-dispatch snapshots from the finalize-time fallback, and base_sha beside head_sha wherever the review snapshot ran - so a consumer can ask &#x27;was this verdict measured?&#x27; instead of trusting narration (issue #312).

| Proof | Value | Sources |
|---|---|---|
| Artifact | `fn-183-aid-d417e358` | artifact identity |
| Base commit | `1dc35f78c9c29f9cafee1a526ef39ddd9c642669` | artifact currentness |
| Head commit | `d417e3581a97ae46de4127ed263006d6a8826f6a` | artifact identity |
| Human-review lines | 494 | deterministic file stats |
| Canonical files | 5 | deterministic membership |
| Total files | 11 | deterministic membership |
| Full gate | 4340 tests, 0 failures; ruff clean; sync-codex idempotent | source:s-t3 |
| New coverage | 17 focused tests: write path, tool-call counter, CLI read surface, legacy rows | source:s-t1, source:s-t2 |
| R-ID coverage | 5/5 satisfied across three tasks | source:s-c1, source:s-c2, source:s-c3 |

**Legend:** `WHY` `PRINCIPLE` `STEP` `KEPT` `VERIFY` · `NEW` `MODIFIED` `DELETED` `RENAMED` `COPIED` · `CANONICAL` `GENERATED` `MECHANICAL`

<details>
<summary><code>WHY</code> 0. A fabricated verdict reads like a real one — A resumed reviewer session can return VERDICT=SHIP in ~1.1-1.6 KB with zero tool calls, asserting true facts from the previous round&#x27;s context while claiming fresh measurement. Verdict text cannot expose this; only work volume can. The attempt row recorded what was reviewed but not how the verdict was produced.</summary>

Evidence: source:s-spec

</details>

<details open>
<summary><code>STEP</code> 1. Write path: four provenance fields on every new attempt row — record_review_attempt gains output_bytes (computed from the output it already receives; text never retained), an optional tool_calls plumbed only from the codex exec --json event-stream sites (a new counter returns None, never 0, for plain text; unknown item types count as work), head_sha_observed as an explicit true/false marker (marker over omission so a fallback row stays distinguishable from a pre-fn-183 row), and base_sha forwarded from the existing _capture_review_snapshot unpacks - absent, not guessed, elsewhere.</summary>

Evidence: source:s-t1, source:s-c1, source:s-r1, source:s-r2, source:s-r3, R-ID:R1, R-ID:R2, R-ID:R3, task:fn-183-review-attempt-provenance-work-volume.1

| Change | Attention | File | Purpose | +/- | Diff | Evidence |
|---|---|---|---|---:|---|---|
| `MODIFIED` | `CANONICAL` | `plugins/flow-next/scripts/flowctl.py` | count_codex_tool_calls plus the four new row fields in _record_review_attempt_locked; reviewed_base_sha/tool_calls kwargs plumbed through the dispatcher call sites. | +89/-0 | — | source:s-diff |

<details>
<summary>Generated/mechanical files (3)</summary>

| Change | Attention | File | Purpose | +/- | Diff | Evidence |
|---|---|---|---|---:|---|---|
| `MODIFIED` | `GENERATED` | `.flow/bin/flowctl.py` | Byte-identical dual copy of flowctl.py, parity-tested. | +89/-0 | — | source:s-diff |
| `MODIFIED` | `GENERATED` | `plugins/flow-next/scripts/flowctl_tracker/MANIFEST.json` | Regenerated by gen_tracker_manifest.py. | +1/-1 | — | source:s-diff |
| `MODIFIED` | `GENERATED` | `.flow/bin/flowctl_tracker/MANIFEST.json` | Regenerated by gen_tracker_manifest.py. | +1/-1 | — | source:s-diff |

</details>

</details>

<details>
<summary><code>STEP</code> 2. Read surface verified and pinned against projection — review-rounds attempts --json already returned whole unprojected rows, so R4 held by construction; new CLI-level tests pin it so a future payload refactor cannot silently drop the fields. Coverage includes the review-rounds record fallback fixture, a measured tool_calls of 0 surviving the read, and pre-fn-183 rows returning with the fields absent - unknown, never zero - at exit 0.</summary>

Evidence: source:s-t1, source:s-t2, source:s-c1, source:s-c2, source:s-r1, source:s-r2, source:s-r3, source:s-r4, R-ID:R1, R-ID:R2, R-ID:R3, R-ID:R4, task:fn-183-review-attempt-provenance-work-volume.1, task:fn-183-review-attempt-provenance-work-volume.2

| Change | Attention | File | Purpose | +/- | Diff | Evidence |
|---|---|---|---|---:|---|---|
| `MODIFIED` | `CANONICAL` | `plugins/flow-next/tests/test_review_convergence_cap.py` | 17 new tests across three classes: attempt-row write path incl. legacy-row tolerance, codex tool-call counter, and the end-to-end attempts --json read surface. | +350/-0 | — | source:s-diff |

</details>

<details>
<summary><code>STEP</code> 3. Schema notes, CLI docs, CHANGELOG — Architecture notes state what each field answers and that absence means unknown, and document session_id as explicitly NOT a work-evidence signal (a resumed session reuses its thread id across a fabricated round and a real one). flowctl.md points the attempts surface at those notes; CHANGELOG Unreleased credits the reporter.</summary>

Evidence: source:s-t3, source:s-c3, source:s-r5, R-ID:R5, task:fn-183-review-attempt-provenance-work-volume.3

| Change | Attention | File | Purpose | +/- | Diff | Evidence |
|---|---|---|---|---:|---|---|
| `MODIFIED` | `CANONICAL` | `plugins/flow-next/docs/architecture.md` | Per-field provenance semantics under Review bookkeeping. | +25/-0 | — | source:s-diff |
| `MODIFIED` | `CANONICAL` | `plugins/flow-next/docs/flowctl.md` | attempts --json field note linking to architecture.md. | +5/-1 | — | source:s-diff |
| `MODIFIED` | `CANONICAL` | `CHANGELOG.md` | Unreleased entry for #312. | +24/-0 | — | source:s-diff |

</details>

<details>
<summary><code>VERIFY</code> 4. Gate and task evidence — Full parallel suite 4340 tests with 0 failures, ruff 0.16.0 clean, sync-codex run twice with no drift; per-task focused suites recorded as task evidence in the flow task-state files.</summary>

Evidence: source:s-t1, source:s-t2, source:s-t3, task:fn-183-review-attempt-provenance-work-volume.1, task:fn-183-review-attempt-provenance-work-volume.2, task:fn-183-review-attempt-provenance-work-volume.3

<details>
<summary>Generated/mechanical files (3)</summary>

| Change | Attention | File | Purpose | +/- | Diff | Evidence |
|---|---|---|---|---:|---|---|
| `MODIFIED` | `MECHANICAL` | `.flow/tasks/fn-183-review-attempt-provenance-work-volume.1.md` | Task-state: done summary and evidence. | +4/-5 | — | source:s-diff |
| `MODIFIED` | `MECHANICAL` | `.flow/tasks/fn-183-review-attempt-provenance-work-volume.2.md` | Task-state: done summary and evidence. | +4/-5 | — | source:s-diff |
| `MODIFIED` | `MECHANICAL` | `.flow/tasks/fn-183-review-attempt-provenance-work-volume.3.md` | Task-state: done summary and evidence. | +4/-5 | — | source:s-diff |

</details>

</details>

## Critical changes

- **High-churn:** [`plugins/flow-next/tests/test_review_convergence_cap.py`](https://github.com/gmickel/flow-next/commit/0f1a016e5a4f1f7f5b6f836495b896ae8207950e#diff-5eff4a0f3e63224ae9dc4b4f552c511a9c24224afefcdc1b652138677703e282) (+350/-0 lines)
- **High-churn:** [`plugins/flow-next/scripts/flowctl.py`](https://github.com/gmickel/flow-next/commit/07cb1f726c18a279887d41cb30e56cf0688e8ce0#diff-a52f4f2101d1a9031615badb0a45084834516bcb0b6ec993a50076403226568d) (+89/-0 lines)
- **High-churn:** `.flow/bin/flowctl.py` (+89/-0 lines) - byte-identical dual copy of the above, parity-tested
- **High-churn:** [`plugins/flow-next/docs/architecture.md`](https://github.com/gmickel/flow-next/commit/17fe7a7b5cc4866b6bda365363f381d4242436c8#diff-73a3c978c4a786a72e11b7f1ee5487dda4874c87c05159884acc390159229f98) (+25/-0 lines)
- **High-churn:** `CHANGELOG.md` (+24/-0 lines)

## How to review this PR

The pipeline already verified this - you don't re-check it from scratch:
- **Tests / gates:** full parallel suite 4340 tests, 0 failures; `uvx ruff@0.16.0` clean; sync-codex run twice with no drift. Focused evidence per task: fn-183.1 - 314 tests across 4 suites; fn-183.2 - 182 tests incl. a mutation-verified anti-projection guard.
- **R-ID coverage:** 5/5 acceptance criteria satisfied.
- **Cross-model review:** no cross-model review recorded on this PR (a codex review is planned before merge).

Your job - the calls the pipeline can't make:
- Line-review the **Must review** bucket below - the one canonical code file carries the whole judgment risk.
- Spot-check the verified claims above; sample, don't re-run everything.
- Own what machines can't judge: is "absence means unknown, never zero" honored everywhere a consumer might coerce?

## Review plan

### Must review (~15%)

- [ ] 🔴 [`plugins/flow-next/scripts/flowctl.py`](https://github.com/gmickel/flow-next/commit/07cb1f726c18a279887d41cb30e56cf0688e8ce0#diff-a52f4f2101d1a9031615badb0a45084834516bcb0b6ec993a50076403226568d) - high churn on the durable audit ledger's single write path - Does `count_codex_tool_calls` ever return 0 for non-stream text, and do the new row fields stay absent (not zero/null) on paths without a snapshot or a measured count? - open `count_codex_tool_calls` and `_record_review_attempt_locked`

### Spot-check

- [ ] 🟡 [`plugins/flow-next/tests/test_review_convergence_cap.py`](https://github.com/gmickel/flow-next/commit/0f1a016e5a4f1f7f5b6f836495b896ae8207950e#diff-5eff4a0f3e63224ae9dc4b4f552c511a9c24224afefcdc1b652138677703e282) - 17 new tests; read the shape, sample the legacy-row and measured-zero cases
- [ ] 🟡 [`plugins/flow-next/docs/architecture.md`](https://github.com/gmickel/flow-next/commit/17fe7a7b5cc4866b6bda365363f381d4242436c8#diff-73a3c978c4a786a72e11b7f1ee5487dda4874c87c05159884acc390159229f98) - do the documented field semantics match the code?
- [ ] 🟡 `plugins/flow-next/docs/flowctl.md` + `CHANGELOG.md` - user-facing wording

### Safe to skim (~55%)

- [ ] ⚪ `.flow/bin/flowctl.py` - byte-identical dual copy, parity-tested - skim
- [ ] ⚪ 2 `flowctl_tracker/MANIFEST.json` files - regenerated by `gen_tracker_manifest.py` - skim
- [ ] ⚪ 3 `.flow/tasks/fn-183-*.md` files - task-state, not hand-written code - skim

---

*Generated by `/flow-next:make-pr` from [fn-183-review-attempt-provenance-work-volume](https://github.com/gmickel/flow-next/blob/d417e3581a97ae46de4127ed263006d6a8826f6a/.flow/specs/fn-183-review-attempt-provenance-work-volume.md) against `origin/main` on 2026-08-10.*
<!-- flow-next:make-pr spec=fn-183-review-attempt-provenance-work-volume base=origin/main -->
