### PR TITLE
Issue batch: R-ID parser straggler, criteria drops, setup detection, resolve --select, reclaim

### DIFF
--- a/.flow/bin/flowctl.py
+++ b/.flow/bin/flowctl.py
@@ -27876,7 +27876,13 @@ PR_COGNITIVE_AID_ATTENTION_CLASSES = frozenset(
 )
 _PR_COGNITIVE_AID_SHA_RE = re.compile(r"^[0-9a-f]{40,64}$")
 _PR_COGNITIVE_AID_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,159}$")
-_PR_COGNITIVE_AID_RID_RE = re.compile(r"^R[1-9][0-9]*$")
+# Canonical R-ID grammar, in lockstep with the spec parser
+# (`_export_parse_acceptance_criteria`) and the review-output extractor
+# (`parse_unaddressed_rids`): a single-letter suffix (`R4a`, `R4b`) is the
+# sub-scoped sibling form the spec template emits. Multi-letter suffixes
+# (`R4ab`) and separators (`R-4`) stay rejected. Both call sites (the
+# `sources[].ref` kind==rid check and the `rIds[]` check) use this constant.
+_PR_COGNITIVE_AID_RID_RE = re.compile(r"^R[1-9][0-9]*[a-z]?$")
 _PR_COGNITIVE_AID_WINDOWS_RESERVED = frozenset(
     {
         "CON",
@@ -31462,21 +31468,78 @@ def _export_resolve_merge_base(base_ref: str) -> Optional[str]:
     return sha if sha else None
 
 
-def _export_parse_acceptance_criteria(spec_text: str) -> list[dict[str, Any]]:
-    """Extract R-ID acceptance criteria from an epic spec.
+# A criterion bullet starts at column 0 with `-`/`*` (indented bullets are
+# sub-bullets of a criterion, never criteria themselves).
+_AC_BULLET_START_RE = re.compile(r"^[-*]\s+")
+# Token anchor: the R-ID must open the bold run, and the character after it
+# must be a boundary - so `R4ab` (multi-letter suffix) and `R-4` (separator)
+# stay rejected, while `R4a` is the canonical sub-scoped sibling form.
+_AC_TOKEN_RE = re.compile(r"^[-*]\s+\*\*\s*(R\d+[a-z]?)(?![0-9A-Za-z])")
+# Residue probe: a bullet that *looks* like a criterion (`- **R…`) - anything
+# matching this but not parsing is counted, never silently dropped. The digit
+# is required so an ordinary bold word starting with R (`- **Renumber-…**`)
+# is not mistaken for a dropped criterion; a separator before it keeps the
+# deliberately-rejected spellings (`R-4`) visible rather than silent.
+_AC_RESIDUE_RE = re.compile(r"^[-*]\s+\*\*\s*R[-_ ]?\d")
+# One leading separator between the R-ID (or its bold close) and the text.
+_AC_LEAD_SEP_RE = re.compile(r"^\s*[:\-–—]\s*")
+_AC_TAG_RE = re.compile(r"\[([^\]]+)\]\s*$")
+
+
+def _export_parse_acceptance_criterion(bullet: str) -> Optional[dict[str, Any]]:
+    """Parse one already-joined criterion bullet, or None if it does not parse.
+
+    Anchors on the R-ID token and stops at the first `**` or `:` boundary, so
+    bold runs that continue past the token still yield the criterion:
+
+        - **R1:** canonical form.
+        - **R14 - the pause protocol survives a restart** and its body.
+        - **R15 (a parenthetical):** body text.
+    """
+    m = _AC_TOKEN_RE.match(bullet)
+    if not m:
+        return None
+    rest = bullet[m.end() :]
+    close = rest.find("**")
+    if close < 0:
+        # Unterminated bold run - not a criterion we can read.
+        return None
+    head = rest[:close].rstrip()
+    tail = rest[close + 2 :].strip()
+    text_raw = (head + " " + tail).strip() if head and tail else (head or tail)
+    text_raw = _AC_LEAD_SEP_RE.sub("", text_raw, count=1).strip()
+    if not text_raw:
+        return None
+    tag = ""
+    tm = _AC_TAG_RE.search(text_raw)
+    if tm:
+        tag = tm.group(1).strip()
+        # Trim the trailing tag from text.
+        text_raw = text_raw[: tm.start()].rstrip()
+    return {"id": m.group(1), "text": text_raw, "tag": tag}
+
+
+def _export_scan_acceptance_criteria(
+    spec_text: str,
+) -> tuple[list[dict[str, Any]], int]:
+    """Return `(criteria, residue)` for an epic spec's acceptance section.
 
     Canonical heading is `## Acceptance Criteria` (since 1.1.4). For
     back-compat, also tolerates `## Acceptance criteria` (older lowercase
-    form) and bare `## Acceptance` (plan template pre-1.1.4). Parses bullets
-    matching `- **R<N>:** <text>`. Source-tag suffixes like `[user]` /
-    `[paraphrase]` / `[inferred]` / `[strategy:track]` are extracted into
-    the `tag` field (last `[...]` token in the bullet).
+    form) and bare `## Acceptance` (plan template pre-1.1.4).
 
-    Returns list of `{"id": "R1", "text": "...", "tag": "..."}`. Empty list
-    if no acceptance section or no R-IDs.
+    A criterion bullet runs until the next bullet or a blank line, so text
+    wrapped across lines keeps its continuation (joined with single spaces).
+    Source-tag suffixes like `[user]` / `[paraphrase]` / `[inferred]` /
+    `[strategy:track]` are extracted into the `tag` field (last `[...]`
+    token in the bullet).
+
+    `residue` counts bullets shaped like criteria (`- **R…`) that did not
+    parse - a non-zero residue is a visible discrepancy instead of a silent
+    drop. It never aborts anything.
     """
     if not spec_text:
-        return []
+        return [], 0
 
     # Find the section heading. Tolerate canonical + 2 legacy forms.
     heading_re = re.compile(
@@ -31485,7 +31548,7 @@ def _export_parse_acceptance_criteria(spec_text: str) -> list[dict[str, Any]]:
     )
     m = heading_re.search(spec_text)
     if not m:
-        return []
+        return [], 0
     body_start = m.end()
     # Section ends at the next H2 or end-of-file.
     next_h2 = re.search(r"^##\s+", spec_text[body_start:], re.MULTILINE)
@@ -31495,30 +31558,49 @@ def _export_parse_acceptance_criteria(spec_text: str) -> list[dict[str, Any]]:
         body_end = len(spec_text)
     body = spec_text[body_start:body_end]
 
-    # Bullet pattern: `- **R<N>:** <text>` or `- **R<N><a-z>:** <text>`.
-    # Tolerate optional whitespace between the bullet marker and the bold token.
-    # The single-letter suffix form (`R4a`, `R4b`) lets capture-driven specs
-    # sub-scope criteria sharing a logical parent; siblings sort lexically
-    # (`R4` < `R4a` < `R4b` < `R5`) via Python's default string ordering.
-    # Multi-letter suffixes (`R4ab`) and separators (`R-4`) remain rejected
-    # by design — broader format support waits for a real need.
-    bullet_re = re.compile(
-        r"^[-*]\s+\*\*(R\d+[a-z]?)\:?\*\*\s*:?\s*(.+?)$",
-        re.MULTILINE,
-    )
-    tag_re = re.compile(r"\[([^\]]+)\]\s*$")
     entries: list[dict[str, Any]] = []
-    for bm in bullet_re.finditer(body):
-        rid = bm.group(1)
-        text_raw = bm.group(2).strip()
-        tag = ""
-        tm = tag_re.search(text_raw)
-        if tm:
-            tag = tm.group(1).strip()
-            # Trim the trailing tag from text.
-            text_raw = text_raw[: tm.start()].rstrip()
-        entries.append({"id": rid, "text": text_raw, "tag": tag})
-    return entries
+    residue = 0
+
+    def flush(lines: list[str]) -> None:
+        nonlocal residue
+        if not lines:
+            return
+        joined = " ".join(
+            [lines[0].rstrip()] + [ln.strip() for ln in lines[1:]]
+        )
+        entry = _export_parse_acceptance_criterion(joined)
+        if entry is None:
+            if _AC_RESIDUE_RE.match(lines[0]):
+                residue += 1
+            return
+        entries.append(entry)
+
+    current: list[str] = []
+    for line in body.splitlines():
+        if _AC_BULLET_START_RE.match(line):
+            flush(current)
+            current = [line]
+        elif not line.strip():
+            flush(current)
+            current = []
+        elif current and line.lstrip().startswith(("- ", "* ", "+ ")):
+            # An indented sub-bullet ends the criterion's own text.
+            flush(current)
+            current = []
+        elif current:
+            current.append(line)
+    flush(current)
+    return entries, residue
+
+
+def _export_parse_acceptance_criteria(spec_text: str) -> list[dict[str, Any]]:
+    """Extract R-ID acceptance criteria from an epic spec.
+
+    Returns list of `{"id": "R1", "text": "...", "tag": "..."}`. Empty list
+    if no acceptance section or no R-IDs. See `_export_scan_acceptance_criteria`
+    for the shapes recognized and for the residue count.
+    """
+    return _export_scan_acceptance_criteria(spec_text)[0]
 
 
 def _export_parse_spec_section(spec_text: str, heading_re: re.Pattern) -> str:
@@ -32824,7 +32906,10 @@ def cmd_spec_export_cognitive_aid(args: argparse.Namespace) -> None:
         except OSError:
             spec_text = ""
 
-    acceptance_criteria = _export_parse_acceptance_criteria(spec_text)
+    (
+        acceptance_criteria,
+        acceptance_criteria_residue,
+    ) = _export_scan_acceptance_criteria(spec_text)
     goal_and_context = _export_parse_spec_section(
         spec_text,
         re.compile(r"^##\s+Goal\s+&?\s*[Cc]ontext\s*$", re.MULTILINE),
@@ -32886,6 +32971,11 @@ def cmd_spec_export_cognitive_aid(args: argparse.Namespace) -> None:
             "goal_and_context": goal_and_context,
             "architecture_overview": architecture_overview,
             "acceptance_criteria": acceptance_criteria,
+            # Bullets shaped like criteria (`- **R…`) that did not parse.
+            # Non-zero means the spec authored a shape this parser cannot
+            # read: the coverage denominator is short by that many. Never
+            # aborts the export.
+            "acceptance_criteria_residue": acceptance_criteria_residue,
             "boundaries": boundaries,
             "decision_context": decision_context,
             "open_questions": open_questions,
@@ -33038,9 +33128,14 @@ def cmd_spec_export_cognitive_aid(args: argparse.Namespace) -> None:
     if "spec" in payload:
         print(f"  Title: {spec_section['title']}")
         print(f"  Status: {spec_section['status']}")
+        residue_note = (
+            f", {acceptance_criteria_residue} unparsed"
+            if acceptance_criteria_residue
+            else ""
+        )
         print(
             f"  R-IDs: {len(acceptance_criteria)} "
-            f"({len(uncovered)} uncovered)"
+            f"({len(uncovered)} uncovered{residue_note})"
         )
     if "tasks" in payload:
         print(

--- a/.flow/bin/flowctl.py
+++ b/.flow/bin/flowctl.py
@@ -34431,18 +34431,34 @@ def cmd_start(args: argparse.Namespace) -> None:
                 use_json=args.json,
             )
 
-        # Check if claimed by someone else (unless --force)
-        if not args.force and existing_assignee and existing_assignee != current_actor:
+        # fn-179.4 (#316): --reclaim is a deliberate identity repair. It relaxes
+        # exactly the two identity gates below (claimed-by-other, in_progress
+        # owned by another) and nothing else - dependency, blocked and done
+        # gates stay where they are, and --force keeps its takeover meaning.
+        reclaiming = bool(
+            args.reclaim and existing_assignee and existing_assignee != current_actor
+        )
+
+        # Check if claimed by someone else (unless --force / --reclaim)
+        if (
+            not args.force
+            and not args.reclaim
+            and existing_assignee
+            and existing_assignee != current_actor
+        ):
             error_exit(
                 f"Cannot start task {args.id}: claimed by '{existing_assignee}'. "
-                f"Use --force to override.",
+                f"Use --force to override, or --reclaim to repair the claimant.",
                 use_json=args.json,
             )
 
         # Validate task is in todo status (unless --force or resuming own task)
         if not args.force and status != "todo":
-            # Allow resuming your own in_progress task
-            if not (status == "in_progress" and existing_assignee == current_actor):
+            # Allow resuming your own in_progress task, or repairing the
+            # claimant of an in_progress task via --reclaim.
+            resuming_own = status == "in_progress" and existing_assignee == current_actor
+            repairing = bool(args.reclaim) and status == "in_progress"
+            if not (resuming_own or repairing):
                 error_exit(
                     f"Cannot start task {args.id}: status is '{status}', expected 'todo'. "
                     f"Use --force to override.",
@@ -34456,6 +34472,17 @@ def cmd_start(args: argparse.Namespace) -> None:
             runtime_updates["claimed_at"] = now_iso()
         if args.note:
             runtime_updates["claim_note"] = args.note
+            if reclaiming:
+                runtime_updates["assignee"] = current_actor
+                runtime_updates["claimed_at"] = now_iso()
+        elif reclaiming:
+            # Identity repair: distinct from the --force takeover note so the
+            # record says which one happened.
+            runtime_updates["assignee"] = current_actor
+            runtime_updates["claimed_at"] = now_iso()
+            runtime_updates["claim_note"] = (
+                f"Reclaimed from {existing_assignee} (identity repair)"
+            )
         elif args.force and existing_assignee and existing_assignee != current_actor:
             # Force override: note the takeover
             runtime_updates["assignee"] = current_actor
@@ -50325,6 +50352,11 @@ def main() -> None:
     p_start.add_argument("id", help="Task ID (e.g., fn-1.2, fn-1-add-auth.2)")
     p_start.add_argument(
         "--force", action="store_true", help="Skip status/dependency/claim checks"
+    )
+    p_start.add_argument(
+        "--reclaim",
+        action="store_true",
+        help="Rewrite the claimant of a task claimed by another identity (identity repair, not a takeover)",
     )
     p_start.add_argument("--note", help="Claim note (e.g., reason for taking over)")
     p_start.add_argument("--json", action="store_true", help="JSON output")

--- a/.flow/bin/flowctl.py
+++ b/.flow/bin/flowctl.py
@@ -34435,14 +34435,17 @@ def cmd_start(args: argparse.Namespace) -> None:
         # exactly the two identity gates below (claimed-by-other, in_progress
         # owned by another) and nothing else - dependency, blocked and done
         # gates stay where they are, and --force keeps its takeover meaning.
+        # getattr: internal callers build a synthetic Namespace without the
+        # CLI-only flag; absence means False, never an AttributeError.
+        reclaim_flag = bool(getattr(args, "reclaim", False))
         reclaiming = bool(
-            args.reclaim and existing_assignee and existing_assignee != current_actor
+            reclaim_flag and existing_assignee and existing_assignee != current_actor
         )
 
         # Check if claimed by someone else (unless --force / --reclaim)
         if (
             not args.force
-            and not args.reclaim
+            and not reclaim_flag
             and existing_assignee
             and existing_assignee != current_actor
         ):
@@ -34457,7 +34460,7 @@ def cmd_start(args: argparse.Namespace) -> None:
             # Allow resuming your own in_progress task, or repairing the
             # claimant of an in_progress task via --reclaim.
             resuming_own = status == "in_progress" and existing_assignee == current_actor
-            repairing = bool(args.reclaim) and status == "in_progress"
+            repairing = reclaim_flag and status == "in_progress"
             if not (resuming_own or repairing):
                 error_exit(
                     f"Cannot start task {args.id}: status is '{status}', expected 'todo'. "

--- a/.flow/bin/flowctl_tracker/MANIFEST.json
+++ b/.flow/bin/flowctl_tracker/MANIFEST.json
@@ -2,7 +2,7 @@
   "files": [
     {
       "path": "flowctl.py",
-      "sha256": "5c198b50ad9449c9bcda90a23481e9b649fcc1bd5405242254428059cc55f2cb"
+      "sha256": "c4e9d2e5d583b103912257cb2542507721ac2cf04f234846e34e7cfaa3a5fb58"
     },
     {
       "path": "flowctl_tracker/__init__.py",

--- a/.flow/bin/flowctl_tracker/MANIFEST.json
+++ b/.flow/bin/flowctl_tracker/MANIFEST.json
@@ -2,7 +2,7 @@
   "files": [
     {
       "path": "flowctl.py",
-      "sha256": "fe20919dc3fed2e5e363700f2951704958ddaec789d6933160a7ba3ea8b23b45"
+      "sha256": "aa41aa9dfbe2bbfec1237c66a2530bffa0d15e7e7abf4f2b71d3bc1b89f11174"
     },
     {
       "path": "flowctl_tracker/__init__.py",

--- a/.flow/bin/flowctl_tracker/MANIFEST.json
+++ b/.flow/bin/flowctl_tracker/MANIFEST.json
@@ -2,7 +2,7 @@
   "files": [
     {
       "path": "flowctl.py",
-      "sha256": "c4e9d2e5d583b103912257cb2542507721ac2cf04f234846e34e7cfaa3a5fb58"
+      "sha256": "fe20919dc3fed2e5e363700f2951704958ddaec789d6933160a7ba3ea8b23b45"
     },
     {
       "path": "flowctl_tracker/__init__.py",

--- a/.flow/bin/flowctl_tracker/MANIFEST.json
+++ b/.flow/bin/flowctl_tracker/MANIFEST.json
@@ -94,11 +94,11 @@
     },
     {
       "path": "flowctl_tracker/providers/jira.py",
-      "sha256": "7c90a22039746df7a94b37c5939cf3ab5611f45dba6462e0e939788516ca82ec"
+      "sha256": "09c635435b44c3ea2473c14f6fe47c061c77105b7f1b64f3e7bd355425a0bcd5"
     },
     {
       "path": "flowctl_tracker/providers/linear.py",
-      "sha256": "f049938c14c41617690c7fb8285cdea281684a83c83ecaae0ccfe89f31cb5331"
+      "sha256": "40a80bf2a3b9701d1eca236be29025ae03beddc2ea3476e1c26f57312b617fcb"
     },
     {
       "path": "flowctl_tracker/question_claim.py",
@@ -122,11 +122,11 @@
     },
     {
       "path": "flowctl_tracker/resolve_verb.py",
-      "sha256": "95ac59474cbc2c125e43a6bcf14137a8b162cb1993a7487d65ece9ffc5f5409c"
+      "sha256": "2e34dd5cbb4981bb8337487f48ba7bc74fe22b259d14512385f7e65e16291ab6"
     },
     {
       "path": "flowctl_tracker/resolved_cache.py",
-      "sha256": "da33f9014e4331c7828c3539c5a46fcb570ff5193af65a559a1b55a040def835"
+      "sha256": "84906600fcfc15b1d691a3379cd6d9623f859473b93e34113ee959777f423354"
     },
     {
       "path": "flowctl_tracker/states.py",

--- a/.flow/bin/flowctl_tracker/providers/jira.py
+++ b/.flow/bin/flowctl_tracker/providers/jira.py
@@ -239,11 +239,12 @@ def _migrated_status_map(config: dict, live: dict) -> tuple[dict, list]:
     return migrated, warnings
 
 
-def resolve_status_ids(config: dict, execute: Callable) -> Union[Assignment, TrackerError]:
-    fetched = fetch_statuses(config, execute)
-    if isinstance(fetched, TrackerError):
-        return fetched
-    pools, live = fetched
+def assign_slots_from_pools(config: dict, pools: dict, live: dict) -> Assignment:
+    """The PURE half of `resolve_status_ids` - no network.
+
+    `--select` reuses it: after merging one human tiebreak it must run the same
+    assignment over the REMAINING slots, against the same pools it already
+    fetched for validation (fn-179.3, #308)."""
     resolved = ((config.get("tracker") or {}).get("resolved") or {})
     existing = (resolved.get("destination") or {}).get("statusIds") or {}
     migrated, warnings = _migrated_status_map(config, live)
@@ -253,6 +254,14 @@ def resolve_status_ids(config: dict, execute: Callable) -> Union[Assignment, Tra
     assignment = assign_slots(pools, live, seed)
     assignment.warnings = warnings + assignment.warnings
     return assignment
+
+
+def resolve_status_ids(config: dict, execute: Callable) -> Union[Assignment, TrackerError]:
+    fetched = fetch_statuses(config, execute)
+    if isinstance(fetched, TrackerError):
+        return fetched
+    pools, live = fetched
+    return assign_slots_from_pools(config, pools, live)
 
 
 def resolve_capabilities(config: dict, execute: Callable) -> dict:

--- a/.flow/bin/flowctl_tracker/providers/linear.py
+++ b/.flow/bin/flowctl_tracker/providers/linear.py
@@ -163,15 +163,24 @@ def fetch_states(config: dict, execute: Callable) -> Union[tuple, TrackerError]:
     return pools, live
 
 
+def assign_slots_from_pools(config: dict, pools: dict, live: dict) -> Assignment:
+    """The PURE half of `resolve_state_ids` - no network.
+
+    `--select` reuses it: after merging one human tiebreak it must run the same
+    assignment over the REMAINING slots, against the same pools it already
+    fetched for validation (fn-179.3, #308)."""
+    existing = (((config.get("tracker") or {}).get("resolved") or {})
+                .get("destination") or {}).get("stateIds") or {}
+    return assign_slots(pools, live, existing if isinstance(existing, dict) else {},
+                        policy="linear")
+
+
 def resolve_state_ids(config: dict, execute: Callable) -> Union[Assignment, TrackerError]:
     fetched = fetch_states(config, execute)
     if isinstance(fetched, TrackerError):
         return fetched
     pools, live = fetched
-    existing = (((config.get("tracker") or {}).get("resolved") or {})
-                .get("destination") or {}).get("stateIds") or {}
-    return assign_slots(pools, live, existing if isinstance(existing, dict) else {},
-                        policy="linear")
+    return assign_slots_from_pools(config, pools, live)
 
 
 def resolve_capabilities(config: dict, execute: Callable) -> dict:

--- a/.flow/bin/flowctl_tracker/resolve_verb.py
+++ b/.flow/bin/flowctl_tracker/resolve_verb.py
@@ -8,7 +8,9 @@ distinct from a consuming verb meeting an absent block - that returns
 `--scope` re-resolves only the named nested path (its own timestamp).
 `--refresh` forces re-resolution of already-fresh scopes.
 `--select slot=id` persists ONE human tiebreak, validated against live
-candidates; repeatable; re-select overwrites.
+candidates; repeatable; re-select overwrites. It then runs the normal
+assignment over the REMAINING slots and persists the union - the tiebreak
+resolves one slot, it does not excuse the others (#308).
 """
 
 from __future__ import annotations
@@ -24,7 +26,7 @@ from .executor import execute as default_execute
 from .providers import resolver_for
 from .resolved_cache import (SCOPES, apply_capability_probe, capabilities_stale,
                              resolve_transaction)
-from .states import Assignment, is_alias, validate_select
+from .states import REQUIRED_SLOTS, Assignment, is_alias, validate_select
 from .types import ErrorClass, TrackerError
 
 #: Scopes each provider resolves, in dependency order (destination first: the
@@ -303,7 +305,7 @@ def _run_select(flow_dir: Path, config: dict, mod, provider: str,
 
     ids_scope = _IDS_SCOPE[provider]
     key = ids_scope.split(".", 1)[1]
-    seen = {}  # pools captured by network_fn for the alias verdict
+    seen = {}  # pools/live captured by network_fn; assignment by finalize_fn
 
     def network_fn(cfg: dict) -> object:
         # Fetch + validate INSIDE the transaction's network step, against the
@@ -317,7 +319,7 @@ def _run_select(flow_dir: Path, config: dict, mod, provider: str,
         error = validate_select(slot, chosen, pools, live)
         if error:
             return TrackerError(ErrorClass.INVALID_INPUT, error, subtype="select")
-        seen["pools"] = pools
+        seen["pools"], seen["live"] = pools, live
         return {slot: chosen}
 
     def finalize_fn(current_cfg: dict, data: dict) -> dict:
@@ -325,19 +327,55 @@ def _run_select(flow_dir: Path, config: dict, mod, provider: str,
         # clobbered by a whole-map replace computed from a stale read.
         existing = _dict(_dict(_dict(_dict(current_cfg.get("tracker"))
                                      .get("resolved")).get("destination")).get(key))
-        return {**existing, **data}
+        merged = {**existing, **data}
+        # The selection is a tiebreak for ONE ambiguous slot, not a reason to
+        # skip the others (#308): run the normal assignment over the remaining
+        # slots and persist the union. `in_review` still never auto-fills - the
+        # policy in states.py owns that, and it stays.
+        assignment = mod.assign_slots_from_pools(
+            _with_ids(current_cfg, key, merged), seen["pools"], seen["live"])
+        seen["assignment"] = assignment
+        return dict(assignment.mapping)
 
-    result = resolve_transaction(flow_dir, ids_scope, network_fn,
-                                 finalize_fn=finalize_fn)
+    result = resolve_transaction(
+        flow_dir, ids_scope, network_fn, finalize_fn=finalize_fn,
+        # A REQUIRED-incomplete map is persisted but NEVER stamped fresh: a
+        # stamp here would make a later plain `resolve` skip the scope and
+        # report success over a map that cannot satisfy REQUIRED_SLOTS.
+        stamp=lambda final: all(s in final for s in REQUIRED_SLOTS))
     if isinstance(result, TrackerError):
         return envelope.failure(result)
+
+    assignment = seen["assignment"]
+    # The union now flows through the SAME guard as the full-assignment path:
+    # an ambiguous or candidate-less REQUIRED slot is a CONFLICT, not a success.
+    guarded = _assignment_to_data(assignment)
+    if isinstance(guarded, TrackerError):
+        return envelope.failure(guarded)
+
     aliased = is_alias(slot, chosen, seen.get("pools", {}))
     final_map = _dict(_dict(_dict(_dict(result.get("tracker"))
                                  .get("resolved")).get("destination")).get(key))
+    warnings = list(assignment.warnings)
+    if aliased:
+        warnings.append(f"{slot!r} aliases a state outside its natural "
+                        "candidates (recorded, not silent)")
     return envelope.success({
         "selected": {slot: chosen},
         "alias": aliased,
         key: final_map,
-        "warnings": ([f"{slot!r} aliases a state outside its natural candidates "
-                      f"(recorded, not silent)"] if aliased else []),
+        "warnings": warnings,
     })
+
+
+def _with_ids(config: dict, key: str, mapping: dict) -> dict:
+    """A config VIEW carrying `mapping` as the resolved slot map - the seed the
+    provider's assignment reads as `existing`. Copied, never mutated in place:
+    the transaction owns the real config document."""
+    tracker = dict(_dict(config.get("tracker")))
+    resolved = dict(_dict(tracker.get("resolved")))
+    destination = dict(_dict(resolved.get("destination")))
+    destination[key] = dict(mapping)
+    resolved["destination"] = destination
+    tracker["resolved"] = resolved
+    return {**config, "tracker": tracker}

--- a/.flow/bin/flowctl_tracker/resolved_cache.py
+++ b/.flow/bin/flowctl_tracker/resolved_cache.py
@@ -143,13 +143,18 @@ def _recompute_resolved_at(resolved: dict, tracker_type: str, now: str) -> None:
 
 
 def apply_scope_result(config: dict, scope: str, data: Any, *,
-                       now: Optional[str] = None) -> dict:
+                       now: Optional[str] = None, stamp: bool = True) -> dict:
     """Pure scope merge: stamp exactly one `scopeResolvedAt` entry and touch
     ONLY that scope's data. Returns the same config object, mutated.
 
     A destination refresh must not clobber `statusIds`/`stateIds` (their own
     scopes) and must not make capabilities look fresh - scope isolation is the
     reason the map exists.
+
+    `stamp=False` persists the scope's data WITHOUT declaring it resolved, and
+    REMOVES any prior stamp: an incomplete slot map must never read fresh, or
+    freshness suppresses the very repair that would complete it (#308). It is
+    the caller's job to decide completeness.
     """
     if scope not in SCOPES:
         raise ValueError(f"unknown scope {scope!r}; canonical scopes are {SCOPES}")
@@ -185,7 +190,10 @@ def apply_scope_result(config: dict, scope: str, data: Any, *,
             raise ValueError(f"unknown capability keys: {sorted(unknown)}")
         resolved["capabilities"] = dict(data)
 
-    sra[scope] = now
+    if stamp:
+        sra[scope] = now
+    else:
+        sra.pop(scope, None)
     _recompute_resolved_at(resolved, (tracker.get("type") or ""), now)
     return config
 
@@ -279,6 +287,7 @@ def resolve_transaction(
     *,
     now: Optional[str] = None,
     finalize_fn: Optional[Callable[[dict, dict], dict]] = None,
+    stamp: Union[bool, Callable[[Any], bool]] = True,
 ) -> Union[dict, TrackerError]:
     """Run one scoped resolve with the R8 ordering. Returns the merged config,
     or a TrackerError (never raises for the specified failure modes).
@@ -291,6 +300,10 @@ def resolve_transaction(
     data is one slot merged into the current map, and computing that merge from
     the pre-lock read would let two concurrent selects clobber each other with
     whole-map replaces.
+
+    `stamp` may be a predicate over the FINAL data, evaluated inside the lock:
+    `--select` persists a still-incomplete slot map (the human's tiebreak is
+    progress worth keeping) but must not stamp it fresh (#308).
     """
     if scope not in SCOPES:
         return TrackerError(ErrorClass.INVALID_INPUT,
@@ -317,7 +330,9 @@ def resolve_transaction(
                     continue
                 migrate_config(current)
                 final_data = finalize_fn(current, data) if finalize_fn else data
-                apply_scope_result(current, scope, final_data, now=now)
+                do_stamp = stamp(final_data) if callable(stamp) else bool(stamp)
+                apply_scope_result(current, scope, final_data, now=now,
+                                   stamp=do_stamp)
                 validate_resolved_block(current["tracker"]["resolved"])
                 _atomic_write_json(config_path, current)
                 return current

--- a/.flow/tasks/fn-179-issue-batch-r-id-parser-straggler.1.md
+++ b/.flow/tasks/fn-179-issue-batch-r-id-parser-straggler.1.md
@@ -12,9 +12,8 @@ Spec fn-179 items 1-2 (#300, #303). Widen _PR_COGNITIVE_AID_RID_RE to ^R[1-9][0-
 R1, R2, R3 of the spec. #303 repro parses 5/5; residue field present and non-aborting; R4ab and R-4 still rejected.
 
 ## Done summary
-TBD
-
+Parser fixes per fn-179 R1-R3 (#300, #303). _PR_COGNITIVE_AID_RID_RE widened to ^R[1-9][0-9]*[a-z]?$ (one constant, both validate call sites; R4ab/R-4 stay rejected). Criteria parser rebuilt as _export_scan_acceptance_criteria: line-wise bullet assembly (wrapped text joined until next bullet/blank/sub-bullet), token-anchored recognition stopping at the first **/: boundary (title form **R14 - title**, parenthetical **R15 (note):**), #303 five-bullet repro parses 5/5, R5a positive control kept; _export_parse_acceptance_criteria stays as a thin wrapper preserving the [{id,text,tag}] contract. Residue count surfaced as spec_sections.acceptance_criteria_residue (probe requires a digit so bold prose is not counted; deliberately-rejected spellings stay visible); text mode prints "K unparsed" only when non-zero; never aborts. 25 criteria recovered across 179 repo specs, none lost.
 ## Evidence
-- Commits:
-- Tests:
+- Commits: ccd9ece
+- Tests: cd plugins/flow-next/tests && python3 -m unittest test_acceptance_criteria_parser test_export_traceability test_pr_cognitive_aid test_qa_smoke test_flowctl_surface test_unaddressed_rids_parser test_prompt_text_pinned test_tracker_distribution -q (143 OK), python3 scripts/run_tests_parallel.py (4361 OK)
 - PRs:

--- a/.flow/tasks/fn-179-issue-batch-r-id-parser-straggler.2.md
+++ b/.flow/tasks/fn-179-issue-batch-r-id-parser-straggler.2.md
@@ -14,9 +14,8 @@ Post-capture (3.19-3.21 style wave, see spec Edge Cases): update the Step 0 `###
 R4, R5 of the spec. Existing droid/cursor/codex fixture outcomes unchanged; sync-codex idempotent.
 
 ## Done summary
-TBD
-
+Setup workflow fixes per fn-179 R4-R5 (#305, #306). SPEC.md discovery HITS now counts distinct files by inode (BSD stat -f %i / GNU stat -c %i, per candidate) - case-insensitive single-file repos take HITS=1 with no bogus both-files warning; branch bodies unchanged. Step 0 cascade detects Claude Code via CLAUDECODE=1 paired with a positive discriminator (.claude-plugin/plugin.json at the resolved PLUGIN_ROOT) and a deliberately LOWERED rung (after Droid/Cursor/Grok, before the codex fallback) because CLAUDECODE is child-inherited and those hosts prove themselves with their own process signals - deviation from the matrix's "precedence unchanged" note, accepted on review with the nesting-edge trade documented. All six prose surfaces naming the old signal changed in one edit; detection matrix items 8-10 added; fixtures follow the pin-shape rule (content + reachability). Conduct checklist setup.md: all 6 items pass; live-setup dogfood replaced by executing the extracted fences under fixtures. Orchestrator follow-up ba41e2df fixed the .4 regression this task's full-suite run caught (synthetic Namespace without reclaim attr).
 ## Evidence
-- Commits:
-- Tests:
+- Commits: 45469dda
+- Tests: cd plugins/flow-next/tests && python3 -m unittest test_setup_spec_discovery_hits test_setup_grok_host + 9 suites -q (144 OK, 1 skip APFS), python3 scripts/run_tests_parallel.py (4385 ran; 4 errors were .4's missing-attr regression, fixed in ba41e2df)
 - PRs:

--- a/.flow/tasks/fn-179-issue-batch-r-id-parser-straggler.3.md
+++ b/.flow/tasks/fn-179-issue-batch-r-id-parser-straggler.3.md
@@ -12,9 +12,8 @@ Spec fn-179 item 5 (#308). After merging the selection in _run_select, run the n
 R6 of the spec. Repro step 3 yields a complete map; REQUIRED-incomplete yields CONFLICT, no fresh stamp.
 
 ## Done summary
-TBD
-
+tracker resolve --select per fn-179 R6 (#308). _run_select now merges the human tiebreak, then runs the provider's normal slot assignment over the remaining slots (new pure assign_slots_from_pools halves extracted from linear/jira resolvers - no second network call inside the lock) and persists the union inside the transaction's finalize_fn. REQUIRED-incomplete maps persist (progress kept, avoids two-select deadlock) but return CONFLICT through the existing _assignment_to_data guard and are NEVER stamped: resolve_transaction gained a stamp predicate evaluated on the final data inside the lock, and stamp=False also removes a prior stamp so #308-damaged configs self-repair on the next select. in_review never auto-fills (policy unchanged). Five-step #308 repro ends complete at step 3.
 ## Evidence
-- Commits:
-- Tests:
+- Commits: 81d8e10c
+- Tests: cd plugins/flow-next/tests && python3 -m unittest test_tracker_resolution_linear_jira -q (49 OK), 8 tracker suites (449 OK), test_tracker_distribution test_tracker_package_import test_tracker_sync_mirror_parity (44 OK)
 - PRs:

--- a/.flow/tasks/fn-179-issue-batch-r-id-parser-straggler.4.md
+++ b/.flow/tasks/fn-179-issue-batch-r-id-parser-straggler.4.md
@@ -12,9 +12,8 @@ Spec fn-179 item 6 (#316). Add --reclaim to flowctl start: rewrites the claimant
 R7 of the spec. Both notes distinguishable in the record; existing --force tests green.
 
 ## Done summary
-TBD
-
+flowctl start --reclaim per fn-179 R7 (#316). Relaxes exactly two identity gates (claimed-by-another, in_progress owned by another); dependency/blocked/done gates unchanged and still --force-only. Repair note "Reclaimed from <identity> (identity repair)" distinct from --force takeover note "Taken over from <identity>"; --force path byte-for-byte unchanged; explicit --note wins but claimant still rewritten; unclaimed/self-claimed = normal claim, no repair note; no sibling-identity heuristic (declined ledger honored). No-flag error now also names --reclaim for discoverability. 10 new focused tests (test_start_reclaim.py).
 ## Evidence
-- Commits:
-- Tests:
+- Commits: c43fbacc
+- Tests: cd plugins/flow-next/tests && python3 -m unittest test_start_reclaim -q (10 OK), test_portable_locks test_status_source (21 OK), test_tracker_distribution test_prompt_text_pinned (25 OK)
 - PRs:

--- a/.flow/tasks/fn-179-issue-batch-r-id-parser-straggler.5.md
+++ b/.flow/tasks/fn-179-issue-batch-r-id-parser-straggler.5.md
@@ -10,9 +10,8 @@ Spec fn-179 R8-R9. Docs: state the gate-classify path taxonomy is deliberately c
 R8, R9 of the spec. Full gate green; no version bump (batched releases).
 
 ## Done summary
-TBD
-
+R8-R9 closed out. flowctl.md gate-classify section now states the taxonomy is deliberately closed to config (misconfigured taxonomy would silently skip gates), per-repo gate policy belongs in the consumer's conductor instructions with pilot.gateClasses as the open vocabulary, and reason strings are diagnostics, not a stable contract (#313 answer, to be posted on the issue). Worker-flagged doc lines landed: start --reclaim (flags, gate semantics, note wordings), tracker resolve --select (union, CONFLICT-unstamped, in_review never auto-fills), platforms.md CLAUDE_PLUGIN_ROOT note tied to #306, make-pr coverage ratio surfaces acceptance_criteria_residue with a never-silent rule. CHANGELOG Unreleased credits @sn-furali per issue (#300 #303 #305 #306 #308 #316) plus the #313 docs entry. Full gate green; no version bump.
 ## Evidence
-- Commits:
-- Tests:
+- Commits: 794df792
+- Tests: python3 scripts/run_tests_parallel.py (4385 OK, 0 failures), uvx ruff@0.16.0 check . (clean), ./scripts/sync-codex.sh x2 (idempotent)
 - PRs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,60 @@
 
 All notable changes to the flow-next.
 
+## Unreleased
+
+Six small defects, one pass - every one arrived as a measured report with a
+verified repro from @sn-furali (thanks!), and each fix takes the reporter's own
+suggested design where one was offered. A criterion your spec wrote should
+never vanish silently, a wrong platform guess should not survive on our primary
+host, and a half-resolved tracker map should never read as resolved.
+
+### Fixed
+
+- **Suffixed R-IDs accepted by the PR cognitive aid.** `pr-cognitive-aid
+  validate` now accepts the canonical sub-scoped sibling form (`R4a`) at both
+  call sites via the one shared constant; `R4ab` and `R-4` stay rejected.
+  (#300)
+- **Acceptance-criteria shapes stop being dropped silently.** The export
+  parser reads title-form (`**R14 - title**`) and parenthetical-form
+  (`**R15 (note):**`) bullets and keeps wrapped continuation lines; the issue
+  repro parses 5/5, and 25 criteria were recovered across this repo's own
+  specs. Criterion-shaped bullets that still do not parse are now counted and
+  surfaced as `acceptance_criteria_residue` in the export payload - a short
+  coverage denominator is visible, never silent, and residue never aborts the
+  export. (#303)
+- **Setup counts SPEC.md files by inode, not by name.** On a case-insensitive
+  filesystem a single `SPEC.md` no longer counts twice and prints a bogus
+  both-files warning; case-sensitive dual-file repos still take the two-file
+  branch. (#305)
+- **Claude Code detects as Claude Code.** The setup platform cascade keyed its
+  Claude branch on `CLAUDE_PLUGIN_ROOT`, which never reaches a plugin skill's
+  Bash env - so our primary host fell through to the codex fallback and got
+  `$flow-next-` snippets. The branch now keys on `CLAUDECODE` paired with the
+  Claude plugin manifest as a positive discriminator, and sits below
+  Droid/Cursor/Grok so those hosts' own signals outrank the child-inherited
+  marker. (#306)
+- **`tracker resolve --select` finishes the job.** Picking one ambiguous slot
+  now runs the normal assignment over the remaining slots and persists the
+  union; a map still missing a required slot is kept but reported as CONFLICT
+  and left unstamped, so a later plain `resolve` repairs it instead of
+  skipping a fresh-looking scope. `in_review` still never auto-fills. Configs
+  already half-stamped by this bug self-repair on the next `--select`. (#308)
+
+### Added
+
+- **`flowctl start --reclaim` - identity repair, distinct from takeover.**
+  Rewrites the claimant of a task held by a stale or wrong identity and
+  records `Reclaimed from <identity> (identity repair)`, so `--force` keeps
+  its takeover meaning and the record says which one happened. Only the
+  claim-ownership gates relax; dependency/blocked/done still require
+  `--force`. (#316)
+- **Gate-classify extensibility documented as deliberately closed.** The path
+  taxonomy takes no config key by design; per-repo gate policy belongs in the
+  consumer's conductor instructions with `pilot.gateClasses` as the open
+  vocabulary, and classifier reason strings are not a stable contract.
+  (#313, docs)
+
 ## [flow-next 3.24.1] - 2026-08-10
 
 ### Fixed

--- a/plugins/flow-next/codex/skills/flow-next-make-pr/workflow.md
+++ b/plugins/flow-next/codex/skills/flow-next-make-pr/workflow.md
@@ -413,7 +413,7 @@ All four values come from the payload directly:
 - `<spec-id>` from `spec.id`
 - `<branch>` from `PHASE0_CONTEXT.branch`, `<base>` from `PHASE0_CONTEXT.base`
 - `<done>` / `<open>` from `tasks_summary.done` / `tasks_summary.open`
-- `<covered>` = `len(acceptance_criteria) - len(tasks_summary.uncovered_r_ids)`; `<total>` = `len(acceptance_criteria)`
+- `<covered>` = `len(acceptance_criteria) - len(tasks_summary.uncovered_r_ids)`; `<total>` = `len(acceptance_criteria)`. When `spec.spec_sections.acceptance_criteria_residue` is non-zero, append ` (<N> unparsed)` to the ratio - the denominator is short by that many criterion-shaped bullets the parser could not read (fn-179, #303); never silently present a short denominator as complete.
 
 A 2-line natural-language summary appears between the H1 and the blockquote, drawn from `spec.spec_sections.goal_and_context` first paragraph, truncated to ~240 characters with sentence-boundary respect. Never invent — if `goal_and_context` is empty the summary is omitted.
 

--- a/plugins/flow-next/codex/skills/flow-next-make-pr/workflow.md
+++ b/plugins/flow-next/codex/skills/flow-next-make-pr/workflow.md
@@ -413,7 +413,7 @@ All four values come from the payload directly:
 - `<spec-id>` from `spec.id`
 - `<branch>` from `PHASE0_CONTEXT.branch`, `<base>` from `PHASE0_CONTEXT.base`
 - `<done>` / `<open>` from `tasks_summary.done` / `tasks_summary.open`
-- `<covered>` = `len(acceptance_criteria) - len(tasks_summary.uncovered_r_ids)`; `<total>` = `len(acceptance_criteria)`. When `spec.spec_sections.acceptance_criteria_residue` is non-zero, append ` (<N> unparsed)` to the ratio - the denominator is short by that many criterion-shaped bullets the parser could not read (fn-179, #303); never silently present a short denominator as complete.
+- `<covered>` = `len(acceptance_criteria) - len(tasks_summary.uncovered_r_ids)`; `<total>` = `len(acceptance_criteria)`. When `spec.spec_sections.acceptance_criteria_residue` is non-zero, append ` (<N> unparsed)` to the ratio - the denominator is short by that many criterion-shaped bullets the parser could not read (fn-179, #303); never silently present a short denominator as complete. This qualifier applies on BOTH ratio paths - artifact-derived (Phase 1.5's supersession covers the coverage *claims*, but the residue count has no artifact counterpart and comes from the same export payload, so appending it is not a legacy-field merge) and legacy fallback alike.
 
 A 2-line natural-language summary appears between the H1 and the blockquote, drawn from `spec.spec_sections.goal_and_context` first paragraph, truncated to ~240 characters with sentence-boundary respect. Never invent — if `goal_and_context` is empty the summary is omitted.
 

--- a/plugins/flow-next/codex/skills/flow-next-setup/workflow.md
+++ b/plugins/flow-next/codex/skills/flow-next-setup/workflow.md
@@ -27,11 +27,18 @@ PLATFORM="codex"
 
 **Positive path discriminator — `PLUGIN_ROOT` under `~/.cursor/` (never `codex/` absence).** The manifest + env checks alone are not enough when Codex runs from the **checked-in plugin source** inside a Cursor shell (Codex marketplace points at `./plugins/flow-next`, which carries `.cursor-plugin/`, `.codex-plugin/`, and the `codex/` mirror) — there the Cursor manifest is present in the workspace tree, so env+manifest would misfire. The positive signal is that a **real Cursor install** resolves `PLUGIN_ROOT` under `~/.cursor/` — local `install-cursor.sh`/`.ps1` → `~/.cursor/plugins/local/flow-next/`; team-marketplace repo-import → Cursor's marketplace plugin cache under `~/.cursor/` (and that cache **may contain `codex/`** because the whole plugin source is imported; explicit component paths in `.cursor-plugin/plugin.json` keep Cursor from loading the mirror as skills). A genuine Codex install resolves under `$CODEX_HOME` (default `~/.codex`); the shared source tree resolves to a workspace path. Neither is under `~/.cursor/`, so both correctly fall through to `codex` even with inherited `CURSOR_AGENT`. **Do not** key detection on the `codex/` directory being absent — that misclassifies marketplace repo-imports as Codex.
 
-**Grok ordering matters (fn-126).** Grok Build (xAI's `grok` CLI) reads the canonical Claude plugin format AS-IS and drives with `/flow-next-*` / `/flow-next:` slash commands — not the Codex `$flow-next-` mirror. Without a positive signal it fell through to `else → codex` and setup wrote Codex-shaped `$flow-next-` snippets into AGENTS.md (dogfood 2026-07-22). **Probe-verified signal:** `GROK_AGENT=1` is set BY grok in its agent shell (absent from a plain-shell control on the same machine). **Rejected non-signals:** `~/.grok/` exists on the machine regardless (install dir), and `~/.grok/bin` on `PATH` is profile-level — neither distinguishes a grok session. The `GROK_AGENT` branch MUST come after Droid / Claude / Cursor (so a real Claude/Cursor/Droid host that merely inherited `GROK_AGENT` from a parent grok shell still classifies by its own higher-precedence signal) and BEFORE the `else → codex` fallback.
+**Claude Code signal - `CLAUDECODE` + the Claude plugin manifest, and why the rung sits low (#306).** `CLAUDE_PLUGIN_ROOT` is **never set in the Bash environment of a running plugin skill** on Claude Code (probe-verified against 2.1.221 and re-verified at v3.16.3), so the branch that keyed on it could not fire on our PRIMARY host: every rung failed and setup fell through to `else -> codex`, writing Codex `$flow-next-` snippets into a repo driven by `/flow-next:` slash commands. The signal that IS present is `CLAUDECODE=1` - the same marker the codex-delegation platform gate keys on. It is set by Claude Code itself, in every install mode (marketplace cache, local marketplace, `--plugin-dir` dev load), so it needs no plugin-root env var; `PLUGIN_ROOT` is already resolved from this file's own location.
 
-**Known nesting edge (Droid → Grok) — NEEDS-HUMAN.** The probe disproved `CLAUDE_PLUGIN_ROOT` propagation into a grok child, so Claude-from-parent does not misfire. It did **not** disprove `DROID_PLUGIN_ROOT` propagation: if a grok child inherits `DROID_PLUGIN_ROOT` from a Droid parent shell, the cascade classifies as `droid` (higher precedence). Treat nested Droid→Grok as **unsupported pending a this-process-is-grok discriminator** unless a NEEDS-HUMAN smoke confirms `DROID_PLUGIN_ROOT` does not propagate. Claude/Cursor-from-grok remain correct via higher-precedence signals.
+`CLAUDECODE` is **inherited by child processes** - same class as the `CURSOR_AGENT` misfire above - so it is paired with a positive discriminator and a lowered position, never used bare:
 
-**Matrix (detection fixtures):** (1) marketplace whole-repo import under `~/.cursor/` + may have `codex/` → `cursor`; (2) local `install-cursor` under `~/.cursor/plugins/local/` (no `codex/`) → `cursor`; (3) Codex under `$CODEX_HOME` / `~/.codex` with inherited `CURSOR_AGENT` → `codex`; (4) Claude (`CLAUDE_PLUGIN_ROOT`) / Droid (`DROID_PLUGIN_ROOT`) still win first — precedence unchanged; (5) standalone `GROK_AGENT=1` (no higher signal) → `grok`; (6) `GROK_AGENT=1` + `CLAUDE_PLUGIN_ROOT` / `CURSOR_AGENT`(+cursor install) / `DROID_PLUGIN_ROOT` → higher host wins; (7) plain shell (no host signal) → `codex`.
+- **Positive discriminator:** the Claude plugin manifest `.claude-plugin/plugin.json` must exist at the resolved `PLUGIN_ROOT`. That is present in every Claude-format install and **absent** from a Codex install root (`$CODEX_HOME`, whose manifest is a top-level `plugin.json`), so a `codex exec` child that inherited `CLAUDECODE` from its Claude parent still classifies `codex`.
+- **Position: after Droid / Cursor / Grok, before the `codex` fallback.** Each of those hosts proves itself with a signal set by its OWN process (`DROID_PLUGIN_ROOT`, `CURSOR_AGENT` + a `~/.cursor/` install, `GROK_AGENT`), and all of them read the canonical Claude plugin format - so a Cursor or Grok agent launched **from** a Claude Code shell inherits `CLAUDECODE` and would be misclassified `claude-code` by a higher rung. Ordering is what keeps an inherited marker from outranking a host's own signal. This is a deliberate precedence change from the pre-#306 cascade, where the Claude rung sat second: that position only ever protected the `CLAUDE_PLUGIN_ROOT` reading, which on Claude Code is never there.
+
+**Grok ordering matters (fn-126).** Grok Build (xAI's `grok` CLI) reads the canonical Claude plugin format AS-IS and drives with `/flow-next-*` / `/flow-next:` slash commands — not the Codex `$flow-next-` mirror. Without a positive signal it fell through to `else → codex` and setup wrote Codex-shaped `$flow-next-` snippets into AGENTS.md (dogfood 2026-07-22). **Probe-verified signal:** `GROK_AGENT=1` is set BY grok in its agent shell (absent from a plain-shell control on the same machine). **Rejected non-signals:** `~/.grok/` exists on the machine regardless (install dir), and `~/.grok/bin` on `PATH` is profile-level — neither distinguishes a grok session. The `GROK_AGENT` branch MUST come after Droid / Cursor (so a real Cursor/Droid host that merely inherited `GROK_AGENT` from a parent grok shell still classifies by its own higher-precedence signal), BEFORE the inherited-marker `CLAUDECODE` rung, and BEFORE the `else → codex` fallback.
+
+**Known nesting edge (Droid → Grok) — NEEDS-HUMAN.** A grok child inherits `CLAUDECODE` from a Claude parent, and the Claude rung now sits BELOW grok, so Claude-from-parent does not misfire. It did **not** disprove `DROID_PLUGIN_ROOT` propagation: if a grok child inherits `DROID_PLUGIN_ROOT` from a Droid parent shell, the cascade classifies as `droid` (higher precedence). Treat nested Droid→Grok as **unsupported pending a this-process-is-grok discriminator** unless a NEEDS-HUMAN smoke confirms `DROID_PLUGIN_ROOT` does not propagate. Cursor-from-grok remains correct via its higher-precedence signal. The mirror-image nesting edge is Claude-from-Grok / Claude-from-Cursor: a Claude Code session launched inside a grok or Cursor agent shell inherits that host's marker and classifies as the parent host. That trade is deliberate - both markers are set by the parent's own process, and the reverse (Claude outranking them on an inherited `CLAUDECODE`) is the far more common nesting, since Claude sessions routinely spawn grok / cursor-agent bridges.
+
+**Matrix (detection fixtures):** (1) marketplace whole-repo import under `~/.cursor/` + may have `codex/` → `cursor`; (2) local `install-cursor` under `~/.cursor/plugins/local/` (no `codex/`) → `cursor`; (3) Codex under `$CODEX_HOME` / `~/.codex` with inherited `CURSOR_AGENT` → `codex`; (4) Droid (`DROID_PLUGIN_ROOT`) still wins first — Droid/Cursor precedence unchanged; (5) standalone `GROK_AGENT=1` (no higher signal) → `grok`; (6) `GROK_AGENT=1` + `CURSOR_AGENT`(+cursor install) / `DROID_PLUGIN_ROOT` → higher host wins; (7) plain shell (no host signal) → `codex`; (8) Claude Code plugin skill — `CLAUDECODE=1`, `CLAUDE_PLUGIN_ROOT` **unset** (it never reaches a skill's Bash env), `PLUGIN_ROOT` carrying `.claude-plugin/plugin.json` → `claude-code`; (9) `CLAUDECODE=1` inherited by a Cursor / Grok / Droid child → that host's own signal wins (Claude rung is last before the fallback); (10) `CLAUDECODE=1` with a Codex-home `PLUGIN_ROOT` (no `.claude-plugin/plugin.json`) → `codex`.
 
 Store `PLATFORM` for use in later steps. This determines:
 - Which manifest to read for version (`plugin.json`)
@@ -42,7 +49,7 @@ Store `PLATFORM` for use in later steps. This determines:
 ### Done when
 
 - `PLUGIN_ROOT` resolves to a directory containing `scripts/` and a plugin manifest, and `PLATFORM` holds exactly one of `claude-code` / `codex` / `droid` / `cursor` / `grok`.
-- **`PLATFORM` came from the host's own signals in the documented precedence, and every downstream choice matches it.** A Cursor or Grok repo that received the Codex `$flow-next-` snippet, or a Codex install misclassified as Cursor through an inherited `CURSOR_AGENT`, has broken this.
+- **`PLATFORM` came from the host's own signals in the documented precedence, and every downstream choice matches it.** A Cursor or Grok repo that received the Codex `$flow-next-` snippet, a Codex install misclassified as Cursor through an inherited `CURSOR_AGENT`, or a Claude Code run classified `codex` because the cascade looked for `CLAUDE_PLUGIN_ROOT` instead of `CLAUDECODE` (#306), has broken this.
 
 ## Step 1: Initialize .flow/
 
@@ -139,7 +146,20 @@ The spec-template discovery cascade prefers a customized scaffold at the repo ro
 **Detect what's already at the repo root** (case-insensitive FS handling — macOS APFS, Windows NTFS):
 
 ```bash
-HITS=$(ls -1 SPEC.md spec.md 2>/dev/null | sort -u | wc -l | tr -d ' ')
+# Count DISTINCT FILES, not argument names. `ls -1 SPEC.md spec.md` echoes each
+# existing argument back, so on a case-insensitive FS one file prints as two
+# names and `sort -u` de-duplicates nothing (#305: HITS=2 on APFS for a repo
+# holding only SPEC.md, firing the bogus both-files warning). Inodes answer the
+# question the branches actually ask.
+# Portable stat, per candidate: GNU form FIRST (`stat -c %i` -> inode; on BSD
+# `-c` is unsupported and errors, so it falls through), BSD form second
+# (`stat -f %i` -> inode). Order matters: GNU reads `-f` as --file-system and
+# would print one shared filesystem id for BOTH files, collapsing a genuine
+# two-file repo to HITS=1.
+HITS=$(for f in SPEC.md spec.md; do
+ [ -e "$f" ] || continue
+ stat -c %i "$f" 2>/dev/null || stat -f %i "$f" 2>/dev/null
+done | sort -u | wc -l | tr -d ' ')
 ```
 
 Then branch:
@@ -159,7 +179,7 @@ On `Copy template`: write the file via Bash `cp` with absolute paths.
 cp "${PLUGIN_ROOT}/templates/spec.md" SPEC.md
 ```
 
-**2. `HITS=1` (single hit OR case-insensitive FS collapsing both to one)** — capture whichever filename actually exists into `EXISTING` (no prompt). Both the read-for-compare and the overwrite target route through `EXISTING` so lowercase `spec.md` repos do not silently fall back to a missing `SPEC.md`:
+**2. `HITS=1` (one file: a single name, OR a case-insensitive FS where both names resolve to one inode)** — capture whichever filename actually exists into `EXISTING` (no prompt). Both the read-for-compare and the overwrite target route through `EXISTING` so lowercase `spec.md` repos do not silently fall back to a missing `SPEC.md`:
 
 ```bash
 EXISTING=$(ls -1 SPEC.md spec.md 2>/dev/null | head -1)

--- a/plugins/flow-next/docs/flowctl.md
+++ b/plugins/flow-next/docs/flowctl.md
@@ -793,8 +793,10 @@ The `--require-completion-review` flag gates spec closure on completion review. 
 Start task (set status=in_progress). Sets assignee to current actor.
 
 ```bash
-flowctl start fn-1.2 [--force] [--note "..."] [--json]
+flowctl start fn-1.2 [--force] [--reclaim] [--note "..."] [--json]
 ```
+
+`--reclaim` rewrites the claimant when a task is held by a stale or wrong identity and records `Reclaimed from <identity> (identity repair)` - distinct from `--force`, which records `Taken over from <identity>`, so the record says which one happened. It relaxes only the claim-ownership gates (claimed-by-another, and `in_progress` owned by another); dependency, `blocked`, and `done` gates still require `--force`. On an unclaimed or self-claimed task it is a plain claim with no repair note; `--note` overrides the generated note; `--reclaim --force` writes the repair note. No identity validation is performed - which identities are legitimate is the consuming repo's governance (#316).
 
 Validates:
 - Status is `todo` (or `in_progress` if resuming own task)
@@ -1387,7 +1389,13 @@ flowctl tracker resolve \
 ```
 
 `resolve` fills or refreshes `tracker.resolved`. `--select` persists one
-validated human tiebreak for an ambiguous Linear state or Jira status slot.
+validated human tiebreak for an ambiguous Linear state or Jira status slot -
+and then runs the normal assignment over the REMAINING slots, persisting the
+union: the tiebreak resolves one slot, it does not excuse the others (#308). A
+map still missing a REQUIRED slot is persisted (progress kept) but reported as
+CONFLICT and left unstamped, so a later plain `resolve` repairs it instead of
+skipping a fresh-looking scope. `in_review` never auto-fills - the two-state
+case genuinely needs the human tiebreak.
 The normalized slots are `todo`, `in_progress`, and `done`; optional provider
 slots may also be retained. The persisted shape is:
 
@@ -1905,6 +1913,8 @@ Callers fail closed on both outcomes.
 Exit `0` (tier-B) only for a non-empty diff where every path is SAFE. Empty diffs and any forcing path exit `1`; errors exit `2+`. `--json` emits per-path `{path, class, reason}` entries for evidence lines. Tier-B runs configured lint/format gates only, and nothing else.
 
 Lint and format commands are always-run and never receipted in v1. Remote CI gates, including land's tri-state and GitHub Actions, are out of scope: a green receipt never means CI can be skipped. Receipts under `.flow/tmp/` are per checkout, so worktree-mode workers never share them across worktrees, correctly because their HEADs differ. Scope guard: every predicate is commit-hash equality, worktree cleanliness, receipt age, or path membership. There is no semantic skipping: fn-83's deterministic-plan-sync-skip ban remains in force; see decision record `plan-sync-skip-gate-not-viable-2026-07-03`.
+
+**The path taxonomy is deliberately closed to config (#313).** The classifier's prefix/extension tables encode flow-next's own repository layout and take no config key by design: a config-extensible taxonomy would make the docs-only fast path a per-repo policy surface whose misconfiguration silently skips gates. Per-repo gate policy belongs in the consumer repository's conductor instructions (CLAUDE.md / AGENTS.md) - the host agent reading them decides when a "safe" classification still deserves the full gate - with `pilot.gateClasses` as the open, config-owned vocabulary for forcing surfacing in autonomous backlog mode. A consumer repo whose highest-risk changes are documents should say so in its conductor instructions rather than expect the classifier to learn its layout. The per-path `reason` strings in `--json` output are diagnostics for evidence lines, not a stable contract: match on `class`, never on `reason` text.
 
 ### rp
 

--- a/plugins/flow-next/docs/platforms.md
+++ b/plugins/flow-next/docs/platforms.md
@@ -243,7 +243,7 @@ chmod +x .flow/bin/flowctl
 
 **Instruction files (probe-verified):** Grok loads **both** `CLAUDE.md` and `AGENTS.md` into context (seeded-codename probe, 2026-07-22). Setup therefore writes the lifecycle docs snippet to **CLAUDE.md** by default (`/flow-next:` slash syntax, not Codex `$flow-next-`) and the model-routing scaffold to **AGENTS.md** (where host-review workflows resolve pins). A pre-existing wrong Codex `$flow-next-` marker block is consent-refreshed to the slash form (marker-scoped).
 
-**Known nesting edge (Droid → Grok) - NEEDS-HUMAN:** if a grok child inherits `DROID_PLUGIN_ROOT` from a Droid parent shell, the cascade classifies as `droid` (higher precedence). Nested Droid→Grok is **unsupported** pending a this-process-is-grok discriminator, unless a live smoke confirms `DROID_PLUGIN_ROOT` does not propagate. Claude/Cursor launched from a grok shell still classify correctly via their own higher-precedence signals. The probe disproved `CLAUDE_PLUGIN_ROOT` propagation into a grok child.
+**Known nesting edge (Droid → Grok) - NEEDS-HUMAN:** if a grok child inherits `DROID_PLUGIN_ROOT` from a Droid parent shell, the cascade classifies as `droid` (higher precedence). Nested Droid→Grok is **unsupported** pending a this-process-is-grok discriminator, unless a live smoke confirms `DROID_PLUGIN_ROOT` does not propagate. Claude/Cursor launched from a grok shell still classify correctly via their own higher-precedence signals. The probe disproved `CLAUDE_PLUGIN_ROOT` propagation into a grok child - and #306 later showed the same variable never reaches a plugin skill's Bash env on Claude Code itself, which is why the cascade keys the Claude rung on `CLAUDECODE` + the plugin manifest instead.
 
 ### Install (pick one)
 

--- a/plugins/flow-next/scripts/flowctl.py
+++ b/plugins/flow-next/scripts/flowctl.py
@@ -27876,7 +27876,13 @@ PR_COGNITIVE_AID_ATTENTION_CLASSES = frozenset(
 )
 _PR_COGNITIVE_AID_SHA_RE = re.compile(r"^[0-9a-f]{40,64}$")
 _PR_COGNITIVE_AID_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,159}$")
-_PR_COGNITIVE_AID_RID_RE = re.compile(r"^R[1-9][0-9]*$")
+# Canonical R-ID grammar, in lockstep with the spec parser
+# (`_export_parse_acceptance_criteria`) and the review-output extractor
+# (`parse_unaddressed_rids`): a single-letter suffix (`R4a`, `R4b`) is the
+# sub-scoped sibling form the spec template emits. Multi-letter suffixes
+# (`R4ab`) and separators (`R-4`) stay rejected. Both call sites (the
+# `sources[].ref` kind==rid check and the `rIds[]` check) use this constant.
+_PR_COGNITIVE_AID_RID_RE = re.compile(r"^R[1-9][0-9]*[a-z]?$")
 _PR_COGNITIVE_AID_WINDOWS_RESERVED = frozenset(
     {
         "CON",
@@ -31462,21 +31468,78 @@ def _export_resolve_merge_base(base_ref: str) -> Optional[str]:
     return sha if sha else None
 
 
-def _export_parse_acceptance_criteria(spec_text: str) -> list[dict[str, Any]]:
-    """Extract R-ID acceptance criteria from an epic spec.
+# A criterion bullet starts at column 0 with `-`/`*` (indented bullets are
+# sub-bullets of a criterion, never criteria themselves).
+_AC_BULLET_START_RE = re.compile(r"^[-*]\s+")
+# Token anchor: the R-ID must open the bold run, and the character after it
+# must be a boundary - so `R4ab` (multi-letter suffix) and `R-4` (separator)
+# stay rejected, while `R4a` is the canonical sub-scoped sibling form.
+_AC_TOKEN_RE = re.compile(r"^[-*]\s+\*\*\s*(R\d+[a-z]?)(?![0-9A-Za-z])")
+# Residue probe: a bullet that *looks* like a criterion (`- **R…`) - anything
+# matching this but not parsing is counted, never silently dropped. The digit
+# is required so an ordinary bold word starting with R (`- **Renumber-…**`)
+# is not mistaken for a dropped criterion; a separator before it keeps the
+# deliberately-rejected spellings (`R-4`) visible rather than silent.
+_AC_RESIDUE_RE = re.compile(r"^[-*]\s+\*\*\s*R[-_ ]?\d")
+# One leading separator between the R-ID (or its bold close) and the text.
+_AC_LEAD_SEP_RE = re.compile(r"^\s*[:\-–—]\s*")
+_AC_TAG_RE = re.compile(r"\[([^\]]+)\]\s*$")
+
+
+def _export_parse_acceptance_criterion(bullet: str) -> Optional[dict[str, Any]]:
+    """Parse one already-joined criterion bullet, or None if it does not parse.
+
+    Anchors on the R-ID token and stops at the first `**` or `:` boundary, so
+    bold runs that continue past the token still yield the criterion:
+
+        - **R1:** canonical form.
+        - **R14 - the pause protocol survives a restart** and its body.
+        - **R15 (a parenthetical):** body text.
+    """
+    m = _AC_TOKEN_RE.match(bullet)
+    if not m:
+        return None
+    rest = bullet[m.end() :]
+    close = rest.find("**")
+    if close < 0:
+        # Unterminated bold run - not a criterion we can read.
+        return None
+    head = rest[:close].rstrip()
+    tail = rest[close + 2 :].strip()
+    text_raw = (head + " " + tail).strip() if head and tail else (head or tail)
+    text_raw = _AC_LEAD_SEP_RE.sub("", text_raw, count=1).strip()
+    if not text_raw:
+        return None
+    tag = ""
+    tm = _AC_TAG_RE.search(text_raw)
+    if tm:
+        tag = tm.group(1).strip()
+        # Trim the trailing tag from text.
+        text_raw = text_raw[: tm.start()].rstrip()
+    return {"id": m.group(1), "text": text_raw, "tag": tag}
+
+
+def _export_scan_acceptance_criteria(
+    spec_text: str,
+) -> tuple[list[dict[str, Any]], int]:
+    """Return `(criteria, residue)` for an epic spec's acceptance section.
 
     Canonical heading is `## Acceptance Criteria` (since 1.1.4). For
     back-compat, also tolerates `## Acceptance criteria` (older lowercase
-    form) and bare `## Acceptance` (plan template pre-1.1.4). Parses bullets
-    matching `- **R<N>:** <text>`. Source-tag suffixes like `[user]` /
-    `[paraphrase]` / `[inferred]` / `[strategy:track]` are extracted into
-    the `tag` field (last `[...]` token in the bullet).
+    form) and bare `## Acceptance` (plan template pre-1.1.4).
 
-    Returns list of `{"id": "R1", "text": "...", "tag": "..."}`. Empty list
-    if no acceptance section or no R-IDs.
+    A criterion bullet runs until the next bullet or a blank line, so text
+    wrapped across lines keeps its continuation (joined with single spaces).
+    Source-tag suffixes like `[user]` / `[paraphrase]` / `[inferred]` /
+    `[strategy:track]` are extracted into the `tag` field (last `[...]`
+    token in the bullet).
+
+    `residue` counts bullets shaped like criteria (`- **R…`) that did not
+    parse - a non-zero residue is a visible discrepancy instead of a silent
+    drop. It never aborts anything.
     """
     if not spec_text:
-        return []
+        return [], 0
 
     # Find the section heading. Tolerate canonical + 2 legacy forms.
     heading_re = re.compile(
@@ -31485,7 +31548,7 @@ def _export_parse_acceptance_criteria(spec_text: str) -> list[dict[str, Any]]:
     )
     m = heading_re.search(spec_text)
     if not m:
-        return []
+        return [], 0
     body_start = m.end()
     # Section ends at the next H2 or end-of-file.
     next_h2 = re.search(r"^##\s+", spec_text[body_start:], re.MULTILINE)
@@ -31495,30 +31558,49 @@ def _export_parse_acceptance_criteria(spec_text: str) -> list[dict[str, Any]]:
         body_end = len(spec_text)
     body = spec_text[body_start:body_end]
 
-    # Bullet pattern: `- **R<N>:** <text>` or `- **R<N><a-z>:** <text>`.
-    # Tolerate optional whitespace between the bullet marker and the bold token.
-    # The single-letter suffix form (`R4a`, `R4b`) lets capture-driven specs
-    # sub-scope criteria sharing a logical parent; siblings sort lexically
-    # (`R4` < `R4a` < `R4b` < `R5`) via Python's default string ordering.
-    # Multi-letter suffixes (`R4ab`) and separators (`R-4`) remain rejected
-    # by design — broader format support waits for a real need.
-    bullet_re = re.compile(
-        r"^[-*]\s+\*\*(R\d+[a-z]?)\:?\*\*\s*:?\s*(.+?)$",
-        re.MULTILINE,
-    )
-    tag_re = re.compile(r"\[([^\]]+)\]\s*$")
     entries: list[dict[str, Any]] = []
-    for bm in bullet_re.finditer(body):
-        rid = bm.group(1)
-        text_raw = bm.group(2).strip()
-        tag = ""
-        tm = tag_re.search(text_raw)
-        if tm:
-            tag = tm.group(1).strip()
-            # Trim the trailing tag from text.
-            text_raw = text_raw[: tm.start()].rstrip()
-        entries.append({"id": rid, "text": text_raw, "tag": tag})
-    return entries
+    residue = 0
+
+    def flush(lines: list[str]) -> None:
+        nonlocal residue
+        if not lines:
+            return
+        joined = " ".join(
+            [lines[0].rstrip()] + [ln.strip() for ln in lines[1:]]
+        )
+        entry = _export_parse_acceptance_criterion(joined)
+        if entry is None:
+            if _AC_RESIDUE_RE.match(lines[0]):
+                residue += 1
+            return
+        entries.append(entry)
+
+    current: list[str] = []
+    for line in body.splitlines():
+        if _AC_BULLET_START_RE.match(line):
+            flush(current)
+            current = [line]
+        elif not line.strip():
+            flush(current)
+            current = []
+        elif current and line.lstrip().startswith(("- ", "* ", "+ ")):
+            # An indented sub-bullet ends the criterion's own text.
+            flush(current)
+            current = []
+        elif current:
+            current.append(line)
+    flush(current)
+    return entries, residue
+
+
+def _export_parse_acceptance_criteria(spec_text: str) -> list[dict[str, Any]]:
+    """Extract R-ID acceptance criteria from an epic spec.
+
+    Returns list of `{"id": "R1", "text": "...", "tag": "..."}`. Empty list
+    if no acceptance section or no R-IDs. See `_export_scan_acceptance_criteria`
+    for the shapes recognized and for the residue count.
+    """
+    return _export_scan_acceptance_criteria(spec_text)[0]
 
 
 def _export_parse_spec_section(spec_text: str, heading_re: re.Pattern) -> str:
@@ -32824,7 +32906,10 @@ def cmd_spec_export_cognitive_aid(args: argparse.Namespace) -> None:
         except OSError:
             spec_text = ""
 
-    acceptance_criteria = _export_parse_acceptance_criteria(spec_text)
+    (
+        acceptance_criteria,
+        acceptance_criteria_residue,
+    ) = _export_scan_acceptance_criteria(spec_text)
     goal_and_context = _export_parse_spec_section(
         spec_text,
         re.compile(r"^##\s+Goal\s+&?\s*[Cc]ontext\s*$", re.MULTILINE),
@@ -32886,6 +32971,11 @@ def cmd_spec_export_cognitive_aid(args: argparse.Namespace) -> None:
             "goal_and_context": goal_and_context,
             "architecture_overview": architecture_overview,
             "acceptance_criteria": acceptance_criteria,
+            # Bullets shaped like criteria (`- **R…`) that did not parse.
+            # Non-zero means the spec authored a shape this parser cannot
+            # read: the coverage denominator is short by that many. Never
+            # aborts the export.
+            "acceptance_criteria_residue": acceptance_criteria_residue,
             "boundaries": boundaries,
             "decision_context": decision_context,
             "open_questions": open_questions,
@@ -33038,9 +33128,14 @@ def cmd_spec_export_cognitive_aid(args: argparse.Namespace) -> None:
     if "spec" in payload:
         print(f"  Title: {spec_section['title']}")
         print(f"  Status: {spec_section['status']}")
+        residue_note = (
+            f", {acceptance_criteria_residue} unparsed"
+            if acceptance_criteria_residue
+            else ""
+        )
         print(
             f"  R-IDs: {len(acceptance_criteria)} "
-            f"({len(uncovered)} uncovered)"
+            f"({len(uncovered)} uncovered{residue_note})"
         )
     if "tasks" in payload:
         print(

--- a/plugins/flow-next/scripts/flowctl.py
+++ b/plugins/flow-next/scripts/flowctl.py
@@ -34431,18 +34431,34 @@ def cmd_start(args: argparse.Namespace) -> None:
                 use_json=args.json,
             )
 
-        # Check if claimed by someone else (unless --force)
-        if not args.force and existing_assignee and existing_assignee != current_actor:
+        # fn-179.4 (#316): --reclaim is a deliberate identity repair. It relaxes
+        # exactly the two identity gates below (claimed-by-other, in_progress
+        # owned by another) and nothing else - dependency, blocked and done
+        # gates stay where they are, and --force keeps its takeover meaning.
+        reclaiming = bool(
+            args.reclaim and existing_assignee and existing_assignee != current_actor
+        )
+
+        # Check if claimed by someone else (unless --force / --reclaim)
+        if (
+            not args.force
+            and not args.reclaim
+            and existing_assignee
+            and existing_assignee != current_actor
+        ):
             error_exit(
                 f"Cannot start task {args.id}: claimed by '{existing_assignee}'. "
-                f"Use --force to override.",
+                f"Use --force to override, or --reclaim to repair the claimant.",
                 use_json=args.json,
             )
 
         # Validate task is in todo status (unless --force or resuming own task)
         if not args.force and status != "todo":
-            # Allow resuming your own in_progress task
-            if not (status == "in_progress" and existing_assignee == current_actor):
+            # Allow resuming your own in_progress task, or repairing the
+            # claimant of an in_progress task via --reclaim.
+            resuming_own = status == "in_progress" and existing_assignee == current_actor
+            repairing = bool(args.reclaim) and status == "in_progress"
+            if not (resuming_own or repairing):
                 error_exit(
                     f"Cannot start task {args.id}: status is '{status}', expected 'todo'. "
                     f"Use --force to override.",
@@ -34456,6 +34472,17 @@ def cmd_start(args: argparse.Namespace) -> None:
             runtime_updates["claimed_at"] = now_iso()
         if args.note:
             runtime_updates["claim_note"] = args.note
+            if reclaiming:
+                runtime_updates["assignee"] = current_actor
+                runtime_updates["claimed_at"] = now_iso()
+        elif reclaiming:
+            # Identity repair: distinct from the --force takeover note so the
+            # record says which one happened.
+            runtime_updates["assignee"] = current_actor
+            runtime_updates["claimed_at"] = now_iso()
+            runtime_updates["claim_note"] = (
+                f"Reclaimed from {existing_assignee} (identity repair)"
+            )
         elif args.force and existing_assignee and existing_assignee != current_actor:
             # Force override: note the takeover
             runtime_updates["assignee"] = current_actor
@@ -50325,6 +50352,11 @@ def main() -> None:
     p_start.add_argument("id", help="Task ID (e.g., fn-1.2, fn-1-add-auth.2)")
     p_start.add_argument(
         "--force", action="store_true", help="Skip status/dependency/claim checks"
+    )
+    p_start.add_argument(
+        "--reclaim",
+        action="store_true",
+        help="Rewrite the claimant of a task claimed by another identity (identity repair, not a takeover)",
     )
     p_start.add_argument("--note", help="Claim note (e.g., reason for taking over)")
     p_start.add_argument("--json", action="store_true", help="JSON output")

--- a/plugins/flow-next/scripts/flowctl.py
+++ b/plugins/flow-next/scripts/flowctl.py
@@ -34435,14 +34435,17 @@ def cmd_start(args: argparse.Namespace) -> None:
         # exactly the two identity gates below (claimed-by-other, in_progress
         # owned by another) and nothing else - dependency, blocked and done
         # gates stay where they are, and --force keeps its takeover meaning.
+        # getattr: internal callers build a synthetic Namespace without the
+        # CLI-only flag; absence means False, never an AttributeError.
+        reclaim_flag = bool(getattr(args, "reclaim", False))
         reclaiming = bool(
-            args.reclaim and existing_assignee and existing_assignee != current_actor
+            reclaim_flag and existing_assignee and existing_assignee != current_actor
         )
 
         # Check if claimed by someone else (unless --force / --reclaim)
         if (
             not args.force
-            and not args.reclaim
+            and not reclaim_flag
             and existing_assignee
             and existing_assignee != current_actor
         ):
@@ -34457,7 +34460,7 @@ def cmd_start(args: argparse.Namespace) -> None:
             # Allow resuming your own in_progress task, or repairing the
             # claimant of an in_progress task via --reclaim.
             resuming_own = status == "in_progress" and existing_assignee == current_actor
-            repairing = bool(args.reclaim) and status == "in_progress"
+            repairing = reclaim_flag and status == "in_progress"
             if not (resuming_own or repairing):
                 error_exit(
                     f"Cannot start task {args.id}: status is '{status}', expected 'todo'. "

--- a/plugins/flow-next/scripts/flowctl_tracker/MANIFEST.json
+++ b/plugins/flow-next/scripts/flowctl_tracker/MANIFEST.json
@@ -2,7 +2,7 @@
   "files": [
     {
       "path": "flowctl.py",
-      "sha256": "5c198b50ad9449c9bcda90a23481e9b649fcc1bd5405242254428059cc55f2cb"
+      "sha256": "c4e9d2e5d583b103912257cb2542507721ac2cf04f234846e34e7cfaa3a5fb58"
     },
     {
       "path": "flowctl_tracker/__init__.py",

--- a/plugins/flow-next/scripts/flowctl_tracker/MANIFEST.json
+++ b/plugins/flow-next/scripts/flowctl_tracker/MANIFEST.json
@@ -2,7 +2,7 @@
   "files": [
     {
       "path": "flowctl.py",
-      "sha256": "fe20919dc3fed2e5e363700f2951704958ddaec789d6933160a7ba3ea8b23b45"
+      "sha256": "aa41aa9dfbe2bbfec1237c66a2530bffa0d15e7e7abf4f2b71d3bc1b89f11174"
     },
     {
       "path": "flowctl_tracker/__init__.py",

--- a/plugins/flow-next/scripts/flowctl_tracker/MANIFEST.json
+++ b/plugins/flow-next/scripts/flowctl_tracker/MANIFEST.json
@@ -2,7 +2,7 @@
   "files": [
     {
       "path": "flowctl.py",
-      "sha256": "c4e9d2e5d583b103912257cb2542507721ac2cf04f234846e34e7cfaa3a5fb58"
+      "sha256": "fe20919dc3fed2e5e363700f2951704958ddaec789d6933160a7ba3ea8b23b45"
     },
     {
       "path": "flowctl_tracker/__init__.py",

--- a/plugins/flow-next/scripts/flowctl_tracker/MANIFEST.json
+++ b/plugins/flow-next/scripts/flowctl_tracker/MANIFEST.json
@@ -94,11 +94,11 @@
     },
     {
       "path": "flowctl_tracker/providers/jira.py",
-      "sha256": "7c90a22039746df7a94b37c5939cf3ab5611f45dba6462e0e939788516ca82ec"
+      "sha256": "09c635435b44c3ea2473c14f6fe47c061c77105b7f1b64f3e7bd355425a0bcd5"
     },
     {
       "path": "flowctl_tracker/providers/linear.py",
-      "sha256": "f049938c14c41617690c7fb8285cdea281684a83c83ecaae0ccfe89f31cb5331"
+      "sha256": "40a80bf2a3b9701d1eca236be29025ae03beddc2ea3476e1c26f57312b617fcb"
     },
     {
       "path": "flowctl_tracker/question_claim.py",
@@ -122,11 +122,11 @@
     },
     {
       "path": "flowctl_tracker/resolve_verb.py",
-      "sha256": "95ac59474cbc2c125e43a6bcf14137a8b162cb1993a7487d65ece9ffc5f5409c"
+      "sha256": "2e34dd5cbb4981bb8337487f48ba7bc74fe22b259d14512385f7e65e16291ab6"
     },
     {
       "path": "flowctl_tracker/resolved_cache.py",
-      "sha256": "da33f9014e4331c7828c3539c5a46fcb570ff5193af65a559a1b55a040def835"
+      "sha256": "84906600fcfc15b1d691a3379cd6d9623f859473b93e34113ee959777f423354"
     },
     {
       "path": "flowctl_tracker/states.py",

--- a/plugins/flow-next/scripts/flowctl_tracker/providers/jira.py
+++ b/plugins/flow-next/scripts/flowctl_tracker/providers/jira.py
@@ -239,11 +239,12 @@ def _migrated_status_map(config: dict, live: dict) -> tuple[dict, list]:
     return migrated, warnings
 
 
-def resolve_status_ids(config: dict, execute: Callable) -> Union[Assignment, TrackerError]:
-    fetched = fetch_statuses(config, execute)
-    if isinstance(fetched, TrackerError):
-        return fetched
-    pools, live = fetched
+def assign_slots_from_pools(config: dict, pools: dict, live: dict) -> Assignment:
+    """The PURE half of `resolve_status_ids` - no network.
+
+    `--select` reuses it: after merging one human tiebreak it must run the same
+    assignment over the REMAINING slots, against the same pools it already
+    fetched for validation (fn-179.3, #308)."""
     resolved = ((config.get("tracker") or {}).get("resolved") or {})
     existing = (resolved.get("destination") or {}).get("statusIds") or {}
     migrated, warnings = _migrated_status_map(config, live)
@@ -253,6 +254,14 @@ def resolve_status_ids(config: dict, execute: Callable) -> Union[Assignment, Tra
     assignment = assign_slots(pools, live, seed)
     assignment.warnings = warnings + assignment.warnings
     return assignment
+
+
+def resolve_status_ids(config: dict, execute: Callable) -> Union[Assignment, TrackerError]:
+    fetched = fetch_statuses(config, execute)
+    if isinstance(fetched, TrackerError):
+        return fetched
+    pools, live = fetched
+    return assign_slots_from_pools(config, pools, live)
 
 
 def resolve_capabilities(config: dict, execute: Callable) -> dict:

--- a/plugins/flow-next/scripts/flowctl_tracker/providers/linear.py
+++ b/plugins/flow-next/scripts/flowctl_tracker/providers/linear.py
@@ -163,15 +163,24 @@ def fetch_states(config: dict, execute: Callable) -> Union[tuple, TrackerError]:
     return pools, live
 
 
+def assign_slots_from_pools(config: dict, pools: dict, live: dict) -> Assignment:
+    """The PURE half of `resolve_state_ids` - no network.
+
+    `--select` reuses it: after merging one human tiebreak it must run the same
+    assignment over the REMAINING slots, against the same pools it already
+    fetched for validation (fn-179.3, #308)."""
+    existing = (((config.get("tracker") or {}).get("resolved") or {})
+                .get("destination") or {}).get("stateIds") or {}
+    return assign_slots(pools, live, existing if isinstance(existing, dict) else {},
+                        policy="linear")
+
+
 def resolve_state_ids(config: dict, execute: Callable) -> Union[Assignment, TrackerError]:
     fetched = fetch_states(config, execute)
     if isinstance(fetched, TrackerError):
         return fetched
     pools, live = fetched
-    existing = (((config.get("tracker") or {}).get("resolved") or {})
-                .get("destination") or {}).get("stateIds") or {}
-    return assign_slots(pools, live, existing if isinstance(existing, dict) else {},
-                        policy="linear")
+    return assign_slots_from_pools(config, pools, live)
 
 
 def resolve_capabilities(config: dict, execute: Callable) -> dict:

--- a/plugins/flow-next/scripts/flowctl_tracker/resolve_verb.py
+++ b/plugins/flow-next/scripts/flowctl_tracker/resolve_verb.py
@@ -8,7 +8,9 @@ distinct from a consuming verb meeting an absent block - that returns
 `--scope` re-resolves only the named nested path (its own timestamp).
 `--refresh` forces re-resolution of already-fresh scopes.
 `--select slot=id` persists ONE human tiebreak, validated against live
-candidates; repeatable; re-select overwrites.
+candidates; repeatable; re-select overwrites. It then runs the normal
+assignment over the REMAINING slots and persists the union - the tiebreak
+resolves one slot, it does not excuse the others (#308).
 """
 
 from __future__ import annotations
@@ -24,7 +26,7 @@ from .executor import execute as default_execute
 from .providers import resolver_for
 from .resolved_cache import (SCOPES, apply_capability_probe, capabilities_stale,
                              resolve_transaction)
-from .states import Assignment, is_alias, validate_select
+from .states import REQUIRED_SLOTS, Assignment, is_alias, validate_select
 from .types import ErrorClass, TrackerError
 
 #: Scopes each provider resolves, in dependency order (destination first: the
@@ -303,7 +305,7 @@ def _run_select(flow_dir: Path, config: dict, mod, provider: str,
 
     ids_scope = _IDS_SCOPE[provider]
     key = ids_scope.split(".", 1)[1]
-    seen = {}  # pools captured by network_fn for the alias verdict
+    seen = {}  # pools/live captured by network_fn; assignment by finalize_fn
 
     def network_fn(cfg: dict) -> object:
         # Fetch + validate INSIDE the transaction's network step, against the
@@ -317,7 +319,7 @@ def _run_select(flow_dir: Path, config: dict, mod, provider: str,
         error = validate_select(slot, chosen, pools, live)
         if error:
             return TrackerError(ErrorClass.INVALID_INPUT, error, subtype="select")
-        seen["pools"] = pools
+        seen["pools"], seen["live"] = pools, live
         return {slot: chosen}
 
     def finalize_fn(current_cfg: dict, data: dict) -> dict:
@@ -325,19 +327,55 @@ def _run_select(flow_dir: Path, config: dict, mod, provider: str,
         # clobbered by a whole-map replace computed from a stale read.
         existing = _dict(_dict(_dict(_dict(current_cfg.get("tracker"))
                                      .get("resolved")).get("destination")).get(key))
-        return {**existing, **data}
+        merged = {**existing, **data}
+        # The selection is a tiebreak for ONE ambiguous slot, not a reason to
+        # skip the others (#308): run the normal assignment over the remaining
+        # slots and persist the union. `in_review` still never auto-fills - the
+        # policy in states.py owns that, and it stays.
+        assignment = mod.assign_slots_from_pools(
+            _with_ids(current_cfg, key, merged), seen["pools"], seen["live"])
+        seen["assignment"] = assignment
+        return dict(assignment.mapping)
 
-    result = resolve_transaction(flow_dir, ids_scope, network_fn,
-                                 finalize_fn=finalize_fn)
+    result = resolve_transaction(
+        flow_dir, ids_scope, network_fn, finalize_fn=finalize_fn,
+        # A REQUIRED-incomplete map is persisted but NEVER stamped fresh: a
+        # stamp here would make a later plain `resolve` skip the scope and
+        # report success over a map that cannot satisfy REQUIRED_SLOTS.
+        stamp=lambda final: all(s in final for s in REQUIRED_SLOTS))
     if isinstance(result, TrackerError):
         return envelope.failure(result)
+
+    assignment = seen["assignment"]
+    # The union now flows through the SAME guard as the full-assignment path:
+    # an ambiguous or candidate-less REQUIRED slot is a CONFLICT, not a success.
+    guarded = _assignment_to_data(assignment)
+    if isinstance(guarded, TrackerError):
+        return envelope.failure(guarded)
+
     aliased = is_alias(slot, chosen, seen.get("pools", {}))
     final_map = _dict(_dict(_dict(_dict(result.get("tracker"))
                                  .get("resolved")).get("destination")).get(key))
+    warnings = list(assignment.warnings)
+    if aliased:
+        warnings.append(f"{slot!r} aliases a state outside its natural "
+                        "candidates (recorded, not silent)")
     return envelope.success({
         "selected": {slot: chosen},
         "alias": aliased,
         key: final_map,
-        "warnings": ([f"{slot!r} aliases a state outside its natural candidates "
-                      f"(recorded, not silent)"] if aliased else []),
+        "warnings": warnings,
     })
+
+
+def _with_ids(config: dict, key: str, mapping: dict) -> dict:
+    """A config VIEW carrying `mapping` as the resolved slot map - the seed the
+    provider's assignment reads as `existing`. Copied, never mutated in place:
+    the transaction owns the real config document."""
+    tracker = dict(_dict(config.get("tracker")))
+    resolved = dict(_dict(tracker.get("resolved")))
+    destination = dict(_dict(resolved.get("destination")))
+    destination[key] = dict(mapping)
+    resolved["destination"] = destination
+    tracker["resolved"] = resolved
+    return {**config, "tracker": tracker}

--- a/plugins/flow-next/scripts/flowctl_tracker/resolved_cache.py
+++ b/plugins/flow-next/scripts/flowctl_tracker/resolved_cache.py
@@ -143,13 +143,18 @@ def _recompute_resolved_at(resolved: dict, tracker_type: str, now: str) -> None:
 
 
 def apply_scope_result(config: dict, scope: str, data: Any, *,
-                       now: Optional[str] = None) -> dict:
+                       now: Optional[str] = None, stamp: bool = True) -> dict:
     """Pure scope merge: stamp exactly one `scopeResolvedAt` entry and touch
     ONLY that scope's data. Returns the same config object, mutated.
 
     A destination refresh must not clobber `statusIds`/`stateIds` (their own
     scopes) and must not make capabilities look fresh - scope isolation is the
     reason the map exists.
+
+    `stamp=False` persists the scope's data WITHOUT declaring it resolved, and
+    REMOVES any prior stamp: an incomplete slot map must never read fresh, or
+    freshness suppresses the very repair that would complete it (#308). It is
+    the caller's job to decide completeness.
     """
     if scope not in SCOPES:
         raise ValueError(f"unknown scope {scope!r}; canonical scopes are {SCOPES}")
@@ -185,7 +190,10 @@ def apply_scope_result(config: dict, scope: str, data: Any, *,
             raise ValueError(f"unknown capability keys: {sorted(unknown)}")
         resolved["capabilities"] = dict(data)
 
-    sra[scope] = now
+    if stamp:
+        sra[scope] = now
+    else:
+        sra.pop(scope, None)
     _recompute_resolved_at(resolved, (tracker.get("type") or ""), now)
     return config
 
@@ -279,6 +287,7 @@ def resolve_transaction(
     *,
     now: Optional[str] = None,
     finalize_fn: Optional[Callable[[dict, dict], dict]] = None,
+    stamp: Union[bool, Callable[[Any], bool]] = True,
 ) -> Union[dict, TrackerError]:
     """Run one scoped resolve with the R8 ordering. Returns the merged config,
     or a TrackerError (never raises for the specified failure modes).
@@ -291,6 +300,10 @@ def resolve_transaction(
     data is one slot merged into the current map, and computing that merge from
     the pre-lock read would let two concurrent selects clobber each other with
     whole-map replaces.
+
+    `stamp` may be a predicate over the FINAL data, evaluated inside the lock:
+    `--select` persists a still-incomplete slot map (the human's tiebreak is
+    progress worth keeping) but must not stamp it fresh (#308).
     """
     if scope not in SCOPES:
         return TrackerError(ErrorClass.INVALID_INPUT,
@@ -317,7 +330,9 @@ def resolve_transaction(
                     continue
                 migrate_config(current)
                 final_data = finalize_fn(current, data) if finalize_fn else data
-                apply_scope_result(current, scope, final_data, now=now)
+                do_stamp = stamp(final_data) if callable(stamp) else bool(stamp)
+                apply_scope_result(current, scope, final_data, now=now,
+                                   stamp=do_stamp)
                 validate_resolved_block(current["tracker"]["resolved"])
                 _atomic_write_json(config_path, current)
                 return current

--- a/plugins/flow-next/skills/flow-next-make-pr/workflow.md
+++ b/plugins/flow-next/skills/flow-next-make-pr/workflow.md
@@ -413,7 +413,7 @@ All four values come from the payload directly:
 - `<spec-id>` from `spec.id`
 - `<branch>` from `PHASE0_CONTEXT.branch`, `<base>` from `PHASE0_CONTEXT.base`
 - `<done>` / `<open>` from `tasks_summary.done` / `tasks_summary.open`
-- `<covered>` = `len(acceptance_criteria) - len(tasks_summary.uncovered_r_ids)`; `<total>` = `len(acceptance_criteria)`
+- `<covered>` = `len(acceptance_criteria) - len(tasks_summary.uncovered_r_ids)`; `<total>` = `len(acceptance_criteria)`. When `spec.spec_sections.acceptance_criteria_residue` is non-zero, append ` (<N> unparsed)` to the ratio - the denominator is short by that many criterion-shaped bullets the parser could not read (fn-179, #303); never silently present a short denominator as complete.
 
 A 2-line natural-language summary appears between the H1 and the blockquote, drawn from `spec.spec_sections.goal_and_context` first paragraph, truncated to ~240 characters with sentence-boundary respect. Never invent — if `goal_and_context` is empty the summary is omitted.
 

--- a/plugins/flow-next/skills/flow-next-make-pr/workflow.md
+++ b/plugins/flow-next/skills/flow-next-make-pr/workflow.md
@@ -413,7 +413,7 @@ All four values come from the payload directly:
 - `<spec-id>` from `spec.id`
 - `<branch>` from `PHASE0_CONTEXT.branch`, `<base>` from `PHASE0_CONTEXT.base`
 - `<done>` / `<open>` from `tasks_summary.done` / `tasks_summary.open`
-- `<covered>` = `len(acceptance_criteria) - len(tasks_summary.uncovered_r_ids)`; `<total>` = `len(acceptance_criteria)`. When `spec.spec_sections.acceptance_criteria_residue` is non-zero, append ` (<N> unparsed)` to the ratio - the denominator is short by that many criterion-shaped bullets the parser could not read (fn-179, #303); never silently present a short denominator as complete.
+- `<covered>` = `len(acceptance_criteria) - len(tasks_summary.uncovered_r_ids)`; `<total>` = `len(acceptance_criteria)`. When `spec.spec_sections.acceptance_criteria_residue` is non-zero, append ` (<N> unparsed)` to the ratio - the denominator is short by that many criterion-shaped bullets the parser could not read (fn-179, #303); never silently present a short denominator as complete. This qualifier applies on BOTH ratio paths - artifact-derived (Phase 1.5's supersession covers the coverage *claims*, but the residue count has no artifact counterpart and comes from the same export payload, so appending it is not a legacy-field merge) and legacy fallback alike.
 
 A 2-line natural-language summary appears between the H1 and the blockquote, drawn from `spec.spec_sections.goal_and_context` first paragraph, truncated to ~240 characters with sentence-boundary respect. Never invent — if `goal_and_context` is empty the summary is omitted.
 

--- a/plugins/flow-next/skills/flow-next-setup/workflow.md
+++ b/plugins/flow-next/skills/flow-next-setup/workflow.md
@@ -25,8 +25,6 @@ CURSOR_HOME_ABS="$(cd "${HOME}/.cursor" 2>/dev/null && pwd -P || printf '%s' "${
 
 if [ -n "${DROID_PLUGIN_ROOT:-}" ]; then
   PLATFORM="droid"
-elif [ -n "${CLAUDE_PLUGIN_ROOT:-}" ]; then
-  PLATFORM="claude-code"
 elif [ -n "${CURSOR_AGENT:-}" ] \
   && [ -f "${PLUGIN_ROOT}/.cursor-plugin/plugin.json" ] \
   && case "${PLUGIN_ROOT_ABS}" in \
@@ -36,6 +34,9 @@ elif [ -n "${CURSOR_AGENT:-}" ] \
   PLATFORM="cursor"
 elif [ -n "${GROK_AGENT:-}" ]; then
   PLATFORM="grok"
+elif [ -n "${CLAUDECODE:-}" ] \
+  && [ -f "${PLUGIN_ROOT}/.claude-plugin/plugin.json" ]; then
+  PLATFORM="claude-code"
 else
   PLATFORM="codex"
 fi
@@ -47,11 +48,18 @@ fi
 
 **Positive path discriminator — `PLUGIN_ROOT` under `~/.cursor/` (never `codex/` absence).** The manifest + env checks alone are not enough when Codex runs from the **checked-in plugin source** inside a Cursor shell (Codex marketplace points at `./plugins/flow-next`, which carries `.cursor-plugin/`, `.codex-plugin/`, and the `codex/` mirror) — there the Cursor manifest is present in the workspace tree, so env+manifest would misfire. The positive signal is that a **real Cursor install** resolves `PLUGIN_ROOT` under `~/.cursor/` — local `install-cursor.sh`/`.ps1` → `~/.cursor/plugins/local/flow-next/`; team-marketplace repo-import → Cursor's marketplace plugin cache under `~/.cursor/` (and that cache **may contain `codex/`** because the whole plugin source is imported; explicit component paths in `.cursor-plugin/plugin.json` keep Cursor from loading the mirror as skills). A genuine Codex install resolves under `$CODEX_HOME` (default `~/.codex`); the shared source tree resolves to a workspace path. Neither is under `~/.cursor/`, so both correctly fall through to `codex` even with inherited `CURSOR_AGENT`. **Do not** key detection on the `codex/` directory being absent — that misclassifies marketplace repo-imports as Codex.
 
-**Grok ordering matters (fn-126).** Grok Build (xAI's `grok` CLI) reads the canonical Claude plugin format AS-IS and drives with `/flow-next-*` / `/flow-next:` slash commands — not the Codex `$flow-next-` mirror. Without a positive signal it fell through to `else → codex` and setup wrote Codex-shaped `$flow-next-` snippets into AGENTS.md (dogfood 2026-07-22). **Probe-verified signal:** `GROK_AGENT=1` is set BY grok in its agent shell (absent from a plain-shell control on the same machine). **Rejected non-signals:** `~/.grok/` exists on the machine regardless (install dir), and `~/.grok/bin` on `PATH` is profile-level — neither distinguishes a grok session. The `GROK_AGENT` branch MUST come after Droid / Claude / Cursor (so a real Claude/Cursor/Droid host that merely inherited `GROK_AGENT` from a parent grok shell still classifies by its own higher-precedence signal) and BEFORE the `else → codex` fallback.
+**Claude Code signal - `CLAUDECODE` + the Claude plugin manifest, and why the rung sits low (#306).** `CLAUDE_PLUGIN_ROOT` is **never set in the Bash environment of a running plugin skill** on Claude Code (probe-verified against 2.1.221 and re-verified at v3.16.3), so the branch that keyed on it could not fire on our PRIMARY host: every rung failed and setup fell through to `else -> codex`, writing Codex `$flow-next-` snippets into a repo driven by `/flow-next:` slash commands. The signal that IS present is `CLAUDECODE=1` - the same marker the codex-delegation platform gate keys on. It is set by Claude Code itself, in every install mode (marketplace cache, local marketplace, `--plugin-dir` dev load), so it needs no plugin-root env var; `PLUGIN_ROOT` is already resolved from this file's own location.
 
-**Known nesting edge (Droid → Grok) — NEEDS-HUMAN.** The probe disproved `CLAUDE_PLUGIN_ROOT` propagation into a grok child, so Claude-from-parent does not misfire. It did **not** disprove `DROID_PLUGIN_ROOT` propagation: if a grok child inherits `DROID_PLUGIN_ROOT` from a Droid parent shell, the cascade classifies as `droid` (higher precedence). Treat nested Droid→Grok as **unsupported pending a this-process-is-grok discriminator** unless a NEEDS-HUMAN smoke confirms `DROID_PLUGIN_ROOT` does not propagate. Claude/Cursor-from-grok remain correct via higher-precedence signals.
+`CLAUDECODE` is **inherited by child processes** - same class as the `CURSOR_AGENT` misfire above - so it is paired with a positive discriminator and a lowered position, never used bare:
 
-**Matrix (detection fixtures):** (1) marketplace whole-repo import under `~/.cursor/` + may have `codex/` → `cursor`; (2) local `install-cursor` under `~/.cursor/plugins/local/` (no `codex/`) → `cursor`; (3) Codex under `$CODEX_HOME` / `~/.codex` with inherited `CURSOR_AGENT` → `codex`; (4) Claude (`CLAUDE_PLUGIN_ROOT`) / Droid (`DROID_PLUGIN_ROOT`) still win first — precedence unchanged; (5) standalone `GROK_AGENT=1` (no higher signal) → `grok`; (6) `GROK_AGENT=1` + `CLAUDE_PLUGIN_ROOT` / `CURSOR_AGENT`(+cursor install) / `DROID_PLUGIN_ROOT` → higher host wins; (7) plain shell (no host signal) → `codex`.
+- **Positive discriminator:** the Claude plugin manifest `.claude-plugin/plugin.json` must exist at the resolved `PLUGIN_ROOT`. That is present in every Claude-format install and **absent** from a Codex install root (`$CODEX_HOME`, whose manifest is a top-level `plugin.json`), so a `codex exec` child that inherited `CLAUDECODE` from its Claude parent still classifies `codex`.
+- **Position: after Droid / Cursor / Grok, before the `codex` fallback.** Each of those hosts proves itself with a signal set by its OWN process (`DROID_PLUGIN_ROOT`, `CURSOR_AGENT` + a `~/.cursor/` install, `GROK_AGENT`), and all of them read the canonical Claude plugin format - so a Cursor or Grok agent launched **from** a Claude Code shell inherits `CLAUDECODE` and would be misclassified `claude-code` by a higher rung. Ordering is what keeps an inherited marker from outranking a host's own signal. This is a deliberate precedence change from the pre-#306 cascade, where the Claude rung sat second: that position only ever protected the `CLAUDE_PLUGIN_ROOT` reading, which on Claude Code is never there.
+
+**Grok ordering matters (fn-126).** Grok Build (xAI's `grok` CLI) reads the canonical Claude plugin format AS-IS and drives with `/flow-next-*` / `/flow-next:` slash commands — not the Codex `$flow-next-` mirror. Without a positive signal it fell through to `else → codex` and setup wrote Codex-shaped `$flow-next-` snippets into AGENTS.md (dogfood 2026-07-22). **Probe-verified signal:** `GROK_AGENT=1` is set BY grok in its agent shell (absent from a plain-shell control on the same machine). **Rejected non-signals:** `~/.grok/` exists on the machine regardless (install dir), and `~/.grok/bin` on `PATH` is profile-level — neither distinguishes a grok session. The `GROK_AGENT` branch MUST come after Droid / Cursor (so a real Cursor/Droid host that merely inherited `GROK_AGENT` from a parent grok shell still classifies by its own higher-precedence signal), BEFORE the inherited-marker `CLAUDECODE` rung, and BEFORE the `else → codex` fallback.
+
+**Known nesting edge (Droid → Grok) — NEEDS-HUMAN.** A grok child inherits `CLAUDECODE` from a Claude parent, and the Claude rung now sits BELOW grok, so Claude-from-parent does not misfire. It did **not** disprove `DROID_PLUGIN_ROOT` propagation: if a grok child inherits `DROID_PLUGIN_ROOT` from a Droid parent shell, the cascade classifies as `droid` (higher precedence). Treat nested Droid→Grok as **unsupported pending a this-process-is-grok discriminator** unless a NEEDS-HUMAN smoke confirms `DROID_PLUGIN_ROOT` does not propagate. Cursor-from-grok remains correct via its higher-precedence signal. The mirror-image nesting edge is Claude-from-Grok / Claude-from-Cursor: a Claude Code session launched inside a grok or Cursor agent shell inherits that host's marker and classifies as the parent host. That trade is deliberate - both markers are set by the parent's own process, and the reverse (Claude outranking them on an inherited `CLAUDECODE`) is the far more common nesting, since Claude sessions routinely spawn grok / cursor-agent bridges.
+
+**Matrix (detection fixtures):** (1) marketplace whole-repo import under `~/.cursor/` + may have `codex/` → `cursor`; (2) local `install-cursor` under `~/.cursor/plugins/local/` (no `codex/`) → `cursor`; (3) Codex under `$CODEX_HOME` / `~/.codex` with inherited `CURSOR_AGENT` → `codex`; (4) Droid (`DROID_PLUGIN_ROOT`) still wins first — Droid/Cursor precedence unchanged; (5) standalone `GROK_AGENT=1` (no higher signal) → `grok`; (6) `GROK_AGENT=1` + `CURSOR_AGENT`(+cursor install) / `DROID_PLUGIN_ROOT` → higher host wins; (7) plain shell (no host signal) → `codex`; (8) Claude Code plugin skill — `CLAUDECODE=1`, `CLAUDE_PLUGIN_ROOT` **unset** (it never reaches a skill's Bash env), `PLUGIN_ROOT` carrying `.claude-plugin/plugin.json` → `claude-code`; (9) `CLAUDECODE=1` inherited by a Cursor / Grok / Droid child → that host's own signal wins (Claude rung is last before the fallback); (10) `CLAUDECODE=1` with a Codex-home `PLUGIN_ROOT` (no `.claude-plugin/plugin.json`) → `codex`.
 
 Store `PLATFORM` for use in later steps. This determines:
 - Which manifest to read for version (`plugin.json`)
@@ -62,7 +70,7 @@ Store `PLATFORM` for use in later steps. This determines:
 ### Done when
 
 - `PLUGIN_ROOT` resolves to a directory containing `scripts/` and a plugin manifest, and `PLATFORM` holds exactly one of `claude-code` / `codex` / `droid` / `cursor` / `grok`.
-- **`PLATFORM` came from the host's own signals in the documented precedence, and every downstream choice matches it.** A Cursor or Grok repo that received the Codex `$flow-next-` snippet, or a Codex install misclassified as Cursor through an inherited `CURSOR_AGENT`, has broken this.
+- **`PLATFORM` came from the host's own signals in the documented precedence, and every downstream choice matches it.** A Cursor or Grok repo that received the Codex `$flow-next-` snippet, a Codex install misclassified as Cursor through an inherited `CURSOR_AGENT`, or a Claude Code run classified `codex` because the cascade looked for `CLAUDE_PLUGIN_ROOT` instead of `CLAUDECODE` (#306), has broken this.
 
 ## Step 1: Initialize .flow/
 
@@ -187,7 +195,20 @@ The spec-template discovery cascade prefers a customized scaffold at the repo ro
 **Detect what's already at the repo root** (case-insensitive FS handling — macOS APFS, Windows NTFS):
 
 ```bash
-HITS=$(ls -1 SPEC.md spec.md 2>/dev/null | sort -u | wc -l | tr -d ' ')
+# Count DISTINCT FILES, not argument names. `ls -1 SPEC.md spec.md` echoes each
+# existing argument back, so on a case-insensitive FS one file prints as two
+# names and `sort -u` de-duplicates nothing (#305: HITS=2 on APFS for a repo
+# holding only SPEC.md, firing the bogus both-files warning). Inodes answer the
+# question the branches actually ask.
+# Portable stat, per candidate: GNU form FIRST (`stat -c %i` -> inode; on BSD
+# `-c` is unsupported and errors, so it falls through), BSD form second
+# (`stat -f %i` -> inode). Order matters: GNU reads `-f` as --file-system and
+# would print one shared filesystem id for BOTH files, collapsing a genuine
+# two-file repo to HITS=1.
+HITS=$(for f in SPEC.md spec.md; do
+  [ -e "$f" ] || continue
+  stat -c %i "$f" 2>/dev/null || stat -f %i "$f" 2>/dev/null
+done | sort -u | wc -l | tr -d ' ')
 ```
 
 Then branch:
@@ -207,7 +228,7 @@ On `Copy template`: write the file via Bash `cp` with absolute paths.
 cp "${PLUGIN_ROOT}/templates/spec.md" SPEC.md
 ```
 
-**2. `HITS=1` (single hit OR case-insensitive FS collapsing both to one)** — capture whichever filename actually exists into `EXISTING` (no prompt). Both the read-for-compare and the overwrite target route through `EXISTING` so lowercase `spec.md` repos do not silently fall back to a missing `SPEC.md`:
+**2. `HITS=1` (one file: a single name, OR a case-insensitive FS where both names resolve to one inode)** — capture whichever filename actually exists into `EXISTING` (no prompt). Both the read-for-compare and the overwrite target route through `EXISTING` so lowercase `spec.md` repos do not silently fall back to a missing `SPEC.md`:
 
 ```bash
 EXISTING=$(ls -1 SPEC.md spec.md 2>/dev/null | head -1)

--- a/plugins/flow-next/tests/test_acceptance_criteria_parser.py
+++ b/plugins/flow-next/tests/test_acceptance_criteria_parser.py
@@ -187,5 +187,191 @@ class TestAcceptanceCriteriaRIdSuffix(unittest.TestCase):
         )
 
 
+class TestAcceptanceCriteriaBoldRunShapes(unittest.TestCase):
+    """Issue #303: bold runs that continue past the R-ID token still parse.
+
+    The old pattern required the bold run to close immediately after the
+    token, so title-form (`**R14 - title**`) and parenthetical-form
+    (`**R15 (note):**`) bullets were dropped entirely - not flagged, not
+    counted. Recognition now anchors on the token and stops at the first
+    `**` or `:` boundary.
+    """
+
+    # The reporter's five-bullet repro, verbatim in shape.
+    REPRO = (
+        "## Acceptance Criteria\n"
+        "\n"
+        "- **R1:** the canonical form, accepted.\n"
+        "- **R5a:** a qualified sibling id, also accepted here.\n"
+        "- **R14 - the pause protocol must survive a restart** and this is "
+        "its body.\n"
+        "- **R15 (the parenthetical form):** body text.\n"
+        "- **R16:** a criterion whose text\n"
+        "  wraps onto a second line that the parser never sees.\n"
+        "\n"
+        "## Next section\n"
+    )
+
+    def test_issue_303_repro_parses_five_of_five(self) -> None:
+        crits = flowctl._export_parse_acceptance_criteria(self.REPRO)
+        self.assertEqual(
+            [c["id"] for c in crits], ["R1", "R5a", "R14", "R15", "R16"]
+        )
+
+    def test_R5a_control_still_parses(self) -> None:
+        """The #147 positive control: this bug is about the run, not the token."""
+        crits = flowctl._export_parse_acceptance_criteria(self.REPRO)
+        entry = next(c for c in crits if c["id"] == "R5a")
+        self.assertEqual(
+            entry["text"], "a qualified sibling id, also accepted here."
+        )
+
+    def test_title_form_keeps_title_and_body(self) -> None:
+        crits = flowctl._export_parse_acceptance_criteria(self.REPRO)
+        entry = next(c for c in crits if c["id"] == "R14")
+        self.assertEqual(
+            entry["text"],
+            "the pause protocol must survive a restart and this is its body.",
+        )
+
+    def test_parenthetical_form_keeps_qualifier_and_body(self) -> None:
+        crits = flowctl._export_parse_acceptance_criteria(self.REPRO)
+        entry = next(c for c in crits if c["id"] == "R15")
+        self.assertEqual(entry["text"], "(the parenthetical form): body text.")
+
+    def test_wrapped_text_keeps_continuation_lines(self) -> None:
+        crits = flowctl._export_parse_acceptance_criteria(self.REPRO)
+        entry = next(c for c in crits if c["id"] == "R16")
+        self.assertEqual(
+            entry["text"],
+            "a criterion whose text wraps onto a second line that the "
+            "parser never sees.",
+        )
+
+    def test_canonical_bold_close_then_colon_unchanged(self) -> None:
+        """`**R1**: text` (colon outside the bold run) parsed before, still does."""
+        body = (
+            "## Acceptance Criteria\n\n"
+            "- **R1**: outside-colon form. [user]\n"
+            "\n## Boundaries\n\nText.\n"
+        )
+        self.assertEqual(
+            flowctl._export_parse_acceptance_criteria(body),
+            [{"id": "R1", "text": "outside-colon form.", "tag": "user"}],
+        )
+
+    def test_wrapped_capture_stops_at_next_bullet_and_blank_line(self) -> None:
+        """A criterion never swallows the next bullet or trailing prose."""
+        body = (
+            "## Acceptance Criteria\n\n"
+            "- **R1:** first\n"
+            "  continues here.\n"
+            "- **R2:** second.\n"
+            "\n"
+            "Trailing prose that belongs to nobody.\n"
+            "\n## Boundaries\n\nText.\n"
+        )
+        self.assertEqual(
+            flowctl._export_parse_acceptance_criteria(body),
+            [
+                {"id": "R1", "text": "first continues here.", "tag": ""},
+                {"id": "R2", "text": "second.", "tag": ""},
+            ],
+        )
+
+    def test_sub_bullet_ends_the_criterion_text(self) -> None:
+        """An indented sub-bullet is not criterion text and is not a criterion."""
+        body = (
+            "## Acceptance Criteria\n\n"
+            "- **R1:** parent text.\n"
+            "  - a sub-bullet.\n"
+            "- **R2:** next.\n"
+            "\n## Boundaries\n\nText.\n"
+        )
+        self.assertEqual(
+            [c["text"] for c in flowctl._export_parse_acceptance_criteria(body)],
+            ["parent text.", "next."],
+        )
+
+    def test_wrapped_tag_extraction_uses_the_joined_text(self) -> None:
+        """A source tag on the continuation line still lands in `tag`."""
+        body = (
+            "## Acceptance Criteria\n\n"
+            "- **R1:** a criterion whose text\n"
+            "  wraps before its tag. [paraphrase]\n"
+            "\n## Boundaries\n\nText.\n"
+        )
+        self.assertEqual(
+            flowctl._export_parse_acceptance_criteria(body),
+            [
+                {
+                    "id": "R1",
+                    "text": "a criterion whose text wraps before its tag.",
+                    "tag": "paraphrase",
+                }
+            ],
+        )
+
+
+class TestAcceptanceCriteriaResidue(unittest.TestCase):
+    """Issue #303 second half: unparsed criterion-shaped bullets are counted.
+
+    The residue count is the durable half of the fix - it stays correct for
+    the next unseen bullet shape, which a widened pattern does not. It never
+    aborts anything.
+    """
+
+    def _scan(self, body: str) -> tuple[list[dict], int]:
+        return flowctl._export_scan_acceptance_criteria(body)
+
+    def test_zero_when_every_bullet_parses(self) -> None:
+        crits, residue = self._scan(
+            TestAcceptanceCriteriaBoldRunShapes.REPRO
+        )
+        self.assertEqual(len(crits), 5)
+        self.assertEqual(residue, 0)
+
+    def test_counts_deliberately_rejected_spellings(self) -> None:
+        """`R4ab` / `R-4` stay rejected by design - but no longer silently."""
+        body = (
+            "## Acceptance Criteria\n\n"
+            "- **R1:** kept.\n"
+            "- **R4ab:** multi-letter suffix, rejected.\n"
+            "- **R-4:** separator form, rejected.\n"
+            "\n## Boundaries\n\nText.\n"
+        )
+        crits, residue = self._scan(body)
+        self.assertEqual([c["id"] for c in crits], ["R1"])
+        self.assertEqual(residue, 2)
+
+    def test_ordinary_bold_prose_bullet_is_not_residue(self) -> None:
+        """A bold word starting with `R` is prose, not a dropped criterion."""
+        body = (
+            "## Acceptance Criteria\n\n"
+            "- **R1:** kept.\n"
+            "- **Renumber-forbidden** after the first review cycle.\n"
+            "\n## Boundaries\n\nText.\n"
+        )
+        crits, residue = self._scan(body)
+        self.assertEqual([c["id"] for c in crits], ["R1"])
+        self.assertEqual(residue, 0)
+
+    def test_residue_never_aborts_the_parse(self) -> None:
+        """Criteria after an unreadable bullet still come through."""
+        body = (
+            "## Acceptance Criteria\n\n"
+            "- **R1:** kept.\n"
+            "- **R2 an unterminated bold run that never closes\n"
+            "- **R3:** also kept.\n"
+            "\n## Boundaries\n\nText.\n"
+        )
+        crits, residue = self._scan(body)
+        self.assertEqual([c["id"] for c in crits], ["R1", "R3"])
+        self.assertEqual(residue, 1)
+
+    def test_no_acceptance_section_has_no_residue(self) -> None:
+        self.assertEqual(self._scan("# Spec\n\n## Goal\n\nText.\n"), ([], 0))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/plugins/flow-next/tests/test_export_traceability.py
+++ b/plugins/flow-next/tests/test_export_traceability.py
@@ -663,5 +663,110 @@ class TestBatchedRemovedRefsGrep(_BatchedRefsGitBase):
         self.assertEqual(len(by_sym["busy_fn"]), cap)
 
 
+# --------------------------------------------------------------------------
+# fn-179.1 / issue #303 - `acceptance_criteria_residue` in the payload
+# --------------------------------------------------------------------------
+class TestAcceptanceCriteriaResiduePayload(unittest.TestCase):
+    """The export payload carries the count of unparsed criterion bullets.
+
+    `acceptance_criteria` feeds `tasks_summary.uncovered_r_ids` and make-pr's
+    `<covered>/<total>` ratio, so a dropped criterion is missing from the
+    DENOMINATOR too and coverage reads better than reality. The residue count
+    sits beside the criteria so the discrepancy is visible; it never aborts
+    the export.
+    """
+
+    def _export(self, plan: str) -> dict:
+        import json as _json
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _git(root, "init")
+            subprocess.run(
+                [sys.executable, str(SCRIPTS_DIR / "flowctl.py"), "init", "--json"],
+                cwd=str(root),
+                capture_output=True,
+                check=True,
+            )
+            _git(root, "add", "-A")
+            _git(root, "commit", "-m", "base")
+            created = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPTS_DIR / "flowctl.py"),
+                    "spec",
+                    "create",
+                    "--title",
+                    "Residue probe",
+                    "--json",
+                ],
+                cwd=str(root),
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            spec_id = _json.loads(created.stdout)["id"]
+            subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPTS_DIR / "flowctl.py"),
+                    "spec",
+                    "set-plan",
+                    spec_id,
+                    "--file",
+                    "-",
+                    "--json",
+                ],
+                cwd=str(root),
+                input=plan,
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            out = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPTS_DIR / "flowctl.py"),
+                    "spec",
+                    "export-cognitive-aid",
+                    spec_id,
+                    "--base",
+                    "HEAD",
+                    "--json",
+                ],
+                cwd=str(root),
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            return _json.loads(out.stdout)
+
+    def test_residue_counts_unparsed_bullets_beside_the_criteria(self) -> None:
+        payload = self._export(
+            "## Acceptance Criteria\n\n"
+            "- **R1:** parsed. [user]\n"
+            "- **R2ab:** an unreadable id. [user]\n"
+            "\n## Boundaries\n\n- None.\n"
+        )
+        sections = payload["spec"]["spec_sections"]
+        self.assertEqual(
+            [c["id"] for c in sections["acceptance_criteria"]], ["R1"]
+        )
+        self.assertEqual(sections["acceptance_criteria_residue"], 1)
+
+    def test_residue_zero_when_every_bullet_parses(self) -> None:
+        payload = self._export(
+            "## Acceptance Criteria\n\n"
+            "- **R1:** parsed. [user]\n"
+            "- **R2 - a title form** with a body. [user]\n"
+            "\n## Boundaries\n\n- None.\n"
+        )
+        sections = payload["spec"]["spec_sections"]
+        self.assertEqual(
+            [c["id"] for c in sections["acceptance_criteria"]], ["R1", "R2"]
+        )
+        self.assertEqual(sections["acceptance_criteria_residue"], 0)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/plugins/flow-next/tests/test_pr_cognitive_aid.py
+++ b/plugins/flow-next/tests/test_pr_cognitive_aid.py
@@ -381,6 +381,50 @@ class ValidationTests(unittest.TestCase):
                     flowctl.validate_pr_cognitive_aid(value)
 
 
+class SuffixedRIdTests(unittest.TestCase):
+    """Issue #300: the sub-scoped sibling form (`R4a`) is a canonical R-ID.
+
+    The spec parser (`_export_parse_acceptance_criteria`) emits `R5a` and the
+    review-output extractor accepts it; this validator was the straggler, so
+    the producer and the consumer disagreed inside one process. Because an
+    `rIds[]` entry needs a same-record `rid` source, a single rejected suffix
+    emptied every `rIds[]` array in the artifact.
+    """
+
+    @staticmethod
+    def _artifact_with_rid(r_id: str) -> dict:
+        """`artifact()` with every `R6` occurrence retyped - both call sites."""
+        return json.loads(json.dumps(artifact()).replace("R6", r_id))
+
+    def test_suffixed_rid_accepted_at_both_call_sites(self) -> None:
+        value = self._artifact_with_rid("R6a")
+        # Guard: the fixture really does exercise both checked sites.
+        self.assertEqual(value["sources"][2]["ref"], "R6a")
+        self.assertIn(
+            "R6a", value["changeWalkthrough"]["groups"][2]["files"][0]["rIds"]
+        )
+        self.assertIs(flowctl.validate_pr_cognitive_aid(value), value)
+
+    def test_multi_letter_suffix_and_separator_forms_stay_rejected(self) -> None:
+        for r_id in ("R6ab", "R-6"):
+            with self.subTest(r_id=r_id):
+                with self.assertRaisesRegex(
+                    flowctl.PrCognitiveAidValidationError, "canonical R-ID"
+                ):
+                    flowctl.validate_pr_cognitive_aid(
+                        self._artifact_with_rid(r_id)
+                    )
+
+    def test_rids_array_rejects_suffix_overrun_independently(self) -> None:
+        """The `rIds[]` site rejects `R6ab` even with a legal `rid` source."""
+        value = artifact()
+        value["changeWalkthrough"]["groups"][2]["files"][0]["rIds"] = ["R6ab"]
+        with self.assertRaisesRegex(
+            flowctl.PrCognitiveAidValidationError, r"rIds\[0\].*canonical R-ID"
+        ):
+            flowctl.validate_pr_cognitive_aid(value)
+
+
 class PersistenceAndCurrentnessTests(unittest.TestCase):
     def test_immutable_generations_form_a_materialized_supersedes_chain(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/plugins/flow-next/tests/test_setup_grok_host.py
+++ b/plugins/flow-next/tests/test_setup_grok_host.py
@@ -5,7 +5,9 @@ Locks:
   (a) Canonical detection bash (extracted from flow-next-setup/workflow.md)
       classifies standalone GROK_AGENT=1 as grok; higher-precedence host
       signals win when present alongside GROK_AGENT; plain shell → codex;
-      droid/claude/cursor/codex unregressed.
+      droid/claude/cursor/codex unregressed. fn-179 (#306) extends this to the
+      claude-code rung: keyed on CLAUDECODE + the .claude-plugin manifest,
+      placed below the hosts that prove themselves with their own signal.
   (b) Codex mirror Step-0 is unconditional PLATFORM=codex — even with
       GROK_AGENT=1 and every other host signal set, the mirror returns codex.
 
@@ -109,6 +111,20 @@ def _run_detection(bash_body: str, env: dict[str, str]) -> str:
     return proc.stdout.strip()
 
 
+def _build_claude_install(home: Path) -> Path:
+    """Temp Claude-format plugin tree: PLUGIN_ROOT + .claude-plugin/plugin.json.
+
+    fn-179 (#306): the claude-code rung's positive discriminator is this
+    manifest at the resolved PLUGIN_ROOT (absent from a Codex install root,
+    whose manifest is a top-level plugin.json).
+    """
+    root = home / "claude-plugins" / "flow-next"
+    manifest = root / ".claude-plugin" / "plugin.json"
+    manifest.parent.mkdir(parents=True, exist_ok=True)
+    manifest.write_text('{"name":"flow-next","version":"0.0.0"}\n', encoding="utf-8")
+    return root
+
+
 def _build_cursor_install(home: Path) -> Path:
     """Temp Cursor install tree: ~/.cursor/plugins/local/flow-next/ + manifest."""
     root = home / ".cursor" / "plugins" / "local" / "flow-next"
@@ -146,6 +162,14 @@ class TestCanonicalDetectionExecutable(unittest.TestCase):
             env = _clean_env(str(home), pr, **host_env)
             return _run_detection(self.bash, env)
 
+    def _run_claude_install(self, **host_env: str) -> str:
+        """Run with a PLUGIN_ROOT that carries .claude-plugin/plugin.json."""
+        with tempfile.TemporaryDirectory() as td:
+            home = Path(td)
+            root = _build_claude_install(home)
+            env = _clean_env(str(home), str(root), **host_env)
+            return _run_detection(self.bash, env)
+
     def test_exactly_one_step0_bash_fence(self) -> None:
         # Extraction already asserts; re-run for an explicit unit-test name.
         body = _extract_step0_detection_bash(
@@ -153,8 +177,11 @@ class TestCanonicalDetectionExecutable(unittest.TestCase):
         )
         self.assertIn("GROK_AGENT", body)
         self.assertIn("DROID_PLUGIN_ROOT", body)
-        self.assertIn("CLAUDE_PLUGIN_ROOT", body)
+        self.assertIn("CLAUDECODE", body)
         self.assertIn("CURSOR_AGENT", body)
+        # fn-179 (#306): CLAUDE_PLUGIN_ROOT never reaches a plugin skill's Bash
+        # env, so it must not key any rung.
+        self.assertNotIn("CLAUDE_PLUGIN_ROOT", body)
 
     def test_grok_agent_alone_is_grok(self) -> None:
         self.assertEqual(self._run(GROK_AGENT="1"), "grok")
@@ -168,10 +195,12 @@ class TestCanonicalDetectionExecutable(unittest.TestCase):
             "droid",
         )
 
-    def test_claude_wins_over_grok(self) -> None:
+    def test_grok_wins_over_inherited_claudecode(self) -> None:
+        # fn-179 (#306): CLAUDECODE is inherited by children, GROK_AGENT is set
+        # by the grok process itself — a grok child of a Claude shell is grok.
         self.assertEqual(
-            self._run(CLAUDE_PLUGIN_ROOT="/tmp/claude-plugin", GROK_AGENT="1"),
-            "claude-code",
+            self._run_claude_install(CLAUDECODE="1", GROK_AGENT="1"),
+            "grok",
         )
 
     def test_cursor_wins_over_grok(self) -> None:
@@ -189,10 +218,35 @@ class TestCanonicalDetectionExecutable(unittest.TestCase):
     def test_droid_alone(self) -> None:
         self.assertEqual(self._run(DROID_PLUGIN_ROOT="/tmp/droid-plugin"), "droid")
 
-    def test_claude_alone(self) -> None:
+    def test_claude_code_plugin_skill_env_is_claude_code(self) -> None:
+        # fn-179 (#306) core case: the env a running plugin skill actually sees
+        # on Claude Code — CLAUDECODE=1, CLAUDE_PLUGIN_ROOT UNSET.
+        self.assertEqual(self._run_claude_install(CLAUDECODE="1"), "claude-code")
+
+    def test_claude_plugin_root_alone_no_longer_classifies(self) -> None:
+        # The pre-#306 key is dead: it never reaches a plugin skill's Bash env,
+        # so it must not be what decides the host.
+        self.assertEqual(self._run(CLAUDE_PLUGIN_ROOT="/tmp/claude-plugin"), "codex")
+
+    def test_inherited_claudecode_without_claude_manifest_is_codex(self) -> None:
+        # codex exec child of a Claude session: inherits CLAUDECODE, resolves a
+        # Codex-home PLUGIN_ROOT with no .claude-plugin/plugin.json → codex.
+        self.assertEqual(self._run(CLAUDECODE="1"), "codex")
+
+    def test_droid_wins_over_inherited_claudecode(self) -> None:
         self.assertEqual(
-            self._run(CLAUDE_PLUGIN_ROOT="/tmp/claude-plugin"), "claude-code"
+            self._run_claude_install(CLAUDECODE="1", DROID_PLUGIN_ROOT="/tmp/droid"),
+            "droid",
         )
+
+    def test_cursor_wins_over_inherited_claudecode(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            home = Path(td)
+            cursor_root = _build_cursor_install(home)
+            env = _clean_env(
+                str(home), str(cursor_root), CURSOR_AGENT="1", CLAUDECODE="1"
+            )
+            self.assertEqual(_run_detection(self.bash, env), "cursor")
 
     def test_cursor_alone(self) -> None:
         with tempfile.TemporaryDirectory() as td:
@@ -230,6 +284,7 @@ class TestMirrorUnconditionalCodex(unittest.TestCase):
             "CURSOR_AGENT",
             "DROID_PLUGIN_ROOT",
             "CLAUDE_PLUGIN_ROOT",
+            "CLAUDECODE",
         ):
             self.assertNotIn(
                 signal,
@@ -247,6 +302,7 @@ class TestMirrorUnconditionalCodex(unittest.TestCase):
                 str(cursor_root),
                 GROK_AGENT="1",
                 CURSOR_AGENT="1",
+                CLAUDECODE="1",
                 CLAUDE_PLUGIN_ROOT="/tmp/claude-plugin",
                 DROID_PLUGIN_ROOT="/tmp/droid-plugin",
             )

--- a/plugins/flow-next/tests/test_setup_spec_discovery_hits.py
+++ b/plugins/flow-next/tests/test_setup_spec_discovery_hits.py
@@ -1,0 +1,131 @@
+"""fn-179 R4 (#305) — executable SPEC.md discovery HITS count.
+
+Locks the SHIPPED Step-4a discovery formula (extracted from
+flow-next-setup/workflow.md, not a copy) against the argument-echo bug:
+`ls -1 SPEC.md spec.md | sort -u | wc -l` counts argument NAMES, so on a
+case-insensitive filesystem (APFS, NTFS) a repo holding only SPEC.md counted 2
+and took the HITS=2 branch, printing a both-files warning at a correct repo.
+The formula counts distinct files by inode instead.
+
+Pin shape: content + reachability — the fence is located by its own anchor
+(the Step-4a discovery section), then EXECUTED, so a moved-but-live formula
+still passes and a silently-reverted one fails.
+
+Run:
+    cd plugins/flow-next/tests && python3 -m unittest test_setup_spec_discovery_hits -q
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+HERE = Path(__file__).resolve()
+PLUGIN = HERE.parent.parent
+CANONICAL_WF = PLUGIN / "skills" / "flow-next-setup" / "workflow.md"
+
+_BASH = shutil.which("bash")
+
+# Reachability anchor: the discovery fence is the bash fence that assigns HITS.
+_HITS_FENCE = re.compile(r"(?ms)^```bash\n((?:(?!^```).)*?\bHITS=.*?)^```\s*$")
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8").replace("\r\n", "\n").replace("\r", "\n")
+
+
+def _extract_hits_fence() -> str:
+    text = _read(CANONICAL_WF)
+    fences = _HITS_FENCE.findall(text)
+    if len(fences) != 1:
+        raise AssertionError(
+            f"expected exactly one HITS-assigning bash fence in {CANONICAL_WF}, "
+            f"found {len(fences)}"
+        )
+    return fences[0]
+
+
+def _run_hits(fence: str, cwd: Path) -> str:
+    script = f"set -eu\n{fence}\nprintf '%s\\n' \"$HITS\"\n"
+    proc = subprocess.run(
+        [_BASH, "-c", script],
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+    if proc.returncode != 0:
+        raise AssertionError(
+            f"HITS bash failed (rc={proc.returncode}):\n"
+            f"stdout={proc.stdout!r}\nstderr={proc.stderr!r}"
+        )
+    return proc.stdout.strip()
+
+
+def _fs_is_case_sensitive(d: Path) -> bool:
+    probe = d / "CaseProbe.md"
+    probe.write_text("x", encoding="utf-8")
+    try:
+        return not (d / "caseprobe.md").exists()
+    finally:
+        probe.unlink()
+
+
+@unittest.skipUnless(_BASH, "bash required to execute the discovery fence")
+class TestSpecDiscoveryHits(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        if not CANONICAL_WF.is_file():
+            raise AssertionError(f"missing {CANONICAL_WF}")
+        cls.fence = _extract_hits_fence()
+
+    def test_fence_counts_inodes_not_argument_names(self) -> None:
+        # Content pin: the shipped formula resolves file identity. A revert to
+        # the `ls | sort -u` argument echo fails here before it fails a repro.
+        self.assertIn("stat", self.fence)
+        self.assertIn("%i", self.fence)
+
+    def test_no_spec_file_is_zero(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            self.assertEqual(_run_hits(self.fence, Path(td)), "0")
+
+    def test_single_uppercase_spec_is_one(self) -> None:
+        # #305: this returned 2 on APFS under the argument-echo formula.
+        with tempfile.TemporaryDirectory() as td:
+            d = Path(td)
+            (d / "SPEC.md").write_text("# spec\n", encoding="utf-8")
+            self.assertEqual(_run_hits(self.fence, d), "1")
+
+    def test_single_lowercase_spec_is_one(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            d = Path(td)
+            (d / "spec.md").write_text("# spec\n", encoding="utf-8")
+            self.assertEqual(_run_hits(self.fence, d), "1")
+
+    def test_unrelated_files_do_not_count(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            d = Path(td)
+            (d / "SPEC.md").write_text("# spec\n", encoding="utf-8")
+            (d / "README.md").write_text("# readme\n", encoding="utf-8")
+            self.assertEqual(_run_hits(self.fence, d), "1")
+
+    def test_two_distinct_files_still_two(self) -> None:
+        # Only expressible on a case-sensitive FS (ext4 in CI); on APFS the two
+        # names ARE one file, which the case above already covers.
+        with tempfile.TemporaryDirectory() as td:
+            d = Path(td)
+            if not _fs_is_case_sensitive(d):
+                self.skipTest("case-insensitive filesystem: two distinct files "
+                              "cannot exist")
+            (d / "SPEC.md").write_text("# upper\n", encoding="utf-8")
+            (d / "spec.md").write_text("# lower\n", encoding="utf-8")
+            self.assertEqual(_run_hits(self.fence, d), "2")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/flow-next/tests/test_start_reclaim.py
+++ b/plugins/flow-next/tests/test_start_reclaim.py
@@ -1,0 +1,167 @@
+"""`flowctl start --reclaim` identity repair (fn-179.4, issue #316).
+
+--reclaim rewrites the claimant deliberately with a repair-flavored claim note.
+--force keeps its takeover meaning and its takeover note; the two must stay
+distinguishable in the record.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from typing import Optional
+
+HERE = Path(__file__).resolve()
+FLOWCTL_PY = HERE.parent.parent / "scripts" / "flowctl.py"
+
+TAKEOVER_NOTE = "Taken over from other-actor"
+REPAIR_NOTE = "Reclaimed from other-actor (identity repair)"
+
+
+class StartReclaimTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.repo = Path(self.tempdir.name)
+        subprocess.run(["git", "init", "-q", str(self.repo)], check=True)
+        self._run("init")
+        self.spec = json.loads(
+            self._run("spec", "create", "--title", "Reclaim").stdout
+        )["id"]
+
+    def tearDown(self) -> None:
+        self.tempdir.cleanup()
+
+    def _run(
+        self, *args: str, actor: Optional[str] = None
+    ) -> subprocess.CompletedProcess:
+        env = os.environ.copy()
+        if actor:
+            env["FLOW_ACTOR"] = actor
+        return subprocess.run(
+            [sys.executable, str(FLOWCTL_PY), *args, "--json"],
+            cwd=self.repo,
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+
+    def _new_task(self, title: str = "Claim me") -> str:
+        return json.loads(
+            self._run("task", "create", "--spec", self.spec, "--title", title).stdout
+        )["id"]
+
+    def _claimed_task(self) -> str:
+        task = self._new_task()
+        proc = self._run("start", task, actor="other-actor")
+        self.assertEqual(proc.returncode, 0, proc.stdout + proc.stderr)
+        return task
+
+    def _state(self, task: str) -> dict:
+        path = self.repo / ".git" / "flow-state" / "tasks" / f"{task}.state.json"
+        return json.loads(path.read_text(encoding="utf-8"))
+
+    # --- reclaim ---------------------------------------------------------
+
+    def test_reclaim_rewrites_claimant_with_repair_note(self) -> None:
+        task = self._claimed_task()
+        proc = self._run("start", task, "--reclaim", actor="me")
+        self.assertEqual(proc.returncode, 0, proc.stdout + proc.stderr)
+        state = self._state(task)
+        self.assertEqual(state["assignee"], "me")
+        self.assertEqual(state["status"], "in_progress")
+        self.assertEqual(state["claim_note"], REPAIR_NOTE)
+
+    def test_repair_note_is_distinct_from_takeover_note(self) -> None:
+        reclaimed = self._claimed_task()
+        self._run("start", reclaimed, "--reclaim", actor="me")
+        taken = self._claimed_task()
+        self._run("start", taken, "--force", actor="me")
+        self.assertNotEqual(
+            self._state(reclaimed)["claim_note"], self._state(taken)["claim_note"]
+        )
+        self.assertEqual(self._state(reclaimed)["claim_note"], REPAIR_NOTE)
+        self.assertEqual(self._state(taken)["claim_note"], TAKEOVER_NOTE)
+
+    def test_reclaim_on_unclaimed_task_is_a_plain_claim(self) -> None:
+        task = self._new_task()
+        proc = self._run("start", task, "--reclaim", actor="me")
+        self.assertEqual(proc.returncode, 0, proc.stdout + proc.stderr)
+        state = self._state(task)
+        self.assertEqual(state["assignee"], "me")
+        self.assertEqual(state.get("claim_note", ""), "")
+
+    def test_reclaim_of_own_claim_writes_no_repair_note(self) -> None:
+        task = self._new_task()
+        self._run("start", task, actor="me")
+        proc = self._run("start", task, "--reclaim", actor="me")
+        self.assertEqual(proc.returncode, 0, proc.stdout + proc.stderr)
+        state = self._state(task)
+        self.assertEqual(state["assignee"], "me")
+        self.assertEqual(state.get("claim_note", ""), "")
+
+    def test_explicit_note_wins_and_still_rewrites_claimant(self) -> None:
+        task = self._claimed_task()
+        proc = self._run("start", task, "--reclaim", "--note", "laptop died", actor="me")
+        self.assertEqual(proc.returncode, 0, proc.stdout + proc.stderr)
+        state = self._state(task)
+        self.assertEqual(state["assignee"], "me")
+        self.assertEqual(state["claim_note"], "laptop died")
+
+    def test_reclaim_with_force_writes_the_repair_note(self) -> None:
+        task = self._claimed_task()
+        proc = self._run("start", task, "--reclaim", "--force", actor="me")
+        self.assertEqual(proc.returncode, 0, proc.stdout + proc.stderr)
+        state = self._state(task)
+        self.assertEqual(state["assignee"], "me")
+        self.assertEqual(state["claim_note"], REPAIR_NOTE)
+
+    def test_reclaim_does_not_relax_the_dependency_gate(self) -> None:
+        first = self._new_task("First")
+        second = json.loads(
+            self._run(
+                "task",
+                "create",
+                "--spec",
+                self.spec,
+                "--title",
+                "Second",
+                "--deps",
+                first,
+            ).stdout
+        )["id"]
+        proc = self._run("start", second, "--reclaim", actor="me")
+        self.assertNotEqual(proc.returncode, 0, proc.stdout)
+        self.assertIn(first, proc.stdout + proc.stderr)
+
+    def test_reclaim_does_not_relax_the_done_gate(self) -> None:
+        task = self._new_task()
+        self._run("start", task, actor="other-actor")
+        self._run("done", task, "--summary", "done", actor="other-actor")
+        proc = self._run("start", task, "--reclaim", actor="me")
+        self.assertNotEqual(proc.returncode, 0, proc.stdout)
+
+    # --- force stays exactly as it was -----------------------------------
+
+    def test_force_takeover_note_unchanged(self) -> None:
+        task = self._claimed_task()
+        proc = self._run("start", task, "--force", actor="me")
+        self.assertEqual(proc.returncode, 0, proc.stdout + proc.stderr)
+        state = self._state(task)
+        self.assertEqual(state["assignee"], "me")
+        self.assertEqual(state["claim_note"], TAKEOVER_NOTE)
+
+    def test_claimed_by_other_without_flags_still_refuses(self) -> None:
+        task = self._claimed_task()
+        proc = self._run("start", task, actor="me")
+        self.assertNotEqual(proc.returncode, 0, proc.stdout)
+        self.assertIn("other-actor", proc.stdout + proc.stderr)
+        self.assertEqual(self._state(task)["assignee"], "other-actor")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/flow-next/tests/test_tracker_resolution_linear_jira.py
+++ b/plugins/flow-next/tests/test_tracker_resolution_linear_jira.py
@@ -424,15 +424,20 @@ class ResolveVerb(unittest.TestCase):
         self.assertEqual(out["details"]["normalized"], "in_progress")
         self.assertEqual(len(out["details"]["candidates"]), 2)
 
-    def test_select_persists_one_slot_and_records_alias_state(self) -> None:
-        states = [
-            {"id": "s-todo", "name": "Todo", "type": "unstarted"},
-            {"id": "s-a", "name": "Doing", "type": "started"},
-            {"id": "s-b", "name": "Verifying", "type": "started"},
-            {"id": "s-done", "name": "Done", "type": "completed"},
-        ]
+    #: Two started states (the #308 shape): in_progress needs a human tiebreak,
+    #: every other slot is unambiguous.
+    TWO_STARTED = [
+        {"id": "s-todo", "name": "Todo", "type": "unstarted"},
+        {"id": "s-a", "name": "Doing", "type": "started"},
+        {"id": "s-b", "name": "Verifying", "type": "started"},
+        {"id": "s-done", "name": "Done", "type": "completed"},
+    ]
+
+    def test_select_persists_the_union_of_selection_and_assignment(self) -> None:
+        """#308: the tiebreak resolves ONE slot; the remaining slots still get
+        the normal assignment, and the union is what is persisted."""
         self._write(linear_cfg())
-        ex = fake_execute({"resolve-states": linear_states(states)})
+        ex = fake_execute({"resolve-states": linear_states(self.TWO_STARTED)})
         payload, code = RV.run(self.flow, select="in_progress=s-a", execute=ex)
         self.assertEqual(code, 0, payload)
         out = json.loads(payload)["data"]
@@ -440,7 +445,125 @@ class ResolveVerb(unittest.TestCase):
         self.assertFalse(out["alias"])
         cfg = json.loads((self.flow / "config.json").read_text(encoding="utf-8"))
         self.assertEqual(cfg["tracker"]["resolved"]["destination"]["stateIds"],
-                         {"in_progress": "s-a"})
+                         {"todo": "s-todo", "in_progress": "s-a",
+                          "done": "s-done"})
+        self.assertNotIn("in_review",
+                         cfg["tracker"]["resolved"]["destination"]["stateIds"],
+                         "the secondary started slot NEVER auto-fills - that "
+                         "design stays (#308)")
+
+    def test_issue_308_repro_ends_with_a_complete_map_at_step_three(self) -> None:
+        """The five-step repro, verbatim: resolve -> conflict, select -> the map
+        is COMPLETE, and the follow-up plain resolve has nothing left to repair.
+        """
+        self._write(linear_cfg())
+        responses = dict(self._linear_responses(),
+                         **{"resolve-states": linear_states(self.TWO_STARTED)})
+
+        # 1. scoped resolve: in_progress is ambiguous.
+        payload, code = RV.run(self.flow, scope="destination.stateIds",
+                               execute=fake_execute(responses))
+        self.assertEqual(code, 10, payload)
+        self.assertEqual(json.loads(payload)["details"]["normalized"],
+                         "in_progress")
+
+        # 2. the human tiebreak.
+        payload, code = RV.run(self.flow, select="in_progress=s-a",
+                               execute=fake_execute(responses))
+        self.assertEqual(code, 0, payload)
+
+        # 3. read the map back: every REQUIRED slot present, stamped fresh.
+        cfg = json.loads((self.flow / "config.json").read_text(encoding="utf-8"))
+        state_ids = cfg["tracker"]["resolved"]["destination"]["stateIds"]
+        for slot in ST.REQUIRED_SLOTS:
+            self.assertIn(slot, state_ids, state_ids)
+        self.assertIn("destination.stateIds",
+                      cfg["tracker"]["resolved"]["scopeResolvedAt"])
+
+        # 4. a plain resolve skips the fresh scope - and now that is correct.
+        payload, code = RV.run(self.flow, execute=fake_execute(responses))
+        self.assertEqual(code, 0, payload)
+        self.assertEqual(
+            json.loads(payload)["data"]["resolved"]["destination"]["stateIds"],
+            state_ids)
+
+        # 5. --refresh has nothing left to add.
+        RV.run(self.flow, scope="destination.stateIds", refresh=True,
+               execute=fake_execute(responses))
+        cfg = json.loads((self.flow / "config.json").read_text(encoding="utf-8"))
+        self.assertEqual(cfg["tracker"]["resolved"]["destination"]["stateIds"],
+                         state_ids)
+
+    def test_required_incomplete_select_is_a_conflict_with_no_fresh_stamp(self) -> None:
+        """A workflow with no unstarted/completed state cannot satisfy
+        REQUIRED_SLOTS: the selection is kept (progress), the scope is NOT
+        stamped, and the caller gets the CONFLICT the full path already had."""
+        states = [
+            {"id": "s-a", "name": "Doing", "type": "started"},
+            {"id": "s-b", "name": "Verifying", "type": "started"},
+        ]
+        self._write(linear_cfg())
+        ex = fake_execute({"resolve-states": linear_states(states)})
+        payload, code = RV.run(self.flow, select="in_progress=s-a", execute=ex)
+        self.assertEqual(code, 10, payload)
+        out = json.loads(payload)
+        self.assertEqual(out["class"], "conflict")
+        self.assertEqual(out["details"]["normalized"], "todo")
+        cfg = json.loads((self.flow / "config.json").read_text(encoding="utf-8"))
+        self.assertEqual(cfg["tracker"]["resolved"]["destination"]["stateIds"],
+                         {"in_progress": "s-a"},
+                         "the human tiebreak is kept - otherwise no sequence of "
+                         "selects can ever complete the map")
+        self.assertNotIn("destination.stateIds",
+                         cfg["tracker"]["resolved"]["scopeResolvedAt"],
+                         "an incomplete map must never read fresh, or a later "
+                         "plain resolve skips the scope (#308)")
+        self.assertIsNone(cfg["tracker"]["resolved"]["resolvedAt"])
+
+    def test_a_stale_fresh_stamp_is_dropped_when_the_map_stays_incomplete(self) -> None:
+        """Configs already damaged by the #308 bug self-repair: writing an
+        incomplete map REMOVES the prior stamp rather than leaving it fresh."""
+        cfg = linear_cfg()
+        cfg["tracker"]["resolved"] = {
+            "destination": {"stateIds": {"in_progress": "s-a"}},
+            "scopeResolvedAt": {"destination.stateIds": "2020-01-01T00:00:00Z"},
+            "resolvedAt": None,
+        }
+        self._write(cfg)
+        ex = fake_execute({"resolve-states": linear_states([
+            {"id": "s-a", "name": "Doing", "type": "started"},
+            {"id": "s-b", "name": "Verifying", "type": "started"},
+        ])})
+        payload, code = RV.run(self.flow, select="in_progress=s-b", execute=ex)
+        self.assertEqual(code, 10, payload)
+        written = json.loads((self.flow / "config.json").read_text(encoding="utf-8"))
+        self.assertEqual(written["tracker"]["resolved"]["destination"]["stateIds"],
+                         {"in_progress": "s-b"})
+        self.assertNotIn("destination.stateIds",
+                         written["tracker"]["resolved"]["scopeResolvedAt"])
+
+    def test_select_leaves_another_ambiguous_required_slot_as_conflict(self) -> None:
+        """Jira: filling one slot must not paper over a second ambiguity."""
+        cfg = jira_cfg()
+        cfg["tracker"]["resolved"] = {"destination": {"issueTypeId": "10001"}}
+        self._write(cfg)
+        ex = fake_execute({"resolve-statuses": ok([{
+            "id": "10001", "name": "Task", "statuses": [
+                {"id": "1", "name": "Triage", "statusCategory": {"key": "new"}},
+                {"id": "2", "name": "Selected", "statusCategory": {"key": "new"}},
+                {"id": "3", "name": "Doing",
+                 "statusCategory": {"key": "indeterminate"}},
+                {"id": "4", "name": "Shipped", "statusCategory": {"key": "done"}},
+            ]}])})
+        payload, code = RV.run(self.flow, select="in_progress=3", execute=ex)
+        self.assertEqual(code, 10, payload)
+        out = json.loads(payload)
+        self.assertEqual(out["details"]["normalized"], "todo")
+        written = json.loads((self.flow / "config.json").read_text(encoding="utf-8"))
+        self.assertEqual(
+            written["tracker"]["resolved"]["destination"]["statusIds"],
+            {"in_progress": "3", "done": "4"},
+            "the unambiguous slots still fill; only the ambiguous one waits")
 
     def test_reselect_overwrites(self) -> None:
         states = [
@@ -465,12 +588,16 @@ class ResolveVerb(unittest.TestCase):
 
     def test_select_outside_natural_pool_is_a_recorded_alias(self) -> None:
         self._write(linear_cfg())
-        ex = fake_execute({"resolve-states": linear_states(FIVE_STATES)})
+        ex = fake_execute({"resolve-states": linear_states(SIMPLE_STATES)})
         payload, code = RV.run(self.flow, select="in_review=s-done", execute=ex)
-        self.assertEqual(code, 0)
+        self.assertEqual(code, 0, payload)
         out = json.loads(payload)["data"]
         self.assertTrue(out["alias"])
         self.assertTrue(out["warnings"], "recorded, not silent")
+        self.assertEqual(out["stateIds"]["in_review"], "s-done")
+        self.assertEqual(out["stateIds"]["in_progress"], "s-prog",
+                         "the alias select still runs the normal assignment "
+                         "over the remaining slots (#308)")
 
     def test_jira_backfill_end_to_end(self) -> None:
         self._write(jira_cfg())
@@ -607,8 +734,10 @@ class SelectIsFingerprintProtected(unittest.TestCase):
                     (flow / "config.json").write_text(json.dumps(repointed),
                                                       encoding="utf-8")
                 return linear_states([
+                    {"id": "s-todo", "name": "Todo", "type": "unstarted"},
                     {"id": "s-a", "name": "Doing", "type": "started"},
                     {"id": "s-b", "name": "Verifying", "type": "started"},
+                    {"id": "s-done", "name": "Done", "type": "completed"},
                 ])
 
             payload, code = RV.run(flow, select="in_progress=s-a", execute=execute)


### PR DESCRIPTION
# Issue batch: R-ID parser straggler, criteria parser drops, setup detection, resolve --select, reclaim

Six small, fully-evidenced defects from the sn-furali 2026-08-08 report batch, fixed in one pass with the reporter's verified repros as the acceptance fixtures - plus the documentation answer promised on #313.

> **Spec:** [fn-179-issue-batch-r-id-parser-straggler](https://github.com/gmickel/flow-next/blob/06936a8c87ae620f6a1072cb38e9d4a47e0000bd/.flow/specs/fn-179-issue-batch-r-id-parser-straggler.md)
> **Branch:** `fn-179-issue-batch` → `origin/main`
> **Tasks:** 5 completed
> **R-ID coverage:** 9/9 satisfied

## TL;DR

- The PR cognitive aid accepts suffixed R-IDs (`R4a`) at both validate call sites; `R4ab` and `R-4` stay rejected (#300).
- The acceptance-criteria parser reads title-form and parenthetical-form bullets and keeps wrapped lines - the issue repro parses 5/5, 25 criteria were recovered across this repo's own specs, and anything still unparseable is counted and surfaced as `acceptance_criteria_residue` instead of vanishing (#303).
- Setup counts SPEC.md by inode (no bogus both-files warning on case-insensitive filesystems, #305) and detects Claude Code via `CLAUDECODE` + the plugin manifest - the old signal never reached a plugin skill's env, so our primary host fell through to the codex fallback (#306).
- `tracker resolve --select` now completes the whole slot map after the human tiebreak; a map still missing a required slot persists but reports CONFLICT and is never stamped fresh (#308).
- `flowctl start --reclaim` repairs a claimant identity with a note distinct from `--force` takeover (#316), and the gate-classify docs state the path taxonomy is deliberately closed to config (#313).

## Not in this PR (by design)

- No new commands; #316 is a flag on `start`.
- No change to the `in_review` never-auto-fill policy (#308).
- No widening of #303 into a general markdown parser; token-anchored recognition plus residue reporting only.
- No headless setup or byte-compare-gate changes (#314 territory, answered separately).
- Version bump deferred to the batched release.

## The change, top to bottom

Six field-reported defects fixed in one pass, each taking the reporter&#x27;s verified repro as the acceptance fixture: suffixed R-IDs accepted by the PR cognitive aid, acceptance-criteria shapes no longer silently dropped (with a residue count when something still cannot parse), SPEC.md counted by inode on case-insensitive filesystems, Claude Code detected via CLAUDECODE on its own host, tracker resolve --select completing the whole slot map or reporting CONFLICT unstamped, and start --reclaim separating identity repair from --force takeover. Plus the #313 docs answer: the gate-classify taxonomy is deliberately closed to config.

| Proof | Value | Sources |
|---|---|---|
| Artifact | `fn-179-aid-06936a8c` | artifact identity |
| Base commit | `c355d4e9525bb618c2601242671ce03275572741` | artifact currentness |
| Head commit | `06936a8c87ae620f6a1072cb38e9d4a47e0000bd` | artifact identity |
| Human-review lines | 1288 | deterministic file stats |
| Canonical files | 17 | deterministic membership |
| Total files | 31 | deterministic membership |
| Full gate | 4385 tests, 0 failures; ruff clean; sync-codex idempotent | source:s-t5 |
| New coverage | ~60 new focused tests across 6 suites incl. 2 new files | source:s-t1, source:s-t2, source:s-t3, source:s-t4 |
| R-ID coverage | 9/9 satisfied across five tasks | source:s-c1, source:s-c2, source:s-c3, source:s-c4, source:s-c5 |

**Legend:** `WHY` `PRINCIPLE` `STEP` `KEPT` `VERIFY` · `NEW` `MODIFIED` `DELETED` `RENAMED` `COPIED` · `CANONICAL` `GENERATED` `MECHANICAL`

<details>
<summary><code>WHY</code> 0. Six measured field reports, one batch — All six defects arrived with verified repros from the same reporter: suffixed R-IDs rejected by one straggler regex, criteria shapes silently dropped by the export parser, SPEC.md double-counted on case-insensitive filesystems, Claude Code misdetected on its own host, tracker --select leaving a half-filled map stamped as resolved, and identity repair conflated with takeover.</summary>

Evidence: source:s-spec

</details>

<details open>
<summary><code>STEP</code> 1. Parser fixes: R-ID suffix, criteria shapes, residue count — _PR_COGNITIVE_AID_RID_RE widened to the canonical ^R\[1-9\]\[0-9\]\*\[a-z\]?$ (one constant, both validate call sites; R4ab/R-4 stay rejected). The acceptance-criteria parser is rebuilt as a line-wise scanner: token-anchored recognition of title-form and parenthetical-form bold runs, wrapped text joined until the next bullet or blank line, and a residue count of criterion-shaped bullets that did not parse, surfaced as spec_sections.acceptance_criteria_residue - visible, never aborting. Issue repro parses 5/5; 25 criteria recovered across this repo&#x27;s own specs. The same flowctl.py diff carries step 4&#x27;s cmd_start changes and the orchestrator&#x27;s getattr hardening for synthetic Namespace callers.</summary>

Evidence: source:s-t1, source:s-c1, source:s-c6, source:s-r1, source:s-r2, source:s-r3, R-ID:R1, R-ID:R2, R-ID:R3, task:fn-179-issue-batch-r-id-parser-straggler.1

| Change | Attention | File | Purpose | +/- | Diff | Evidence |
|---|---|---|---|---:|---|---|
| `MODIFIED` | `CANONICAL` | `plugins/flow-next/scripts/flowctl.py` | Regex widening, _export_scan_acceptance_criteria engine + residue, start --reclaim gates (step 4), getattr hardening. | +171/-41 | — | source:s-diff |

<details>
<summary>Generated/mechanical files (3)</summary>

| Change | Attention | File | Purpose | +/- | Diff | Evidence |
|---|---|---|---|---:|---|---|
| `MODIFIED` | `GENERATED` | `.flow/bin/flowctl.py` | Byte-identical dual copy, parity-tested. | +171/-41 | — | source:s-diff |
| `MODIFIED` | `GENERATED` | `plugins/flow-next/scripts/flowctl_tracker/MANIFEST.json` | Regenerated by gen_tracker_manifest.py. | +5/-5 | — | source:s-diff |
| `MODIFIED` | `GENERATED` | `.flow/bin/flowctl_tracker/MANIFEST.json` | Regenerated by gen_tracker_manifest.py. | +5/-5 | — | source:s-diff |

</details>

| Change | Attention | File | Purpose | +/- | Diff | Evidence |
|---|---|---|---|---:|---|---|
| `MODIFIED` | `CANONICAL` | `plugins/flow-next/tests/test_acceptance_criteria_parser.py` | New suite: repro 5/5, title/parenthetical/wrapped forms, residue semantics. | +186/-0 | — | source:s-diff |
| `MODIFIED` | `CANONICAL` | `plugins/flow-next/tests/test_export_traceability.py` | Residue field in the export payload; text-mode rendering. | +105/-0 | — | source:s-diff |
| `MODIFIED` | `CANONICAL` | `plugins/flow-next/tests/test_pr_cognitive_aid.py` | R4a accepted at both call sites; R4ab / R-4 rejected. | +44/-0 | — | source:s-diff |

</details>

<details>
<summary><code>STEP</code> 2. Setup: inode-counted SPEC.md, CLAUDECODE detection — SPEC.md discovery counts distinct files by inode (BSD/GNU stat portable), so a case-insensitive filesystem with one file takes the single-file branch with no bogus warning. The Step 0 cascade keys the Claude Code rung on CLAUDECODE paired with the Claude plugin manifest as a positive discriminator, and the rung deliberately moves below Droid/Cursor/Grok: those hosts prove themselves with signals their own process sets, while CLAUDECODE is child-inherited. All six prose surfaces naming the old signal changed in the one edit; detection-matrix items 8-10 added.</summary>

Evidence: source:s-t2, source:s-c2, source:s-r4, source:s-r5, R-ID:R4, R-ID:R5, task:fn-179-issue-batch-r-id-parser-straggler.2

| Change | Attention | File | Purpose | +/- | Diff | Evidence |
|---|---|---|---|---:|---|---|
| `MODIFIED` | `CANONICAL` | `plugins/flow-next/skills/flow-next-setup/workflow.md` | Inode HITS count; CLAUDECODE + manifest cascade rung, lowered; matrix + Done-when + nesting-edge prose. | +29/-8 | — | source:s-diff |

<details>
<summary>Generated/mechanical files (1)</summary>

| Change | Attention | File | Purpose | +/- | Diff | Evidence |
|---|---|---|---|---:|---|---|
| `MODIFIED` | `GENERATED` | `plugins/flow-next/codex/skills/flow-next-setup/workflow.md` | Codex mirror regen (Step 0 fence collapses to PLATFORM=codex). | +26/-6 | — | source:s-diff |

</details>

| Change | Attention | File | Purpose | +/- | Diff | Evidence |
|---|---|---|---|---:|---|---|
| `MODIFIED` | `CANONICAL` | `plugins/flow-next/tests/test_setup_grok_host.py` | CLAUDECODE fixtures beside the existing host cases; droid/cursor/codex outcomes unchanged. | +63/-7 | — | source:s-diff |
| `NEW` | `CANONICAL` | `plugins/flow-next/tests/test_setup_spec_discovery_hits.py` | New suite executing the extracted HITS fence under fixtures. | +131/-0 | — | source:s-diff |

</details>

<details>
<summary><code>STEP</code> 3. Tracker: --select runs the full assignment — _run_select merges the human tiebreak, then runs the provider&#x27;s normal slot assignment over the remaining slots (pure assign_slots_from_pools halves extracted from the linear/jira resolvers - no second network call inside the lock) and persists the union. A REQUIRED-incomplete map persists (progress kept, avoids a two-select deadlock) but returns CONFLICT through the existing guard and is never stamped; stamp=False also removes a prior stamp so already-damaged configs self-repair. in_review never auto-fills.</summary>

Evidence: source:s-t3, source:s-c3, source:s-r6, R-ID:R6, task:fn-179-issue-batch-r-id-parser-straggler.3

| Change | Attention | File | Purpose | +/- | Diff | Evidence |
|---|---|---|---|---:|---|---|
| `MODIFIED` | `CANONICAL` | `plugins/flow-next/scripts/flowctl_tracker/resolve_verb.py` | Union in finalize_fn, stamp predicate, _with_ids view helper, guard on the result. | +47/-9 | — | source:s-diff |
| `MODIFIED` | `CANONICAL` | `plugins/flow-next/scripts/flowctl_tracker/resolved_cache.py` | apply_scope_result/resolve_transaction stamp control; stamp=False pops a prior stamp. | +18/-3 | — | source:s-diff |
| `MODIFIED` | `CANONICAL` | `plugins/flow-next/scripts/flowctl_tracker/providers/linear.py` | Pure assign_slots_from_pools half extracted; resolve_state_ids unchanged in behavior. | +13/-4 | — | source:s-diff |
| `MODIFIED` | `CANONICAL` | `plugins/flow-next/scripts/flowctl_tracker/providers/jira.py` | Pure assign_slots_from_pools half extracted; legacy statusMap seed reused. | +14/-5 | — | source:s-diff |

<details>
<summary>Generated/mechanical files (4)</summary>

| Change | Attention | File | Purpose | +/- | Diff | Evidence |
|---|---|---|---|---:|---|---|
| `MODIFIED` | `GENERATED` | `.flow/bin/flowctl_tracker/resolve_verb.py` | rsync dual copy. | +47/-9 | — | source:s-diff |
| `MODIFIED` | `GENERATED` | `.flow/bin/flowctl_tracker/resolved_cache.py` | rsync dual copy. | +18/-3 | — | source:s-diff |
| `MODIFIED` | `GENERATED` | `.flow/bin/flowctl_tracker/providers/linear.py` | rsync dual copy. | +13/-4 | — | source:s-diff |
| `MODIFIED` | `GENERATED` | `.flow/bin/flowctl_tracker/providers/jira.py` | rsync dual copy. | +14/-5 | — | source:s-diff |

</details>

| Change | Attention | File | Purpose | +/- | Diff | Evidence |
|---|---|---|---|---:|---|---|
| `MODIFIED` | `CANONICAL` | `plugins/flow-next/tests/test_tracker_resolution_linear_jira.py` | Five-step repro, union persisted, CONFLICT-unstamped, stamp self-repair, in_review never auto-fills. | +140/-11 | — | source:s-diff |

</details>

<details>
<summary><code>STEP</code> 4. start --reclaim: identity repair, not takeover — A new flag on the existing verb rewrites the claimant with the note &#x27;Reclaimed from &lt;identity&gt; (identity repair)&#x27;, distinct from --force&#x27;s &#x27;Taken over from &lt;identity&gt;&#x27;. Only the two claim-ownership gates relax; dependency, blocked and done gates still require --force, whose path is byte-for-byte unchanged. No identity validation and no sibling-identity heuristic - the latter is a declined-ledger entry this task honors. Code lives in the step-1 flowctl.py diff; this group carries its dedicated suite.</summary>

Evidence: source:s-t4, source:s-c4, source:s-r7, R-ID:R7, task:fn-179-issue-batch-r-id-parser-straggler.4

| Change | Attention | File | Purpose | +/- | Diff | Evidence |
|---|---|---|---|---:|---|---|
| `NEW` | `CANONICAL` | `plugins/flow-next/tests/test_start_reclaim.py` | New suite: repair vs takeover notes, gate semantics, flag combinations, --force unchanged. | +167/-0 | — | source:s-diff |

</details>

<details>
<summary><code>STEP</code> 5. Docs and CHANGELOG — flowctl.md gains the #313 answer (gate-classify taxonomy deliberately closed to config; per-repo policy in conductor instructions with pilot.gateClasses as the open vocabulary; reason strings not a stable contract) plus start --reclaim and --select union semantics; platforms.md ties its CLAUDE_PLUGIN_ROOT note to #306; make-pr&#x27;s coverage ratio surfaces the residue count. CHANGELOG Unreleased credits the reporter per issue.</summary>

Evidence: source:s-t5, source:s-c5, source:s-r8, source:s-r9, R-ID:R8, R-ID:R9, task:fn-179-issue-batch-r-id-parser-straggler.5

| Change | Attention | File | Purpose | +/- | Diff | Evidence |
|---|---|---|---|---:|---|---|
| `MODIFIED` | `CANONICAL` | `plugins/flow-next/docs/flowctl.md` | #313 closed-taxonomy statement; start --reclaim; --select union + CONFLICT-unstamped. | +12/-2 | — | source:s-diff |
| `MODIFIED` | `CANONICAL` | `plugins/flow-next/docs/platforms.md` | CLAUDE_PLUGIN_ROOT note updated for #306. | +1/-1 | — | source:s-diff |
| `MODIFIED` | `CANONICAL` | `plugins/flow-next/skills/flow-next-make-pr/workflow.md` | Coverage ratio appends &#x27;(N unparsed)&#x27; from acceptance_criteria_residue. | +1/-1 | — | source:s-diff |

<details>
<summary>Generated/mechanical files (1)</summary>

| Change | Attention | File | Purpose | +/- | Diff | Evidence |
|---|---|---|---|---:|---|---|
| `MODIFIED` | `GENERATED` | `plugins/flow-next/codex/skills/flow-next-make-pr/workflow.md` | Codex mirror regen. | +1/-1 | — | source:s-diff |

</details>

| Change | Attention | File | Purpose | +/- | Diff | Evidence |
|---|---|---|---|---:|---|---|
| `MODIFIED` | `CANONICAL` | `CHANGELOG.md` | Unreleased entries, user-outcome-first, per-issue credits. | +54/-0 | — | source:s-diff |

</details>

<details>
<summary><code>VERIFY</code> 6. Gate and task evidence — Full parallel suite 4385 tests with 0 failures, ruff 0.16.0 clean, sync-codex run twice with no drift. Worker D&#x27;s full-suite run caught task .4&#x27;s synthetic-Namespace regression mid-wave; the orchestrator fixed it before close-out. Per-task focused suites recorded as task evidence.</summary>

Evidence: source:s-t1, source:s-t2, source:s-t3, source:s-t4, source:s-t5, task:fn-179-issue-batch-r-id-parser-straggler.1, task:fn-179-issue-batch-r-id-parser-straggler.2, task:fn-179-issue-batch-r-id-parser-straggler.3, task:fn-179-issue-batch-r-id-parser-straggler.4, task:fn-179-issue-batch-r-id-parser-straggler.5

<details>
<summary>Generated/mechanical files (5)</summary>

| Change | Attention | File | Purpose | +/- | Diff | Evidence |
|---|---|---|---|---:|---|---|
| `MODIFIED` | `MECHANICAL` | `.flow/tasks/fn-179-issue-batch-r-id-parser-straggler.1.md` | Task-state: done summary and evidence. | +4/-5 | — | source:s-diff |
| `MODIFIED` | `MECHANICAL` | `.flow/tasks/fn-179-issue-batch-r-id-parser-straggler.2.md` | Task-state: done summary and evidence. | +4/-5 | — | source:s-diff |
| `MODIFIED` | `MECHANICAL` | `.flow/tasks/fn-179-issue-batch-r-id-parser-straggler.3.md` | Task-state: done summary and evidence. | +4/-5 | — | source:s-diff |
| `MODIFIED` | `MECHANICAL` | `.flow/tasks/fn-179-issue-batch-r-id-parser-straggler.4.md` | Task-state: done summary and evidence. | +4/-5 | — | source:s-diff |
| `MODIFIED` | `MECHANICAL` | `.flow/tasks/fn-179-issue-batch-r-id-parser-straggler.5.md` | Task-state: done summary and evidence. | +4/-5 | — | source:s-diff |

</details>

</details>

## Critical changes

- **High-churn:** [`plugins/flow-next/scripts/flowctl.py`](https://github.com/gmickel/flow-next/commit/ccd9ecedb68d0a5006415c5e9cfbdd66d921da03#diff-a52f4f2101d1a9031615badb0a45084834516bcb0b6ec993a50076403226568d) (+171/-41) - parser engine rewrite + `--reclaim` gates
- **Cross-module:** `.flow/bin` / `plugins/flow-next` import edges are the dual-copy propagation, not new coupling
- **High-churn:** [`plugins/flow-next/skills/flow-next-setup/workflow.md`](https://github.com/gmickel/flow-next/commit/45469dda7ef2805b721120ac7911d27d0fbd16c6#diff-fca0c008b842c2ab987363b722b177a6b2c4e947b5ba85cdb1efe26539631df7) (+29/-8) - platform-cascade precedence deliberately changed (Claude rung lowered)
- **High-churn:** [`plugins/flow-next/scripts/flowctl_tracker/resolve_verb.py`](https://github.com/gmickel/flow-next/commit/81d8e10c80fb45e15b574e20ff2073c96b96171e#diff-335256056fecf685361f075122b78a00a7e1ac2642441ed87745a0f2dffbdb46) (+47/-9) - select union + stamp predicate
- **Behavior-visible:** [`plugins/flow-next/scripts/flowctl_tracker/resolved_cache.py`](https://github.com/gmickel/flow-next/commit/81d8e10c80fb45e15b574e20ff2073c96b96171e#diff-fdbd1a48923de471a5a88fe9bd86def36cebefe13dd6c4ea4cd8e9b2746824bd) (+18/-3) - `stamp=False` also removes a prior stamp (self-repair)

## How to review this PR

The pipeline already verified this - you don't re-check it from scratch:
- **Tests / gates:** full parallel suite 4385 tests, 0 failures; `uvx ruff@0.16.0` clean; sync-codex idempotent. Per-task focused evidence: .1 - 143 tests; .2 - 144 tests (incl. executing the extracted bash fences under fixtures); .3 - 449 tracker tests; .4 - 10 new reclaim tests. Worker cross-checking caught one mid-wave regression (synthetic Namespace without the new flag) - fixed and pinned before close-out.
- **R-ID coverage:** 9/9 acceptance criteria satisfied; residue 0 on this spec (the new field, eating its own dogfood).
- **Cross-model review:** no cross-model review recorded on this PR.

Your job - the calls the pipeline can't make:
- Line-review the **Must review** bucket - two behavior changes carry real judgment: the platform-cascade precedence change and the tracker stamp semantics.
- Spot-check the parser rewrite's edge handling; sample, don't re-run everything.
- Own the product call: is lowering the Claude rung below Cursor/Grok the right nesting trade?

## Review plan

### Must review (~20%)

- [ ] 🔴 [`plugins/flow-next/skills/flow-next-setup/workflow.md`](https://github.com/gmickel/flow-next/commit/45469dda7ef2805b721120ac7911d27d0fbd16c6#diff-fca0c008b842c2ab987363b722b177a6b2c4e947b5ba85cdb1efe26539631df7) - deliberate precedence change on the primary host's detection - Does the lowered Claude rung + manifest discriminator misclassify any real nesting you use? - open the Step 0 cascade + "Claude Code signal" paragraph
- [ ] 🔴 [`plugins/flow-next/scripts/flowctl_tracker/resolved_cache.py`](https://github.com/gmickel/flow-next/commit/81d8e10c80fb45e15b574e20ff2073c96b96171e#diff-fdbd1a48923de471a5a88fe9bd86def36cebefe13dd6c4ea4cd8e9b2746824bd) - stamp semantics on the shared resolve transaction - Can `stamp=False` popping a prior stamp regress any non-select scope caller? - open `apply_scope_result` / `resolve_transaction`
- [ ] 🔴 [`plugins/flow-next/scripts/flowctl.py`](https://github.com/gmickel/flow-next/commit/ccd9ecedb68d0a5006415c5e9cfbdd66d921da03#diff-a52f4f2101d1a9031615badb0a45084834516bcb0b6ec993a50076403226568d) - export-parser rewrite feeding every make-pr/qa consumer - Do the flush boundaries (next bullet / blank line / sub-bullet) preserve every previously-parsed shape? - open `_export_scan_acceptance_criteria` and `cmd_start`

### Spot-check

- [ ] 🟡 [`plugins/flow-next/scripts/flowctl_tracker/resolve_verb.py`](https://github.com/gmickel/flow-next/commit/81d8e10c80fb45e15b574e20ff2073c96b96171e#diff-335256056fecf685361f075122b78a00a7e1ac2642441ed87745a0f2dffbdb46) - union + CONFLICT path shape
- [ ] 🟡 6 test files - read the fixture shapes, sample the repro tests
- [ ] 🟡 `plugins/flow-next/docs/flowctl.md` + `CHANGELOG.md` - user-facing wording incl. the #313 statement

### Safe to skim (~45%)

- [ ] ⚪ `.flow/bin/flowctl.py` + 4 `.flow/bin/flowctl_tracker/*` - byte-identical dual copies, parity-tested - skim
- [ ] ⚪ 2 `MANIFEST.json` + 2 codex mirror files - regenerated - skim
- [ ] ⚪ 5 `.flow/tasks/*.md` + `platforms.md` one-liner - task-state / mechanical - skim

---

*Generated by `/flow-next:make-pr` from [fn-179-issue-batch-r-id-parser-straggler](https://github.com/gmickel/flow-next/blob/06936a8c87ae620f6a1072cb38e9d4a47e0000bd/.flow/specs/fn-179-issue-batch-r-id-parser-straggler.md) against `origin/main` on 2026-08-10.*
<!-- flow-next:make-pr spec=fn-179-issue-batch-r-id-parser-straggler base=origin/main -->
